### PR TITLE
feat:portfolio-snapshots

### DIFF
--- a/apps/backend/PORTFOLIO_SNAPSHOT_IMPLEMENTATION.md
+++ b/apps/backend/PORTFOLIO_SNAPSHOT_IMPLEMENTATION.md
@@ -1,0 +1,183 @@
+# Portfolio Snapshot History Implementation
+
+## Issue #332: Portfolio Snapshot History
+
+### Overview
+Implemented periodic portfolio snapshots to track historical performance over time for each user. This allows the frontend to display portfolio value trends and asset allocation changes.
+
+## Features Implemented
+
+### 1. Database Schema
+- **PortfolioSnapshot Entity**: Stores periodic snapshots of user portfolios
+  - `id`: UUID primary key
+  - `userId`: UUID foreign key to users table
+  - `createdAt`: Timestamp of snapshot creation
+  - `assetBalances`: JSONB array containing per-asset balances and USD values
+  - `totalValueUsd`: Total portfolio value in USD
+  - Index on `(userId, createdAt)` for efficient querying
+
+### 2. Services
+
+#### StellarBalanceService
+- Fetches real-time account balances from Stellar Horizon API
+- Converts asset balances to USD values (mock prices for now)
+- Handles native XLM and custom assets
+
+#### PortfolioService
+- `createSnapshot(userId)`: Creates a snapshot for a specific user
+- `getPortfolioHistory(userId, page, limit)`: Retrieves paginated snapshot history
+- `createSnapshotsForAllUsers()`: Scheduled job that runs daily at midnight
+- `triggerSnapshotCreation()`: Manual trigger for testing/admin use
+
+### 3. API Endpoints
+
+#### GET /portfolio/history
+Returns portfolio snapshots for the authenticated user with pagination.
+
+**Query Parameters:**
+- `page` (optional): Page number (default: 1)
+- `limit` (optional): Items per page (default: 10)
+
+**Response:**
+```json
+{
+  "snapshots": [
+    {
+      "id": "uuid",
+      "userId": "uuid",
+      "createdAt": "2026-02-20T00:00:00Z",
+      "assetBalances": [
+        {
+          "assetCode": "XLM",
+          "assetIssuer": null,
+          "amount": "1000.50",
+          "valueUsd": 120.06
+        }
+      ],
+      "totalValueUsd": "120.06"
+    }
+  ],
+  "total": 30,
+  "page": 1,
+  "limit": 10,
+  "totalPages": 3
+}
+```
+
+#### POST /portfolio/snapshot
+Manually trigger snapshot creation for the authenticated user.
+
+**Response:**
+```json
+{
+  "success": true,
+  "snapshot": {
+    "id": "uuid",
+    "createdAt": "2026-02-20T10:30:00Z",
+    "totalValueUsd": "120.06"
+  }
+}
+```
+
+#### POST /portfolio/snapshots/trigger
+Admin endpoint to trigger snapshot creation for all users.
+
+**Response:**
+```json
+{
+  "message": "Snapshot creation triggered",
+  "success": 15,
+  "failed": 0
+}
+```
+
+### 4. Scheduled Jobs
+- **Daily Snapshots**: Runs every day at midnight (00:00)
+- Uses `@nestjs/schedule` with cron expressions
+- Automatically creates snapshots for all users
+- Logs success/failure counts
+
+### 5. Data Flow
+
+1. **Stellar Integration**:
+   - Fetches real-time balances from Stellar Horizon API
+   - Falls back to `portfolio_assets` table if Stellar fetch fails
+   - User's Stellar public key is stored as their user ID
+
+2. **USD Valuation**:
+   - Mock prices implemented for demonstration
+   - Production should integrate with CoinGecko, CoinMarketCap, or similar API
+   - Calculates per-asset and total portfolio value
+
+3. **Storage**:
+   - Snapshots stored in `portfolio_snapshots` table
+   - Asset balances stored as JSONB for flexibility
+   - Indexed for efficient time-series queries
+
+## Database Migration
+
+Run the migration to create the portfolio_snapshots table:
+
+```bash
+npm run migration:run
+```
+
+Migration file: `1769600000000-CreatePortfolioSnapshot.ts`
+
+## Dependencies Added
+
+- `@nestjs/schedule`: For cron job scheduling
+
+## Testing
+
+### Manual Snapshot Creation
+```bash
+curl -X POST http://localhost:3000/portfolio/snapshot \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN"
+```
+
+### Get Portfolio History
+```bash
+curl -X GET "http://localhost:3000/portfolio/history?page=1&limit=10" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN"
+```
+
+### Trigger Snapshots for All Users (Admin)
+```bash
+curl -X POST http://localhost:3000/portfolio/snapshots/trigger \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN"
+```
+
+## Future Enhancements
+
+1. **Real Price Integration**: Replace mock prices with actual market data from CoinGecko or similar
+2. **Admin Guard**: Add role-based access control for admin endpoints
+3. **Snapshot Retention**: Implement data retention policies (e.g., keep daily snapshots for 1 year)
+4. **Performance Metrics**: Add calculated fields like 24h change, 7d change, etc.
+5. **Asset Filtering**: Allow filtering snapshots by specific assets
+6. **Export Functionality**: Add CSV/JSON export for tax reporting
+7. **Alerts**: Notify users of significant portfolio value changes
+
+## Architecture Notes
+
+- **Separation of Concerns**: Stellar integration separated into dedicated service
+- **Fallback Strategy**: Uses portfolio_assets table if Stellar API is unavailable
+- **Scalability**: Indexed queries and pagination support large datasets
+- **Type Safety**: Full TypeScript typing with DTOs and entities
+- **Error Handling**: Comprehensive logging and graceful degradation
+
+## Files Created/Modified
+
+### New Files:
+- `src/portfolio/entities/portfolio-snapshot.entity.ts`
+- `src/portfolio/dto/portfolio-snapshot.dto.ts`
+- `src/portfolio/stellar-balance.service.ts`
+- `src/portfolio/portfolio.service.ts`
+- `src/portfolio/portfolio.controller.ts`
+- `src/database/migrations/1769600000000-CreatePortfolioSnapshot.ts`
+
+### Modified Files:
+- `src/portfolio/portfolio.module.ts` - Added services and controller
+- `src/portfolio/portfolio-asset.entity.ts` - Updated imports and timestamps
+- `src/app.module.ts` - Added PortfolioModule and ScheduleModule
+- `package.json` - Added @nestjs/schedule dependency

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -16,6 +16,7 @@
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/schedule": "^6.1.1",
         "@nestjs/swagger": "^11.2.5",
         "@nestjs/typeorm": "^11.0.0",
         "axios": "^1.13.2",
@@ -2322,6 +2323,19 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/schedule": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/schedule/-/schedule-6.1.1.tgz",
+      "integrity": "sha512-kQl1RRgi02GJ0uaUGCrXHCcwISsCsJDciCKe38ykJZgnAeeoeVWs8luWtBo4AqAAXm4nS5K8RlV0smHUJ4+2FA==",
+      "license": "MIT",
+      "dependencies": {
+        "cron": "4.4.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.9",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.9.tgz",
@@ -2912,6 +2926,12 @@
         "@types/ms": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.7.1.tgz",
+      "integrity": "sha512-H3iskjFIAn5SlJU7OuxUmTEpebK6TKB8rxZShDslBMZJ5u9S//KM1sbdAisiSrqwLQncVjnpi2OK2J51h+4lsg==",
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -4939,6 +4959,23 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/cron": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-4.4.0.tgz",
+      "integrity": "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/luxon": "~3.7.0",
+        "luxon": "~3.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/intcreator"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7776,6 +7813,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -31,6 +31,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^6.1.1",
     "@nestjs/swagger": "^11.2.5",
     "@nestjs/typeorm": "^11.0.0",
     "axios": "^1.13.2",

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { TestExceptionController } from './test-exception.controller';
@@ -8,6 +9,7 @@ import { SentimentModule } from './sentiment/sentiment.module';
 import { NewsModule } from './news/news.module';
 import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
+import { PortfolioModule } from './portfolio/portfolio.module';
 import databaseConfig from './database/database.config';
 import { LoggerMiddleware } from './common/middleware/logger.middleware';
 import { TestController } from './test/test.controller';
@@ -34,10 +36,12 @@ import { TestController } from './test/test.controller';
       }),
       inject: [ConfigService],
     }),
+    ScheduleModule.forRoot(),
     SentimentModule,
     NewsModule,
     AuthModule,
     UsersModule,
+    PortfolioModule,
   ],
   controllers: [AppController, TestController, TestExceptionController],
   providers: [AppService],

--- a/apps/backend/src/database/migrations/1769600000000-CreatePortfolioSnapshot.ts
+++ b/apps/backend/src/database/migrations/1769600000000-CreatePortfolioSnapshot.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreatePortfolioSnapshot1769600000000 implements MigrationInterface {
+  name = 'CreatePortfolioSnapshot1769600000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Create portfolio_snapshots table
+    await queryRunner.query(
+      `CREATE TABLE "portfolio_snapshots" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "userId" uuid NOT NULL,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "assetBalances" jsonb NOT NULL,
+        "totalValueUsd" numeric(18,2) NOT NULL,
+        CONSTRAINT "PK_portfolio_snapshots" PRIMARY KEY ("id")
+      )`,
+    );
+
+    // Create index for efficient querying by userId and createdAt
+    await queryRunner.query(
+      `CREATE INDEX "IDX_portfolio_snapshots_userId_createdAt" ON "portfolio_snapshots" ("userId", "createdAt")`,
+    );
+
+    // Add foreign key constraint
+    await queryRunner.query(
+      `ALTER TABLE "portfolio_snapshots" ADD CONSTRAINT "FK_portfolio_snapshots_userId" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "portfolio_snapshots" DROP CONSTRAINT "FK_portfolio_snapshots_userId"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "IDX_portfolio_snapshots_userId_createdAt"`,
+    );
+    await queryRunner.query(`DROP TABLE "portfolio_snapshots"`);
+  }
+}

--- a/apps/backend/src/portfolio/dto/portfolio-snapshot.dto.ts
+++ b/apps/backend/src/portfolio/dto/portfolio-snapshot.dto.ts
@@ -1,0 +1,39 @@
+import { IsNumber, IsOptional, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class AssetBalanceDto {
+  assetCode: string;
+  assetIssuer: string | null;
+  amount: string;
+  valueUsd: number;
+}
+
+export class PortfolioSnapshotDto {
+  id: string;
+  userId: string;
+  createdAt: Date;
+  assetBalances: AssetBalanceDto[];
+  totalValueUsd: string;
+}
+
+export class GetPortfolioHistoryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  limit?: number = 10;
+}
+
+export class PortfolioHistoryResponseDto {
+  snapshots: PortfolioSnapshotDto[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}

--- a/apps/backend/src/portfolio/entities/portfolio-snapshot.entity.ts
+++ b/apps/backend/src/portfolio/entities/portfolio-snapshot.entity.ts
@@ -1,0 +1,38 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('portfolio_snapshots')
+@Index(['userId', 'createdAt'])
+export class PortfolioSnapshot {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @Column({ type: 'jsonb' })
+  assetBalances: {
+    assetCode: string;
+    assetIssuer: string | null;
+    amount: string;
+    valueUsd: number;
+  }[];
+
+  @Column({ type: 'decimal', precision: 18, scale: 2 })
+  totalValueUsd: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+}

--- a/apps/backend/src/portfolio/portfolio-asset.entity.ts
+++ b/apps/backend/src/portfolio/portfolio-asset.entity.ts
@@ -1,23 +1,24 @@
-// src/portfolio/portfolio-asset.entity.ts
 import {
   Entity,
   PrimaryGeneratedColumn,
   Column,
   ManyToOne,
   JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
 } from 'typeorm';
-import { User } from '../users/user.entity';
+import { User } from '../users/entities/user.entity';
 
 @Entity('portfolio_assets')
 export class PortfolioAsset {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column()
+  @Column({ type: 'uuid' })
   userId: string;
 
   @Column()
-  assetCode: string; // e.g. XLM
+  assetCode: string; // e.g. XLM, USDC
 
   @Column({ nullable: true })
   assetIssuer: string;
@@ -25,9 +26,13 @@ export class PortfolioAsset {
   @Column('decimal', { precision: 18, scale: 8 })
   amount: string;
 
-  @ManyToOne(() => User, (user) => user.portfolioAssets, {
-    onDelete: 'CASCADE',
-  })
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   user: User;
 }

--- a/apps/backend/src/portfolio/portfolio.controller.ts
+++ b/apps/backend/src/portfolio/portfolio.controller.ts
@@ -1,0 +1,76 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Query,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { PortfolioService } from './portfolio.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import {
+  GetPortfolioHistoryDto,
+  PortfolioHistoryResponseDto,
+} from './dto/portfolio-snapshot.dto';
+
+@Controller('portfolio')
+@UseGuards(JwtAuthGuard)
+export class PortfolioController {
+  constructor(private readonly portfolioService: PortfolioService) {}
+
+  /**
+   * GET /portfolio/history
+   * Returns portfolio snapshots for the authenticated user with pagination
+   */
+  @Get('history')
+  async getPortfolioHistory(
+    @Request() req: any,
+    @Query() query: GetPortfolioHistoryDto,
+  ): Promise<PortfolioHistoryResponseDto> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const userId = req.user.sub as string; // Extract user ID from JWT
+    return this.portfolioService.getPortfolioHistory(
+      userId,
+      query.page,
+      query.limit,
+    );
+  }
+
+  /**
+   * POST /portfolio/snapshot
+   * Manually trigger snapshot creation for the authenticated user
+   */
+  @Post('snapshot')
+  @HttpCode(HttpStatus.CREATED)
+  async createSnapshot(@Request() req: any) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const userId = req.user.sub as string;
+    const snapshot = await this.portfolioService.createSnapshot(userId);
+    return {
+      success: true,
+      snapshot: {
+        id: snapshot.id,
+        createdAt: snapshot.createdAt,
+        totalValueUsd: snapshot.totalValueUsd,
+      },
+    };
+  }
+
+  /**
+   * POST /portfolio/snapshots/trigger
+   * Admin endpoint to manually trigger snapshot creation for all users
+   * In production, this should be protected with admin guard
+   */
+  @Post('snapshots/trigger')
+  @HttpCode(HttpStatus.OK)
+  async triggerSnapshotCreation() {
+    const result = await this.portfolioService.triggerSnapshotCreation();
+    return {
+      message: 'Snapshot creation triggered',
+      success: result.success,
+      failed: result.failed,
+    };
+  }
+}

--- a/apps/backend/src/portfolio/portfolio.module.ts
+++ b/apps/backend/src/portfolio/portfolio.module.ts
@@ -2,11 +2,18 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PortfolioAsset } from './portfolio-asset.entity';
+import { PortfolioSnapshot } from './entities/portfolio-snapshot.entity';
+import { User } from '../users/entities/user.entity';
+import { PortfolioService } from './portfolio.service';
+import { PortfolioController } from './portfolio.controller';
+import { StellarBalanceService } from './stellar-balance.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([PortfolioAsset])],
-  controllers: [], // no controllers yet
-  providers: [], // no services yet
-  exports: [TypeOrmModule], // optional, in case other modules need access
+  imports: [
+    TypeOrmModule.forFeature([PortfolioAsset, PortfolioSnapshot, User]),
+  ],
+  controllers: [PortfolioController],
+  providers: [PortfolioService, StellarBalanceService],
+  exports: [PortfolioService, TypeOrmModule],
 })
 export class PortfolioModule {}

--- a/apps/backend/src/portfolio/portfolio.service.ts
+++ b/apps/backend/src/portfolio/portfolio.service.ts
@@ -1,0 +1,198 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { PortfolioSnapshot } from './entities/portfolio-snapshot.entity';
+import { PortfolioAsset } from './portfolio-asset.entity';
+import { User } from '../users/entities/user.entity';
+import { StellarBalanceService } from './stellar-balance.service';
+import {
+  PortfolioHistoryResponseDto,
+  PortfolioSnapshotDto,
+} from './dto/portfolio-snapshot.dto';
+
+@Injectable()
+export class PortfolioService {
+  private readonly logger = new Logger(PortfolioService.name);
+
+  constructor(
+    @InjectRepository(PortfolioSnapshot)
+    private readonly snapshotRepository: Repository<PortfolioSnapshot>,
+    @InjectRepository(PortfolioAsset)
+    private readonly assetRepository: Repository<PortfolioAsset>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    private readonly stellarBalanceService: StellarBalanceService,
+  ) {}
+
+  /**
+   * Create a snapshot for a specific user
+   */
+  async createSnapshot(userId: string): Promise<PortfolioSnapshot> {
+    this.logger.log(`Creating snapshot for user ${userId}`);
+
+    // Get user to access their Stellar public key
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException(`User ${userId} not found`);
+    }
+
+    // Fetch balances from Stellar network using user's public key (id)
+    let assetBalances: Array<{
+      assetCode: string;
+      assetIssuer: string | null;
+      amount: string;
+      valueUsd: number;
+    }> = [];
+    let totalValueUsd = 0;
+
+    try {
+      const stellarBalances =
+        await this.stellarBalanceService.getAccountBalances(user.id);
+
+      // Calculate USD values for each asset
+      assetBalances = stellarBalances.map((balance) => {
+        const valueUsd = this.stellarBalanceService.getAssetValueUsd(
+          balance.assetCode,
+          balance.assetIssuer,
+          balance.balance,
+        );
+
+        totalValueUsd += valueUsd;
+
+        return {
+          assetCode: balance.assetCode,
+          assetIssuer: balance.assetIssuer,
+          amount: balance.balance,
+          valueUsd,
+        };
+      });
+    } catch {
+      this.logger.warn(
+        `Failed to fetch Stellar balances for user ${userId}, using portfolio assets as fallback`,
+      );
+
+      // Fallback to portfolio_assets table if Stellar fetch fails
+      const portfolioAssets = await this.assetRepository.find({
+        where: { userId },
+      });
+
+      assetBalances = portfolioAssets.map((asset) => {
+        const valueUsd = this.stellarBalanceService.getAssetValueUsd(
+          asset.assetCode,
+          asset.assetIssuer,
+          asset.amount,
+        );
+
+        totalValueUsd += valueUsd;
+
+        return {
+          assetCode: asset.assetCode,
+          assetIssuer: asset.assetIssuer,
+          amount: asset.amount,
+          valueUsd,
+        };
+      });
+    }
+
+    // Create and save snapshot
+    const snapshot = this.snapshotRepository.create({
+      userId,
+      assetBalances,
+      totalValueUsd: totalValueUsd.toFixed(2),
+    });
+
+    return await this.snapshotRepository.save(snapshot);
+  }
+
+  /**
+   * Get portfolio history for a user with pagination
+   */
+  async getPortfolioHistory(
+    userId: string,
+    page: number = 1,
+    limit: number = 10,
+  ): Promise<PortfolioHistoryResponseDto> {
+    const skip = (page - 1) * limit;
+
+    const [snapshots, total] = await this.snapshotRepository.findAndCount({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    const snapshotDtos: PortfolioSnapshotDto[] = snapshots.map((snapshot) => ({
+      id: snapshot.id,
+      userId: snapshot.userId,
+      createdAt: snapshot.createdAt,
+      assetBalances: snapshot.assetBalances,
+      totalValueUsd: snapshot.totalValueUsd,
+    }));
+
+    return {
+      snapshots: snapshotDtos,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  /**
+   * Scheduled job to create snapshots for all users
+   * Runs daily at midnight
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async createSnapshotsForAllUsers(): Promise<void> {
+    this.logger.log('Starting scheduled snapshot creation for all users');
+
+    const users = await this.userRepository.find();
+    let successCount = 0;
+    let failCount = 0;
+
+    for (const user of users) {
+      try {
+        await this.createSnapshot(user.id);
+        successCount++;
+      } catch (error: unknown) {
+        this.logger.error(
+          `Failed to create snapshot for user ${user.id}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        );
+        failCount++;
+      }
+    }
+
+    this.logger.log(
+      `Snapshot creation completed. Success: ${successCount}, Failed: ${failCount}`,
+    );
+  }
+
+  /**
+   * Manual trigger for creating snapshots (useful for testing)
+   */
+  async triggerSnapshotCreation(): Promise<{
+    success: number;
+    failed: number;
+  }> {
+    this.logger.log('Manual snapshot creation triggered');
+
+    const users = await this.userRepository.find();
+    let successCount = 0;
+    let failCount = 0;
+
+    for (const user of users) {
+      try {
+        await this.createSnapshot(user.id);
+        successCount++;
+      } catch (error: unknown) {
+        this.logger.error(
+          `Failed to create snapshot for user ${user.id}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        );
+        failCount++;
+      }
+    }
+
+    return { success: successCount, failed: failCount };
+  }
+}

--- a/apps/backend/src/portfolio/stellar-balance.service.ts
+++ b/apps/backend/src/portfolio/stellar-balance.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, Logger } from '@nestjs/common';
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-unsafe-assignment
+const StellarSdk = require('stellar-sdk');
+
+export interface StellarBalance {
+  assetCode: string;
+  assetIssuer: string | null;
+  balance: string;
+}
+
+interface BalanceLine {
+  asset_type: string;
+  asset_code?: string;
+  asset_issuer?: string;
+  balance: string;
+}
+
+@Injectable()
+export class StellarBalanceService {
+  private readonly logger = new Logger(StellarBalanceService.name);
+
+  private readonly server: any;
+
+  constructor() {
+    // Use public Stellar Horizon server
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    this.server = new StellarSdk.Server('https://horizon.stellar.org');
+  }
+
+  /**
+   * Fetch account balances from Stellar network
+   */
+  async getAccountBalances(publicKey: string): Promise<StellarBalance[]> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+      const account = await this.server.loadAccount(publicKey);
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+      const balances: BalanceLine[] = account.balances;
+
+      return balances
+        .map((balance: BalanceLine) => {
+          if (balance.asset_type === 'native') {
+            return {
+              assetCode: 'XLM',
+              assetIssuer: null,
+              balance: balance.balance,
+            };
+          } else if (balance.asset_code && balance.asset_issuer) {
+            return {
+              assetCode: balance.asset_code,
+              assetIssuer: balance.asset_issuer,
+              balance: balance.balance,
+            };
+          }
+          return null;
+        })
+        .filter((b: StellarBalance | null): b is StellarBalance => b !== null);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to fetch balances for ${publicKey}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Get USD value for an asset (mock implementation)
+   * In production, this should call a price API like CoinGecko or similar
+   */
+  getAssetValueUsd(
+    assetCode: string,
+    assetIssuer: string | null,
+    amount: string,
+  ): number {
+    // Mock prices for demonstration
+    const mockPrices: Record<string, number> = {
+      XLM: 0.12, // $0.12 per XLM
+      USDC: 1.0, // $1.00 per USDC
+      BTC: 45000.0, // Mock BTC price
+    };
+
+    const price = mockPrices[assetCode] || 0;
+    const numAmount = parseFloat(amount);
+
+    return numAmount * price;
+  }
+}


### PR DESCRIPTION
I implemented the store periodic portfolio snapshots for users

- Add PortfolioSnapshot entity with JSONB asset balances
- Create StellarBalanceService to fetch real-time balances from Horizon API
- Implement PortfolioService with snapshot creation and history retrieval
- Add scheduled job to create daily snapshots at midnight
- Create GET /portfolio/history endpoint with pagination
- Create POST /portfolio/snapshot for manual snapshot creation
- Add database migration for portfolio_snapshots table
- Install @nestjs/schedule for cron job support
- Integrate with Stellar SDK for balance fetching
- Add fallback to portfolio_assets table if Stellar fetch fails

Closes #332 