### PR TITLE
implemented role-based access control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ Thumbs.db
 
 # Documentation
 PR_PASSWORD_RESET.md
+
+.agent/
+.agents/
+issue.md

--- a/apps/backend/.gitignore
+++ b/apps/backend/.gitignore
@@ -37,3 +37,4 @@ lerna-debug.log*
 # OS
 .DS_Store
 Thumbs.db
+COMMIT_MSG.md

--- a/apps/backend/src/auth/auth.module.ts
+++ b/apps/backend/src/auth/auth.module.ts
@@ -8,6 +8,7 @@ import { EmailModule } from '../email/email.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { JwtStrategy } from './jwt.strategy';
+import { RolesGuard } from './roles.guard';
 import { User } from '../users/entities/user.entity';
 import { PasswordResetToken } from './entities/password-reset-token.entity';
 import { RefreshToken } from './entities/refresh-token.entity';
@@ -30,7 +31,7 @@ import { RefreshToken } from './entities/refresh-token.entity';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy],
-  exports: [AuthService, JwtStrategy, PassportModule],
+  providers: [AuthService, JwtStrategy, RolesGuard],
+  exports: [AuthService, JwtStrategy, RolesGuard, PassportModule],
 })
 export class AuthModule {}

--- a/apps/backend/src/auth/auth.service.ts
+++ b/apps/backend/src/auth/auth.service.ts
@@ -99,11 +99,11 @@ export class AuthService {
   }
 
   async login(
-    user: { id: string; email: string },
+    user: { id: string; email: string; role?: string },
     deviceInfo?: string,
     ipAddress?: string,
   ) {
-    const payload = { email: user.email, sub: user.id };
+    const payload = { email: user.email, sub: user.id, role: user.role };
     const accessToken = this.jwtService.sign(payload);
 
     // Generate and store refresh token

--- a/apps/backend/src/auth/decorators/auth.decorators.ts
+++ b/apps/backend/src/auth/decorators/auth.decorators.ts
@@ -4,7 +4,21 @@ import {
   ExecutionContext,
 } from '@nestjs/common';
 import { Request } from 'express';
-import { User } from '../../users/entities/user.entity';
+import { User, UserRole } from '../../users/entities/user.entity';
+
+export const ROLES_KEY = 'roles';
+
+/**
+ * Restrict a route to users with specific roles.
+ * Must be combined with JwtAuthGuard + RolesGuard.
+ *
+ * @example
+ * @Roles(UserRole.ADMIN)
+ * @UseGuards(JwtAuthGuard, RolesGuard)
+ * @Post()
+ * create(@Body() dto: CreateDto) { ... }
+ */
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);
 
 /**
  * Decorator to mark routes as public (skip JWT authentication)

--- a/apps/backend/src/auth/jwt.strategy.ts
+++ b/apps/backend/src/auth/jwt.strategy.ts
@@ -13,6 +13,7 @@ export interface JwtPayload {
   iat?: number;
   exp?: number;
   email?: string;
+  role?: string;
 }
 
 @Injectable()
@@ -34,6 +35,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
     const user = await this.userRepository.findOne({
       where: { id: userId },
+      // role column is selected by default
     });
 
     if (!user) {

--- a/apps/backend/src/auth/roles.guard.ts
+++ b/apps/backend/src/auth/roles.guard.ts
@@ -1,0 +1,37 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { UserRole } from '../users/entities/user.entity';
+import { ROLES_KEY } from './decorators/auth.decorators';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+      ROLES_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const { user } = context
+      .switchToHttp()
+      .getRequest<{ user?: { role?: UserRole } }>();
+
+    if (!user || !requiredRoles.includes(user.role as UserRole)) {
+      throw new ForbiddenException(
+        'You do not have permission to access this resource',
+      );
+    }
+
+    return true;
+  }
+}

--- a/apps/backend/src/database/migrations/1769700000000-AddRoleToUsers.ts
+++ b/apps/backend/src/database/migrations/1769700000000-AddRoleToUsers.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRoleToUsers1769700000000 implements MigrationInterface {
+  name = 'AddRoleToUsers1769700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."users_role_enum" AS ENUM('user', 'admin')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD "role" "public"."users_role_enum" NOT NULL DEFAULT 'user'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "role"`);
+    await queryRunner.query(`DROP TYPE "public"."users_role_enum"`);
+  }
+}

--- a/apps/backend/src/users/entities/user.entity.ts
+++ b/apps/backend/src/users/entities/user.entity.ts
@@ -7,6 +7,11 @@ import {
   Index,
 } from 'typeorm';
 
+export enum UserRole {
+  USER = 'user',
+  ADMIN = 'admin',
+}
+
 @Entity('users')
 export class User {
   @PrimaryGeneratedColumn('uuid')
@@ -28,6 +33,13 @@ export class User {
   @Index({ unique: true })
   @Column({ type: 'varchar', length: 255, unique: true, nullable: true })
   stellarPublicKey: string;
+
+  @Column({
+    type: 'enum',
+    enum: UserRole,
+    default: UserRole.USER,
+  })
+  role: UserRole;
 
   @CreateDateColumn({ type: 'timestamptz' })
   createdAt: Date;


### PR DESCRIPTION
# Commit Message

feat(auth): add basic role-based access control

- Add UserRole enum (user | admin) to User entity with role column (default: user)
- Add migration 1769700000000-AddRoleToUsers for the role enum + column
- Add @Roles() decorator via SetMetadata in auth.decorators.ts
- Implement RolesGuard that reads required roles via Reflector and throws
  ForbiddenException (403) when the authenticated user's role is not in the list
- Include role in JWT payload in AuthService.login()
- Extend JwtPayload interface in JwtStrategy to carry role; JwtStrategy.validate()
  fetches the full User row (which now includes role) so req.user always has it
- Export RolesGuard from AuthModule so it can be injected in feature modules

Usage example:
  @Roles(UserRole.ADMIN)
  @UseGuards(JwtAuthGuard, RolesGuard)
  @Post()
  create(@Body() dto: CreateDto) { ... }

closes:  #384
