### PR TITLE
feat(data-processing): add multi-language sentiment support with graceful fallback

### DIFF
--- a/apps/data-processing/requirements.txt
+++ b/apps/data-processing/requirements.txt
@@ -3,6 +3,7 @@ python-dotenv
 fastapi
 uvicorn
 vaderSentiment
+langdetect
 apscheduler
 stellar-sdk
 pytest

--- a/apps/data-processing/src/analytics/sentiment.py
+++ b/apps/data-processing/src/analytics/sentiment.py
@@ -1,5 +1,60 @@
-from typing import Optional
+import re
+import unicodedata
+from typing import Optional, Set
+
 from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
+
+try:
+    from langdetect import DetectorFactory, LangDetectException, detect
+
+    DetectorFactory.seed = 0
+    LANGDETECT_AVAILABLE = True
+except ImportError:
+    LANGDETECT_AVAILABLE = False
+
+    class LangDetectException(Exception):
+        """Fallback exception when langdetect is unavailable."""
+
+
+class SentimentScore(float):
+    """
+    Float sentiment score enriched with language metadata.
+    """
+
+    language: str
+    language_supported: bool
+    language_unsupported: bool
+
+    def __new__(
+        cls,
+        value: float,
+        language: str,
+        language_supported: bool,
+        language_unsupported: bool,
+    ) -> "SentimentScore":
+        instance = float.__new__(cls, value)
+        instance.language = language
+        instance.language_supported = language_supported
+        instance.language_unsupported = language_unsupported
+        return instance
+
+    def to_dict(self) -> dict:
+        return {
+            "score": float(self),
+            "language": self.language,
+            "language_supported": self.language_supported,
+            "language_unsupported": self.language_unsupported,
+        }
+
+    @property
+    def score(self) -> float:
+        return float(self)
+
+    def __getitem__(self, key: str):
+        return self.to_dict()[key]
+
+    def get(self, key: str, default=None):
+        return self.to_dict().get(key, default)
 
 
 class SentimentAnalyzer:
@@ -10,35 +65,187 @@ class SentimentAnalyzer:
 
     def __init__(self) -> None:
         self.analyzer = SentimentIntensityAnalyzer()
+        self.supported_languages: Set[str] = {"en", "es", "pt"}
 
-    def analyze_text(self, text: Optional[str]) -> float:
+        self.negative_keywords_en = {
+            "crash",
+            "crashing",
+            "dump",
+            "bear",
+            "plunge",
+            "collapse",
+        }
+        self.positive_keywords_en = {
+            "moon",
+            "bull",
+            "surge",
+            "rally",
+            "all time high",
+            "ath",
+        }
+
+        # Lightweight keyword mapping for non-English sentiment support.
+        self.positive_keywords_es = {
+            "sube",
+            "subida",
+            "alza",
+            "rally",
+            "maximo historico",
+            "alcista",
+        }
+        self.negative_keywords_es = {
+            "cae",
+            "caida",
+            "baja",
+            "desplome",
+            "colapso",
+            "bajista",
+        }
+
+        self.positive_keywords_pt = {
+            "sobe",
+            "alta",
+            "rali",
+            "maxima historica",
+            "otimista",
+            "altista",
+        }
+        self.negative_keywords_pt = {
+            "cai",
+            "queda",
+            "baixa",
+            "despenca",
+            "colapso",
+            "baixista",
+        }
+
+    def analyze_text(
+        self, text: Optional[str], lang_hint: Optional[str] = None
+    ) -> SentimentScore:
         """
         Analyze the sentiment of the given text.
 
         Args:
             text (str): Input text (headline or article)
+            lang_hint (str, optional): Optional ISO language hint (e.g. "en", "es").
 
         Returns:
-            float: Sentiment score between -1.0 (very negative) and 1.0 (very positive)
+            SentimentScore: Float-like score with language metadata.
         """
         if not text or not isinstance(text, str):
-            return 0.0
+            return SentimentScore(0.0, "unknown", False, False)
 
-        cleaned = text.strip().lower()
+        cleaned = text.strip()
         if not cleaned:
-            return 0.0
+            return SentimentScore(0.0, "unknown", False, False)
+
+        language = self._resolve_language(cleaned, lang_hint)
+        if language not in self.supported_languages:
+            return SentimentScore(0.0, language, False, True)
+
+        if language == "en":
+            score = self._analyze_english(cleaned)
+        elif language == "es":
+            score = self._keyword_sentiment_score(
+                cleaned, self.positive_keywords_es, self.negative_keywords_es
+            )
+        else:
+            score = self._keyword_sentiment_score(
+                cleaned, self.positive_keywords_pt, self.negative_keywords_pt
+            )
+
+        return SentimentScore(score, language, True, False)
+
+    def _analyze_english(self, text: str) -> float:
+        cleaned = text.lower()
 
         scores = self.analyzer.polarity_scores(cleaned)
         compound = float(scores.get("compound", 0.0))
 
-        # --- Domain-specific crypto boost ---
-        NEGATIVE_KEYWORDS = ["crash", "crashing", "dump", "bear", "plunge", "collapse"]
-        POSITIVE_KEYWORDS = ["moon", "bull", "surge", "rally", "all time high", "ath"]
-
         if compound == 0.0:
-            if any(word in cleaned for word in NEGATIVE_KEYWORDS):
+            if any(word in cleaned for word in self.negative_keywords_en):
                 return -0.4
-            if any(word in cleaned for word in POSITIVE_KEYWORDS):
+            if any(word in cleaned for word in self.positive_keywords_en):
                 return 0.4
 
         return compound
+
+    def _keyword_sentiment_score(
+        self, text: str, positive_keywords: Set[str], negative_keywords: Set[str]
+    ) -> float:
+        normalized_text = self._normalize_text(text)
+        positive_hits = sum(1 for word in positive_keywords if word in normalized_text)
+        negative_hits = sum(1 for word in negative_keywords if word in normalized_text)
+
+        total_hits = positive_hits + negative_hits
+        if total_hits == 0:
+            return 0.0
+
+        score = (positive_hits - negative_hits) / total_hits
+        return max(-1.0, min(1.0, float(score)))
+
+    def _normalize_text(self, text: str) -> str:
+        normalized = unicodedata.normalize("NFKD", text).encode("ascii", "ignore")
+        ascii_text = normalized.decode("ascii")
+        return re.sub(r"\s+", " ", ascii_text).strip().lower()
+
+    def _resolve_language(self, text: str, lang_hint: Optional[str]) -> str:
+        if lang_hint:
+            return self._normalize_language_code(lang_hint)
+
+        script_language = self._detect_script_language(text)
+        if script_language:
+            return script_language
+
+        if LANGDETECT_AVAILABLE:
+            try:
+                detected = detect(text)
+                return self._normalize_language_code(detected)
+            except LangDetectException:
+                pass
+
+        return self._heuristic_language_detection(text)
+
+    def _normalize_language_code(self, language: str) -> str:
+        normalized = language.strip().lower().replace("_", "-")
+        if not normalized:
+            return "unknown"
+        return normalized.split("-")[0]
+
+    def _heuristic_language_detection(self, text: str) -> str:
+        normalized_text = self._normalize_text(text)
+        words = set(normalized_text.split())
+
+        spanish_markers = {"sube", "caida", "mercado", "hoy", "alcista", "bajista"}
+        portuguese_markers = {
+            "sobe",
+            "queda",
+            "alta",
+            "baixa",
+            "mercado",
+            "hoje",
+            "altista",
+            "baixista",
+        }
+
+        spanish_hits = len(words & spanish_markers)
+        portuguese_hits = len(words & portuguese_markers)
+
+        if spanish_hits > portuguese_hits and spanish_hits > 0:
+            return "es"
+        if portuguese_hits > spanish_hits and portuguese_hits > 0:
+            return "pt"
+        return "en"
+
+    def _detect_script_language(self, text: str) -> Optional[str]:
+        if re.search(r"[\u4e00-\u9fff]", text):
+            return "zh"
+        if re.search(r"[\u3040-\u30ff]", text):
+            return "ja"
+        if re.search(r"[\uac00-\ud7af]", text):
+            return "ko"
+        if re.search(r"[\u0400-\u04ff]", text):
+            return "ru"
+        if re.search(r"[\u0600-\u06ff]", text):
+            return "ar"
+        return None

--- a/apps/data-processing/tests/test_sentiment.py
+++ b/apps/data-processing/tests/test_sentiment.py
@@ -1,4 +1,3 @@
-import pytest
 from src.analytics.sentiment import SentimentAnalyzer
 
 
@@ -9,6 +8,9 @@ def test_negative_sentiment():
 
     assert isinstance(score, float)
     assert score < 0.0
+    assert score.language == "en"
+    assert score.language_supported is True
+    assert score.language_unsupported is False
 
 
 def test_positive_sentiment():
@@ -18,6 +20,9 @@ def test_positive_sentiment():
 
     assert isinstance(score, float)
     assert score > 0.0
+    assert score.language == "en"
+    assert score.language_supported is True
+    assert score.language_unsupported is False
 
 
 def test_empty_string_returns_zero():
@@ -25,6 +30,8 @@ def test_empty_string_returns_zero():
     score = analyzer.analyze_text("")
 
     assert score == 0.0
+    assert score.language_supported is False
+    assert score.language_unsupported is False
 
 
 def test_none_returns_zero():
@@ -32,11 +39,51 @@ def test_none_returns_zero():
     score = analyzer.analyze_text(None)
 
     assert score == 0.0
+    assert score.language_supported is False
+    assert score.language_unsupported is False
 
 
-def test_non_english_text_graceful():
+def test_supported_spanish_text_sentiment():
     analyzer = SentimentAnalyzer()
-    text = "这是一个测试"
+    text = "Bitcoin sube con fuerte rally en el mercado"
     score = analyzer.analyze_text(text)
 
     assert isinstance(score, float)
+    assert score > 0.0
+    assert score.language == "es"
+    assert score.language_supported is True
+    assert score.language_unsupported is False
+
+
+def test_supported_portuguese_text_sentiment():
+    analyzer = SentimentAnalyzer()
+    text = "Bitcoin sobe em alta no mercado com rali"
+    score = analyzer.analyze_text(text)
+
+    assert isinstance(score, float)
+    assert score > 0.0
+    assert score.language == "pt"
+    assert score.language_supported is True
+    assert score.language_unsupported is False
+
+
+def test_unsupported_language_fallback_to_neutral():
+    analyzer = SentimentAnalyzer()
+    text = "\u8fd9\u662f\u4e00\u4e2a\u6d4b\u8bd5"
+    score = analyzer.analyze_text(text)
+
+    assert score == 0.0
+    assert score.language == "zh"
+    assert score.language_supported is False
+    assert score.language_unsupported is True
+
+
+def test_lang_hint_overrides_detection():
+    analyzer = SentimentAnalyzer()
+    text = "Bitcoin is crashing hard"
+    score = analyzer.analyze_text(text, lang_hint="fr")
+
+    assert score == 0.0
+    assert score.language == "fr"
+    assert score.language_supported is False
+    assert score.language_unsupported is True


### PR DESCRIPTION
Use this PR description:

Implemented multilingual sentiment support in the data-processing analyzer so non-English crypto news is handled safely and predictably.

### What changed
- Added language-aware sentiment entrypoint: `analyze_text(text, lang_hint=None)`.
- Added language detection before sentiment scoring (`langdetect` + safe fallback logic).
- Supported languages now include:
  - English (`en`) via VADER + existing crypto keyword boost
  - Spanish (`es`) and Portuguese (`pt`) via keyword-based sentiment mapping
- For unsupported languages, analyzer now returns neutral score `0.0` and flags `language_unsupported=True`.
- Added/updated unit tests for English, Spanish/Portuguese, unsupported language fallback, and `lang_hint` override.

### Validation
- `python -m pytest tests/test_sentiment.py -q`
- Result: `8 passed`

Closes #324