### PR TITLE
feat(data): initialise python workspace and structure

### DIFF
--- a/apps/data-processing/.gitignore
+++ b/apps/data-processing/.gitignore
@@ -1,0 +1,151 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Typically these are written to a standalone folder, so they can be safe to ignore
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypotheses/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the Python version is
+#   usually handled by the user. Everything else can be ignored.
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or even
+#   refuse to install them.
+# Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   poetry.lock
+#   pyproject.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+# pdm.lock
+# .pdm-python
+
+# PEP 582; used by e.g. github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate repository (see .gitignore)
+.idea/

--- a/apps/data-processing/README.md
+++ b/apps/data-processing/README.md
@@ -1,0 +1,45 @@
+# LumenPulse Data Processing Service
+
+This service handles compute-heavy tasks such as sentiment analysis and market trend prediction for the StarkPulse project.
+
+## Project Structure
+
+- `src/`: Core logic and service implementation.
+- `tests/`: Unit and integration tests.
+- `scripts/`: Helper scripts for data management and development.
+
+## Setup Instructions
+
+### 1. Prerequisites
+
+- Python 3.9 or higher
+
+### 2. Create and Activate Virtual Environment
+
+**On macOS/Linux:**
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+**On Windows:**
+```bash
+python -m venv venv
+venv\Scripts\activate
+```
+
+### 3. Install Dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### 4. Environment Variables
+
+Create a `.env` file in the root of `apps/data-processing` and add any necessary configuration.
+
+### 5. Running the Service
+
+```bash
+python src/main.py
+```

--- a/apps/data-processing/requirements.txt
+++ b/apps/data-processing/requirements.txt
@@ -1,0 +1,2 @@
+requests
+python-dotenv

--- a/apps/data-processing/src/main.py
+++ b/apps/data-processing/src/main.py
@@ -1,0 +1,9 @@
+import os
+from dotenv import load_dotenv
+
+def main():
+    load_dotenv()
+    print("LumenPulse Data Service Running")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I have successfully initialized the Python workspace for the data processing service.

Changes Made
Directory Structure
I created the following directory structure:

apps/data-processing/
├── src/
│   └── main.py
├── tests/
├── scripts/
├── .gitignore
├── README.md
└── requirements.txt
Files Created
main.py
: Entry point printing "LumenPulse Data Service Running".
requirements.txt
: Initial dependencies (requests, python-dotenv).
.gitignore
: Python-specific ignore patterns.
README.md
: Setup and usage instructions.
Verification Results
Automated Test Run
I verified the setup by creating a virtual environment, installing dependencies, and running the main script.

Command:

python3 -m venv venv && source venv/bin/activate && pip install -r requirements.txt && python src/main.py

Output:

Successfully installed certifi-2026.1.4 charset_normalizer-3.4.4 idna-3.11 python-dotenv-1.2.1 requests-2.32.5 urllib3-2.6.3
LumenPulse Data Service Running
<img width="652" height="123" alt="image" src="https://github.com/user-attachments/assets/2f9d8571-439c-405e-87af-ffd946980848" />


The service started correctly and printed the expected message.

closes #213 
