### PR TITLE
feat/token-burn

### DIFF
--- a/apps/onchain/contracts/lumen_token/src/events.rs
+++ b/apps/onchain/contracts/lumen_token/src/events.rs
@@ -15,3 +15,10 @@ pub struct AdminChangedEvent {
     pub old_admin: Address,
     pub new_admin: Address,
 }
+
+#[contractevent]
+pub struct BurnEvent {
+    #[topic]
+    pub from: Address,
+    pub amount: i128,
+}


### PR DESCRIPTION
## feat/token-burn — Closes #315

### What
Adds `burn` and `burn_from` entrypoints to `LumenToken` with event emission and total supply tracking.

### Changes
- **`lib.rs`** — `burn(from, amount)` and `burn_from(spender, from, amount)` entrypoints
- **`balance.rs`** — total supply tracking via `read_total_supply` / `write_total_supply`; decremented inside `spend_balance`
- **`events.rs`** — `BurnEvent { from, amount }` following existing event patterns

### Authorization Model
| Caller | Permission |
|---|---|
| Token owner (`from`) | ✅ via `burn` |
| Delegated spender | ✅ via `burn_from` + allowance |
| Frozen accounts | ❌ rejected |
| Admin | No special burn privilege |

### Success Criteria
- [x] `burn(env, from, amount)` entrypoint
- [x] `burn_from(env, spender, from, amount)` entrypoint  
- [x] Frozen accounts cannot burn
- [x] Balances and total supply reduced correctly
- [x] `BurnEvent` emitted on both paths

<img width="1262" height="625" alt="Screenshot From 2026-02-21 14-24-45" src="https://github.com/user-attachments/assets/69e270b0-17bf-4df6-9b07-1550e6eabf2c" />


Closes #315