### PR TITLE
feat(mobile): add account management and notification settings

### DIFF
--- a/apps/backend/src/database/migrations/1769800000000-AddUserPreferences.ts
+++ b/apps/backend/src/database/migrations/1769800000000-AddUserPreferences.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserPreferences1769800000000 implements MigrationInterface {
+  name = 'AddUserPreferences1769800000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "users" ADD "preferences" jsonb NOT NULL DEFAULT '{"notifications":{"priceAlerts":true,"newsAlerts":true,"securityAlerts":true}}'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "preferences"`);
+  }
+}

--- a/apps/backend/src/users/dto/profile-response.dto.ts
+++ b/apps/backend/src/users/dto/profile-response.dto.ts
@@ -1,3 +1,5 @@
+import { UserPreferences } from '../entities/user.entity';
+
 export class ProfileResponseDto {
   id: string;
   email: string;
@@ -7,6 +9,7 @@ export class ProfileResponseDto {
   bio?: string;
   avatarUrl?: string;
   stellarPublicKey?: string;
+  preferences?: UserPreferences;
   createdAt: Date;
   updatedAt: Date;
 

--- a/apps/backend/src/users/dto/update-profile.dto.ts
+++ b/apps/backend/src/users/dto/update-profile.dto.ts
@@ -1,5 +1,50 @@
-import { IsString, IsOptional, IsUrl, MaxLength } from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+  ValidateNested,
+} from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateNotificationPreferencesDto {
+  @ApiPropertyOptional({
+    description: 'Enable price alert notifications',
+    example: true,
+  })
+  @IsBoolean()
+  @IsOptional()
+  priceAlerts?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Enable news alert notifications',
+    example: true,
+  })
+  @IsBoolean()
+  @IsOptional()
+  newsAlerts?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Enable security alert notifications',
+    example: true,
+  })
+  @IsBoolean()
+  @IsOptional()
+  securityAlerts?: boolean;
+}
+
+export class UpdatePreferencesDto {
+  @ApiPropertyOptional({
+    description: 'Notification preference set',
+    type: UpdateNotificationPreferencesDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UpdateNotificationPreferencesDto)
+  notifications?: UpdateNotificationPreferencesDto;
+}
 
 export class UpdateProfileDto {
   @ApiPropertyOptional({
@@ -28,4 +73,13 @@ export class UpdateProfileDto {
   @IsUrl()
   @MaxLength(500)
   avatarUrl?: string;
+
+  @ApiPropertyOptional({
+    description: 'User preference updates',
+    type: UpdatePreferencesDto,
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UpdatePreferencesDto)
+  preferences?: UpdatePreferencesDto;
 }

--- a/apps/backend/src/users/entities/user.entity.ts
+++ b/apps/backend/src/users/entities/user.entity.ts
@@ -14,6 +14,16 @@ export enum UserRole {
   ADMIN = 'admin',
 }
 
+export interface NotificationPreferences {
+  priceAlerts: boolean;
+  newsAlerts: boolean;
+  securityAlerts: boolean;
+}
+
+export interface UserPreferences {
+  notifications: NotificationPreferences;
+}
+
 @Entity('users')
 export class User {
   @PrimaryGeneratedColumn('uuid')
@@ -51,6 +61,18 @@ export class User {
     default: UserRole.USER,
   })
   role: UserRole;
+
+  @Column({
+    type: 'jsonb',
+    default: {
+      notifications: {
+        priceAlerts: true,
+        newsAlerts: true,
+        securityAlerts: true,
+      },
+    },
+  })
+  preferences: UserPreferences;
 
   @OneToMany(() => StellarAccount, (stellarAccount) => stellarAccount.user)
   stellarAccounts: StellarAccount[];

--- a/apps/backend/src/users/users.controller.spec.ts
+++ b/apps/backend/src/users/users.controller.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
-import { User } from './entities/user.entity';
+import { User, UserRole } from './entities/user.entity';
 
 describe('UsersController', () => {
   let controller: UsersController;
@@ -16,6 +16,15 @@ describe('UsersController', () => {
     bio: 'Test user bio',
     avatarUrl: 'https://example.com/avatar.jpg',
     stellarPublicKey: 'GABC123',
+    role: UserRole.USER,
+    preferences: {
+      notifications: {
+        priceAlerts: true,
+        newsAlerts: true,
+        securityAlerts: true,
+      },
+    },
+    stellarAccounts: [],
     createdAt: new Date(),
     updatedAt: new Date(),
     passwordHash: 'hashed-password',
@@ -65,6 +74,7 @@ describe('UsersController', () => {
       expect(result.id).toBe('test-id');
       expect(result.email).toBe('test@example.com');
       expect(result.displayName).toBe('John Doe');
+      expect(result.preferences?.notifications.priceAlerts).toBe(true);
     });
   });
 
@@ -103,6 +113,37 @@ describe('UsersController', () => {
 
       expect(service.update).toHaveBeenCalledWith('test-id', {
         displayName: 'Updated Name',
+      });
+    });
+
+    it('should merge notification preferences without dropping existing values', async () => {
+      const mockRequest = {
+        user: { id: 'test-id', email: 'test@example.com' },
+      } as any;
+      const updateData = {
+        preferences: {
+          notifications: {
+            newsAlerts: false,
+          },
+        },
+      };
+
+      const result = await controller.updateProfile(mockRequest, updateData);
+
+      expect(result.preferences?.notifications).toEqual({
+        priceAlerts: true,
+        newsAlerts: false,
+        securityAlerts: true,
+      });
+
+      expect(service.update).toHaveBeenCalledWith('test-id', {
+        preferences: {
+          notifications: {
+            priceAlerts: true,
+            newsAlerts: false,
+            securityAlerts: true,
+          },
+        },
       });
     });
   });

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -12,6 +12,7 @@ import {
   HttpStatus,
   UsePipes,
   ValidationPipe,
+  NotFoundException,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -21,7 +22,11 @@ import {
 } from '@nestjs/swagger';
 import { Request } from 'express';
 import { UsersService } from './users.service';
-import { User } from './entities/user.entity';
+import {
+  NotificationPreferences,
+  User,
+  UserPreferences,
+} from './entities/user.entity';
 import { LinkStellarAccountDto } from './dto/link-stellar-account.dto';
 import { StellarAccountResponseDto } from './dto/stellar-account-response.dto';
 import { UpdateStellarAccountLabelDto } from './dto/update-stellar-account-label.dto';
@@ -44,6 +49,51 @@ interface RequestWithUser extends Request {
 @UseGuards(JwtAuthGuard)
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
+
+  private buildDefaultPreferences(): UserPreferences {
+    return {
+      notifications: {
+        priceAlerts: true,
+        newsAlerts: true,
+        securityAlerts: true,
+      },
+    };
+  }
+
+  /**
+   * Profile responses always include a complete preferences object so clients
+   * can render deterministic toggle state without guessing missing fields.
+   */
+  private resolvePreferences(
+    preferences?: Partial<UserPreferences>,
+  ): UserPreferences {
+    const defaults = this.buildDefaultPreferences();
+
+    return {
+      ...defaults,
+      ...preferences,
+      notifications: {
+        ...defaults.notifications,
+        ...(preferences?.notifications ?? {}),
+      },
+    };
+  }
+
+  private mapProfileResponse(user: User): ProfileResponseDto {
+    return new ProfileResponseDto({
+      id: user.id,
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      displayName: user.displayName,
+      bio: user.bio,
+      avatarUrl: user.avatarUrl,
+      stellarPublicKey: user.stellarPublicKey,
+      preferences: this.resolvePreferences(user.preferences),
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    });
+  }
 
   // --- ADMIN/GENERAL ENDPOINTS ---
 
@@ -71,21 +121,10 @@ export class UsersController {
     const user = await this.usersService.findById(userId);
 
     if (!user) {
-      throw new Error('User not found');
+      throw new NotFoundException('User not found');
     }
 
-    return new ProfileResponseDto({
-      id: user.id,
-      email: user.email,
-      firstName: user.firstName,
-      lastName: user.lastName,
-      displayName: user.displayName,
-      bio: user.bio,
-      avatarUrl: user.avatarUrl,
-      stellarPublicKey: user.stellarPublicKey,
-      createdAt: user.createdAt,
-      updatedAt: user.updatedAt,
-    });
+    return this.mapProfileResponse(user);
   }
 
   @Patch('me')
@@ -96,6 +135,11 @@ export class UsersController {
     @Body() updateProfileDto: UpdateProfileDto,
   ): Promise<ProfileResponseDto> {
     const userId = req.user.id;
+    const currentUser = await this.usersService.findById(userId);
+
+    if (!currentUser) {
+      throw new NotFoundException('User not found');
+    }
 
     const allowedUpdates: Partial<User> = {};
     if (updateProfileDto.displayName !== undefined)
@@ -104,21 +148,20 @@ export class UsersController {
       allowedUpdates.bio = updateProfileDto.bio;
     if (updateProfileDto.avatarUrl !== undefined)
       allowedUpdates.avatarUrl = updateProfileDto.avatarUrl;
+    if (updateProfileDto.preferences?.notifications) {
+      const nextNotifications: NotificationPreferences = {
+        ...this.resolvePreferences(currentUser.preferences).notifications,
+        ...updateProfileDto.preferences.notifications,
+      };
+      allowedUpdates.preferences = {
+        ...this.resolvePreferences(currentUser.preferences),
+        notifications: nextNotifications,
+      };
+    }
 
     const updatedUser = await this.usersService.update(userId, allowedUpdates);
 
-    return new ProfileResponseDto({
-      id: updatedUser.id,
-      email: updatedUser.email,
-      firstName: updatedUser.firstName,
-      lastName: updatedUser.lastName,
-      displayName: updatedUser.displayName,
-      bio: updatedUser.bio,
-      avatarUrl: updatedUser.avatarUrl,
-      stellarPublicKey: updatedUser.stellarPublicKey,
-      createdAt: updatedUser.createdAt,
-      updatedAt: updatedUser.updatedAt,
-    });
+    return this.mapProfileResponse(updatedUser);
   }
 
   // --- STELLAR ACCOUNT MANAGEMENT (From Feature Branch) ---

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -28,9 +28,7 @@
       "favicon": "./assets/favicon.png",
       "bundler": "metro"
     },
-    "plugins": [
-      "expo-router"
-    ],
+    "plugins": ["expo-router", "expo-barcode-scanner"],
     "scheme": "mobile",
     "extra": {
       "backendUrl": "http://localhost:3000",

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-  StyleSheet,
-  Text,
-  View,
-  SafeAreaView,
-  TouchableOpacity,
-  ScrollView,
-} from 'react-native';
+import { StyleSheet, Text, View, SafeAreaView, TouchableOpacity, ScrollView } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import Constants from 'expo-constants';
 import { useAuth } from '../../contexts/AuthContext';
@@ -42,8 +35,58 @@ export default function SettingsScreen() {
       <ScrollView style={styles.scroll} contentContainerStyle={styles.content}>
         <Text style={[styles.title, { color: colors.text }]}>Settings</Text>
 
-        {/* ── Theme Section ── */}
-        <View style={[styles.section, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+        <View
+          style={[styles.section, { backgroundColor: colors.surface, borderColor: colors.border }]}
+        >
+          <View style={styles.sectionHeader}>
+            <Ionicons name="options-outline" size={20} color={colors.accent} />
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>Account & Preferences</Text>
+          </View>
+
+          <TouchableOpacity
+            style={styles.navRow}
+            activeOpacity={0.75}
+            onPress={() => router.push('/settings/manage-accounts')}
+          >
+            <View style={styles.navRowCopy}>
+              <View style={[styles.navIconShell, { backgroundColor: colors.card }]}>
+                <Ionicons name="wallet-outline" size={18} color={colors.accent} />
+              </View>
+              <View style={styles.navTextWrap}>
+                <Text style={[styles.navTitle, { color: colors.text }]}>Manage Accounts</Text>
+                <Text style={[styles.navDescription, { color: colors.textSecondary }]}>
+                  Add linked Stellar public keys with QR and remove them when needed.
+                </Text>
+              </View>
+            </View>
+            <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
+          </TouchableOpacity>
+
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+
+          <TouchableOpacity
+            style={styles.navRow}
+            activeOpacity={0.75}
+            onPress={() => router.push('/settings/notification-settings')}
+          >
+            <View style={styles.navRowCopy}>
+              <View style={[styles.navIconShell, { backgroundColor: colors.card }]}>
+                <Ionicons name="notifications-outline" size={18} color={colors.accent} />
+              </View>
+              <View style={styles.navTextWrap}>
+                <Text style={[styles.navTitle, { color: colors.text }]}>Notification Settings</Text>
+                <Text style={[styles.navDescription, { color: colors.textSecondary }]}>
+                  Control price, news, and security alerts individually.
+                </Text>
+              </View>
+            </View>
+            <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
+          </TouchableOpacity>
+        </View>
+
+        <View
+          style={[styles.section, { backgroundColor: colors.surface, borderColor: colors.border }]}
+        >
           <View style={styles.sectionHeader}>
             <Ionicons name="color-palette-outline" size={20} color={colors.accent} />
             <Text style={[styles.sectionTitle, { color: colors.text }]}>Appearance</Text>
@@ -70,12 +113,7 @@ export default function SettingsScreen() {
                     size={20}
                     color={isActive ? '#ffffff' : colors.textSecondary}
                   />
-                  <Text
-                    style={[
-                      styles.themeLabel,
-                      { color: isActive ? '#ffffff' : colors.text },
-                    ]}
-                  >
+                  <Text style={[styles.themeLabel, { color: isActive ? '#ffffff' : colors.text }]}>
                     {opt.label}
                   </Text>
                 </TouchableOpacity>
@@ -84,8 +122,9 @@ export default function SettingsScreen() {
           </View>
         </View>
 
-        {/* ── App Info Section ── */}
-        <View style={[styles.section, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+        <View
+          style={[styles.section, { backgroundColor: colors.surface, borderColor: colors.border }]}
+        >
           <View style={styles.sectionHeader}>
             <Ionicons name="information-circle-outline" size={20} color={colors.accent} />
             <Text style={[styles.sectionTitle, { color: colors.text }]}>App Info</Text>
@@ -100,7 +139,12 @@ export default function SettingsScreen() {
 
           <View style={styles.infoRow}>
             <Text style={[styles.infoLabel, { color: colors.textSecondary }]}>Environment</Text>
-            <View style={[styles.envBadge, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
+            <View
+              style={[
+                styles.envBadge,
+                { backgroundColor: colors.card, borderColor: colors.cardBorder },
+              ]}
+            >
               <Text style={[styles.envBadgeText, { color: colors.accent }]}>
                 {appEnv === 'production' ? 'Production' : 'Contributor Build'}
               </Text>
@@ -115,7 +159,6 @@ export default function SettingsScreen() {
           </View>
         </View>
 
-        {/* ── Logout ── */}
         {isAuthenticated && (
           <TouchableOpacity
             style={[styles.logoutButton, { backgroundColor: colors.danger }]}
@@ -148,8 +191,6 @@ const styles = StyleSheet.create({
     marginBottom: 24,
     letterSpacing: -0.5,
   },
-
-  /* Sections */
   section: {
     borderRadius: 16,
     padding: 16,
@@ -166,8 +207,38 @@ const styles = StyleSheet.create({
     fontWeight: '600',
     marginLeft: 8,
   },
-
-  /* Theme Selector */
+  navRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+    paddingVertical: 4,
+  },
+  navRowCopy: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  navIconShell: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  navTextWrap: {
+    flex: 1,
+  },
+  navTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  navDescription: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
   themeRow: {
     flexDirection: 'row',
     gap: 10,
@@ -185,8 +256,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '600',
   },
-
-  /* App Info */
   infoRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -202,6 +271,7 @@ const styles = StyleSheet.create({
   },
   divider: {
     height: StyleSheet.hairlineWidth,
+    marginVertical: 14,
   },
   envBadge: {
     paddingHorizontal: 10,
@@ -213,8 +283,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '600',
   },
-
-  /* Logout */
   logoutButton: {
     flexDirection: 'row',
     height: 56,

--- a/apps/mobile/app/auth/login.tsx
+++ b/apps/mobile/app/auth/login.tsx
@@ -10,9 +10,9 @@ import {
   KeyboardAvoidingView,
   Platform,
   ActivityIndicator,
+  StatusBar,
 } from 'react-native';
-import { StatusBar } from 'react-native';
-import { useRouter, Link } from 'expo-router';
+import { useRouter } from 'expo-router';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 
@@ -63,7 +63,7 @@ const LoginScreen = () => {
       console.error('Login error:', error);
       Alert.alert(
         'Login Failed',
-        error.message || 'An error occurred during login. Please try again.'
+        error.message || 'An error occurred during login. Please try again.',
       );
     } finally {
       setLoading(false);
@@ -79,7 +79,7 @@ const LoginScreen = () => {
       <ScrollView contentContainerStyle={styles.scrollContainer} bounces={false}>
         <View style={styles.content}>
           <Text style={[styles.title, { color: colors.text }]}>Welcome Back</Text>
-          <Text style={[styles.subtitle, { color: colors.primary }]}>Sign in to your account</Text>
+          <Text style={[styles.subtitle, { color: colors.accent }]}>Sign in to your account</Text>
 
           <View style={styles.form}>
             <View style={styles.inputContainer}>
@@ -90,7 +90,7 @@ const LoginScreen = () => {
                   {
                     backgroundColor: colors.surface,
                     color: colors.text,
-                    borderColor: `${colors.primary}33`,
+                    borderColor: `${colors.accent}33`,
                   },
                 ]}
                 value={email}
@@ -112,7 +112,7 @@ const LoginScreen = () => {
                   {
                     backgroundColor: colors.surface,
                     color: colors.text,
-                    borderColor: `${colors.primary}33`,
+                    borderColor: `${colors.accent}33`,
                   },
                 ]}
                 value={password}
@@ -128,7 +128,7 @@ const LoginScreen = () => {
             <TouchableOpacity
               style={[
                 styles.button,
-                { backgroundColor: colors.primary, shadowColor: colors.primary },
+                { backgroundColor: colors.accent, shadowColor: colors.accent },
                 loading && styles.disabledButton,
               ]}
               onPress={handleLogin}
@@ -146,7 +146,8 @@ const LoginScreen = () => {
               onPress={() => router.push('/auth/register')}
             >
               <Text style={[styles.linkText, { color: colors.textSecondary }]}>
-                Don't have an account? <Text style={[styles.linkHighlight, { color: colors.primary }]}>Sign Up</Text>
+                Don&apos;t have an account?{' '}
+                <Text style={[styles.linkHighlight, { color: colors.accent }]}>Sign Up</Text>
               </Text>
             </TouchableOpacity>
 
@@ -155,7 +156,10 @@ const LoginScreen = () => {
               onPress={() => router.replace('/(tabs)')}
             >
               <Text style={[styles.linkText, { color: colors.textSecondary, fontSize: 14 }]}>
-                (Debug) <Text style={{ color: colors.primary, fontWeight: 'bold' }}>Bypass Login to Dashboard</Text>
+                (Debug){' '}
+                <Text style={{ color: colors.accent, fontWeight: 'bold' }}>
+                  Bypass Login to Dashboard
+                </Text>
               </Text>
             </TouchableOpacity>
           </View>

--- a/apps/mobile/app/settings/manage-accounts.tsx
+++ b/apps/mobile/app/settings/manage-accounts.tsx
@@ -1,0 +1,533 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Modal,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { BarCodeScanner, BarCodeScannerResult } from 'expo-barcode-scanner';
+import { LinkedStellarAccount, usersApi } from '../../lib/api';
+import { useTheme } from '../../contexts/ThemeContext';
+
+const STELLAR_PUBLIC_KEY_REGEX = /\bG[A-Z2-7]{55}\b/;
+
+const truncateKey = (value: string) => `${value.slice(0, 6)}…${value.slice(-6)}`;
+
+const extractPublicKey = (payload: string): string | null => {
+  const directMatch = payload.match(STELLAR_PUBLIC_KEY_REGEX);
+  if (directMatch?.[0]) {
+    return directMatch[0];
+  }
+
+  try {
+    const decoded = decodeURIComponent(payload);
+    const decodedMatch = decoded.match(STELLAR_PUBLIC_KEY_REGEX);
+    return decodedMatch?.[0] ?? null;
+  } catch {
+    return null;
+  }
+};
+
+export default function ManageAccountsScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const [accounts, setAccounts] = useState<LinkedStellarAccount[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [nickname, setNickname] = useState('');
+  const [scannerOpen, setScannerOpen] = useState(false);
+  const [permissionGranted, setPermissionGranted] = useState<boolean | null>(null);
+  const [scanLocked, setScanLocked] = useState(false);
+
+  const sortedAccounts = useMemo(
+    () =>
+      [...accounts].sort(
+        (left, right) => new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime(),
+      ),
+    [accounts],
+  );
+
+  const loadAccounts = useCallback(async () => {
+    const response = await usersApi.getLinkedAccounts();
+
+    if (!response.success) {
+      Alert.alert('Could not load accounts', response.error?.message ?? 'Try again in a moment.');
+      return;
+    }
+
+    setAccounts(response.data ?? []);
+  }, []);
+
+  useEffect(() => {
+    const bootstrap = async () => {
+      setLoading(true);
+      await loadAccounts();
+      setLoading(false);
+    };
+
+    void bootstrap();
+  }, [loadAccounts]);
+
+  const openScanner = async () => {
+    const permission = await BarCodeScanner.requestPermissionsAsync();
+    const granted = permission.status === 'granted';
+    setPermissionGranted(granted);
+
+    if (!granted) {
+      Alert.alert(
+        'Camera permission required',
+        'Allow camera access to scan a Stellar public key QR code.',
+      );
+      return;
+    }
+
+    setScanLocked(false);
+    setScannerOpen(true);
+  };
+
+  const handleScanned = async ({ data }: BarCodeScannerResult) => {
+    if (scanLocked || submitting) {
+      return;
+    }
+
+    setScanLocked(true);
+    const publicKey = extractPublicKey(data);
+
+    if (!publicKey) {
+      Alert.alert(
+        'Unsupported QR payload',
+        'Scan a Stellar public key QR code or a QR payload containing one.',
+      );
+      setScanLocked(false);
+      return;
+    }
+
+    setScannerOpen(false);
+    setSubmitting(true);
+
+    const response = await usersApi.linkStellarAccount({
+      publicKey,
+      label: nickname.trim() || undefined,
+    });
+
+    setSubmitting(false);
+    setScanLocked(false);
+
+    if (!response.success) {
+      Alert.alert(
+        'Could not link account',
+        response.error?.message ?? 'The account could not be linked.',
+      );
+      return;
+    }
+
+    setNickname('');
+    await loadAccounts();
+    Alert.alert('Account linked', `${truncateKey(publicKey)} is now available in Settings.`);
+  };
+
+  const handleRemove = (account: LinkedStellarAccount) => {
+    Alert.alert(
+      'Remove linked account',
+      `Remove ${account.label || truncateKey(account.publicKey)} from this profile?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Remove',
+          style: 'destructive',
+          onPress: () => {
+            void (async () => {
+              setSubmitting(true);
+              const response = await usersApi.removeLinkedAccount(account.id);
+              setSubmitting(false);
+
+              if (!response.success) {
+                Alert.alert(
+                  'Could not remove account',
+                  response.error?.message ?? 'The account could not be removed.',
+                );
+                return;
+              }
+
+              await loadAccounts();
+            })();
+          },
+        },
+      ],
+    );
+  };
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    await loadAccounts();
+    setRefreshing(false);
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={[styles.headerButton, { backgroundColor: colors.card }]}
+            onPress={() => router.back()}
+            activeOpacity={0.8}
+          >
+            <Ionicons name="arrow-back" size={20} color={colors.text} />
+          </TouchableOpacity>
+          <View style={styles.headerCopy}>
+            <Text style={[styles.title, { color: colors.text }]}>Manage Accounts</Text>
+            <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+              Link Stellar public keys with QR, then remove them if you no longer want them attached
+              to this profile.
+            </Text>
+          </View>
+        </View>
+
+        <View
+          style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}
+        >
+          <View style={styles.cardHeader}>
+            <Ionicons name="qr-code-outline" size={20} color={colors.accent} />
+            <Text style={[styles.cardTitle, { color: colors.text }]}>Add Account</Text>
+          </View>
+
+          <Text style={[styles.helperText, { color: colors.textSecondary }]}>
+            Optional nickname for the next scanned account.
+          </Text>
+          <TextInput
+            style={[
+              styles.input,
+              {
+                backgroundColor: colors.card,
+                borderColor: colors.cardBorder,
+                color: colors.text,
+              },
+            ]}
+            value={nickname}
+            onChangeText={setNickname}
+            placeholder="e.g. Trading Wallet"
+            placeholderTextColor={colors.textSecondary}
+          />
+
+          <TouchableOpacity
+            style={[styles.primaryButton, { backgroundColor: colors.accent }]}
+            onPress={openScanner}
+            activeOpacity={0.85}
+            disabled={submitting}
+          >
+            {submitting ? (
+              <ActivityIndicator color="#ffffff" />
+            ) : (
+              <>
+                <Ionicons name="scan-outline" size={18} color="#ffffff" />
+                <Text style={styles.primaryButtonText}>Scan QR to Add Account</Text>
+              </>
+            )}
+          </TouchableOpacity>
+
+          <Text style={[styles.noteText, { color: colors.textSecondary }]}>
+            The scanner accepts a raw Stellar public key or a QR payload that contains one.
+          </Text>
+        </View>
+
+        <View
+          style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}
+        >
+          <View style={styles.sectionRow}>
+            <View style={styles.cardHeader}>
+              <Ionicons name="wallet-outline" size={20} color={colors.accent} />
+              <Text style={[styles.cardTitle, { color: colors.text }]}>Linked Accounts</Text>
+            </View>
+
+            <TouchableOpacity onPress={handleRefresh} disabled={refreshing} activeOpacity={0.8}>
+              {refreshing ? (
+                <ActivityIndicator size="small" color={colors.accent} />
+              ) : (
+                <Ionicons name="refresh-outline" size={20} color={colors.textSecondary} />
+              )}
+            </TouchableOpacity>
+          </View>
+
+          {loading ? (
+            <View style={styles.loadingWrap}>
+              <ActivityIndicator color={colors.accent} />
+            </View>
+          ) : sortedAccounts.length === 0 ? (
+            <View style={[styles.emptyState, { backgroundColor: colors.card }]}>
+              <Ionicons name="wallet-outline" size={22} color={colors.textSecondary} />
+              <Text style={[styles.emptyTitle, { color: colors.text }]}>
+                No linked accounts yet
+              </Text>
+              <Text style={[styles.emptyDescription, { color: colors.textSecondary }]}>
+                Scan a Stellar account QR code above to attach it to this profile.
+              </Text>
+            </View>
+          ) : (
+            sortedAccounts.map((account, index) => (
+              <View key={account.id}>
+                {index > 0 && <View style={[styles.divider, { backgroundColor: colors.border }]} />}
+                <View style={styles.accountRow}>
+                  <View style={styles.accountCopy}>
+                    <Text style={[styles.accountLabel, { color: colors.text }]}>
+                      {account.label?.trim() || 'Linked account'}
+                    </Text>
+                    <Text style={[styles.accountKey, { color: colors.textSecondary }]}>
+                      {truncateKey(account.publicKey)}
+                    </Text>
+                  </View>
+                  <TouchableOpacity
+                    style={[styles.removeButton, { borderColor: colors.danger }]}
+                    onPress={() => handleRemove(account)}
+                    activeOpacity={0.8}
+                    disabled={submitting}
+                  >
+                    <Ionicons name="trash-outline" size={16} color={colors.danger} />
+                    <Text style={[styles.removeButtonText, { color: colors.danger }]}>Remove</Text>
+                  </TouchableOpacity>
+                </View>
+              </View>
+            ))
+          )}
+        </View>
+      </ScrollView>
+
+      <Modal
+        visible={scannerOpen}
+        animationType="slide"
+        onRequestClose={() => setScannerOpen(false)}
+      >
+        <SafeAreaView style={[styles.scannerContainer, { backgroundColor: '#000000' }]}>
+          <View style={styles.scannerHeader}>
+            <TouchableOpacity
+              style={styles.scannerClose}
+              onPress={() => setScannerOpen(false)}
+              activeOpacity={0.85}
+            >
+              <Ionicons name="close" size={24} color="#ffffff" />
+            </TouchableOpacity>
+            <Text style={styles.scannerTitle}>Scan account QR</Text>
+            <View style={styles.scannerClose} />
+          </View>
+
+          {permissionGranted === false ? (
+            <View style={styles.permissionFallback}>
+              <Text style={styles.permissionFallbackText}>
+                Camera permission is required to scan account QR codes.
+              </Text>
+            </View>
+          ) : (
+            <BarCodeScanner
+              onBarCodeScanned={handleScanned}
+              style={StyleSheet.absoluteFillObject}
+              barCodeTypes={[BarCodeScanner.Constants.BarCodeType.qr]}
+            />
+          )}
+
+          <View style={styles.scannerFooter}>
+            <Text style={styles.scannerHint}>
+              Point the camera at a Stellar public key QR code.
+            </Text>
+          </View>
+        </SafeAreaView>
+      </Modal>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 24,
+    paddingBottom: 40,
+    gap: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    gap: 16,
+    alignItems: 'flex-start',
+  },
+  headerButton: {
+    width: 42,
+    height: 42,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerCopy: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '800',
+    letterSpacing: -0.5,
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  card: {
+    borderRadius: 18,
+    borderWidth: 1,
+    padding: 18,
+  },
+  cardHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 12,
+  },
+  cardTitle: {
+    fontSize: 17,
+    fontWeight: '700',
+  },
+  helperText: {
+    fontSize: 13,
+    marginBottom: 10,
+  },
+  input: {
+    minHeight: 52,
+    borderRadius: 14,
+    borderWidth: 1,
+    paddingHorizontal: 14,
+    fontSize: 15,
+    marginBottom: 12,
+  },
+  primaryButton: {
+    minHeight: 52,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    gap: 10,
+    marginBottom: 10,
+  },
+  primaryButtonText: {
+    color: '#ffffff',
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  noteText: {
+    fontSize: 12,
+    lineHeight: 18,
+  },
+  sectionRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
+  loadingWrap: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  emptyState: {
+    borderRadius: 14,
+    padding: 18,
+    alignItems: 'center',
+    gap: 10,
+  },
+  emptyTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  emptyDescription: {
+    fontSize: 13,
+    textAlign: 'center',
+    lineHeight: 19,
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    marginVertical: 14,
+  },
+  accountRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 12,
+    alignItems: 'center',
+  },
+  accountCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  accountLabel: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  accountKey: {
+    fontSize: 13,
+  },
+  removeButton: {
+    borderWidth: 1,
+    borderRadius: 12,
+    minHeight: 40,
+    paddingHorizontal: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  removeButtonText: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  scannerContainer: {
+    flex: 1,
+  },
+  scannerHeader: {
+    zIndex: 2,
+    paddingHorizontal: 20,
+    paddingVertical: 18,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  scannerClose: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  scannerTitle: {
+    color: '#ffffff',
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  scannerFooter: {
+    position: 'absolute',
+    bottom: 32,
+    left: 24,
+    right: 24,
+    backgroundColor: 'rgba(0, 0, 0, 0.72)',
+    borderRadius: 16,
+    padding: 16,
+  },
+  scannerHint: {
+    color: '#ffffff',
+    fontSize: 14,
+    textAlign: 'center',
+    lineHeight: 20,
+  },
+  permissionFallback: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  permissionFallbackText: {
+    color: '#ffffff',
+    textAlign: 'center',
+    fontSize: 15,
+    lineHeight: 22,
+  },
+});

--- a/apps/mobile/app/settings/notification-settings.tsx
+++ b/apps/mobile/app/settings/notification-settings.tsx
@@ -1,0 +1,260 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { NotificationPreferences, usersApi } from '../../lib/api';
+import { useTheme } from '../../contexts/ThemeContext';
+
+const DEFAULT_PREFERENCES: NotificationPreferences = {
+  priceAlerts: true,
+  newsAlerts: true,
+  securityAlerts: true,
+};
+
+const NOTIFICATION_ROWS: {
+  key: keyof NotificationPreferences;
+  title: string;
+  description: string;
+  icon: keyof typeof Ionicons.glyphMap;
+}[] = [
+  {
+    key: 'priceAlerts',
+    title: 'Price Alerts',
+    description: 'Immediate notifications when tracked market prices change meaningfully.',
+    icon: 'pulse-outline',
+  },
+  {
+    key: 'newsAlerts',
+    title: 'News Alerts',
+    description: 'Breaking ecosystem and market headlines relevant to your portfolio.',
+    icon: 'newspaper-outline',
+  },
+  {
+    key: 'securityAlerts',
+    title: 'Security Alerts',
+    description: 'Critical account, phishing, and suspicious-activity notices.',
+    icon: 'shield-checkmark-outline',
+  },
+];
+
+export default function NotificationSettingsScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const [preferences, setPreferences] = useState<NotificationPreferences>(DEFAULT_PREFERENCES);
+  const [loading, setLoading] = useState(true);
+  const [savingKey, setSavingKey] = useState<keyof NotificationPreferences | null>(null);
+
+  const loadPreferences = useCallback(async () => {
+    const response = await usersApi.getProfile();
+    if (!response.success) {
+      Alert.alert(
+        'Could not load preferences',
+        response.error?.message ?? 'Try again in a moment.',
+      );
+      return;
+    }
+
+    setPreferences({
+      ...DEFAULT_PREFERENCES,
+      ...(response.data?.preferences?.notifications ?? {}),
+    });
+  }, []);
+
+  useEffect(() => {
+    const bootstrap = async () => {
+      setLoading(true);
+      await loadPreferences();
+      setLoading(false);
+    };
+
+    void bootstrap();
+  }, [loadPreferences]);
+
+  const handleToggle = async (key: keyof NotificationPreferences, nextValue: boolean) => {
+    const previous = preferences;
+    const nextPreferences = { ...preferences, [key]: nextValue };
+
+    setPreferences(nextPreferences);
+    setSavingKey(key);
+
+    const response = await usersApi.updateProfile({
+      preferences: {
+        notifications: nextPreferences,
+      },
+    });
+
+    setSavingKey(null);
+
+    if (!response.success) {
+      setPreferences(previous);
+      Alert.alert(
+        'Could not update preferences',
+        response.error?.message ?? 'Your notification settings could not be saved.',
+      );
+      return;
+    }
+
+    setPreferences({
+      ...DEFAULT_PREFERENCES,
+      ...(response.data?.preferences?.notifications ?? nextPreferences),
+    });
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.header}>
+          <TouchableOpacity
+            style={[styles.headerButton, { backgroundColor: colors.card }]}
+            onPress={() => router.back()}
+            activeOpacity={0.8}
+          >
+            <Ionicons name="arrow-back" size={20} color={colors.text} />
+          </TouchableOpacity>
+          <View style={styles.headerCopy}>
+            <Text style={[styles.title, { color: colors.text }]}>Notification Settings</Text>
+            <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+              Toggle the specific alerts you want. Each change is pushed to the backend immediately.
+            </Text>
+          </View>
+        </View>
+
+        <View
+          style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.border }]}
+        >
+          {loading ? (
+            <View style={styles.loadingWrap}>
+              <ActivityIndicator color={colors.accent} />
+            </View>
+          ) : (
+            NOTIFICATION_ROWS.map((row, index) => (
+              <View key={row.key}>
+                {index > 0 && <View style={[styles.divider, { backgroundColor: colors.border }]} />}
+                <View style={styles.preferenceRow}>
+                  <View style={styles.preferenceCopy}>
+                    <View style={[styles.iconShell, { backgroundColor: colors.card }]}>
+                      <Ionicons name={row.icon} size={18} color={colors.accent} />
+                    </View>
+                    <View style={styles.preferenceTextWrap}>
+                      <Text style={[styles.preferenceTitle, { color: colors.text }]}>
+                        {row.title}
+                      </Text>
+                      <Text style={[styles.preferenceDescription, { color: colors.textSecondary }]}>
+                        {row.description}
+                      </Text>
+                    </View>
+                  </View>
+
+                  {savingKey === row.key ? (
+                    <ActivityIndicator color={colors.accent} />
+                  ) : (
+                    <Switch
+                      value={preferences[row.key]}
+                      onValueChange={(value) => void handleToggle(row.key, value)}
+                      trackColor={{
+                        false: colors.cardBorder,
+                        true: colors.accent,
+                      }}
+                      thumbColor="#ffffff"
+                    />
+                  )}
+                </View>
+              </View>
+            ))
+          )}
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 24,
+    paddingBottom: 40,
+    gap: 16,
+  },
+  header: {
+    flexDirection: 'row',
+    gap: 16,
+    alignItems: 'flex-start',
+  },
+  headerButton: {
+    width: 42,
+    height: 42,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerCopy: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '800',
+    letterSpacing: -0.5,
+    marginBottom: 6,
+  },
+  subtitle: {
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  card: {
+    borderRadius: 18,
+    borderWidth: 1,
+    padding: 18,
+  },
+  loadingWrap: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    marginVertical: 16,
+  },
+  preferenceRow: {
+    flexDirection: 'row',
+    gap: 14,
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  preferenceCopy: {
+    flex: 1,
+    flexDirection: 'row',
+    gap: 12,
+    alignItems: 'flex-start',
+  },
+  iconShell: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 2,
+  },
+  preferenceTextWrap: {
+    flex: 1,
+  },
+  preferenceTitle: {
+    fontSize: 15,
+    fontWeight: '700',
+    marginBottom: 4,
+  },
+  preferenceDescription: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
+});

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -55,6 +55,53 @@ export interface SnapshotResponse {
   };
 }
 
+export interface NotificationPreferences {
+  priceAlerts: boolean;
+  newsAlerts: boolean;
+  securityAlerts: boolean;
+}
+
+export interface UserPreferences {
+  notifications: NotificationPreferences;
+}
+
+export interface UserProfileResponse {
+  id: string;
+  email: string;
+  firstName?: string;
+  lastName?: string;
+  displayName?: string;
+  bio?: string;
+  avatarUrl?: string;
+  stellarPublicKey?: string;
+  preferences?: UserPreferences;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LinkedStellarAccount {
+  id: string;
+  publicKey: string;
+  label?: string | null;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LinkStellarAccountPayload {
+  publicKey: string;
+  label?: string;
+}
+
+export interface UpdateProfilePayload {
+  displayName?: string;
+  bio?: string;
+  avatarUrl?: string;
+  preferences?: {
+    notifications?: Partial<NotificationPreferences>;
+  };
+}
+
 /**
  * Auth API Service
  * Uses the shared API client for all requests
@@ -104,6 +151,33 @@ export const portfolioApi = {
    */
   async createSnapshot(): Promise<ApiResponse<SnapshotResponse>> {
     return apiClient.post<SnapshotResponse>('/portfolio/snapshot');
+  },
+};
+
+/**
+ * User/Profile API Service
+ */
+export const usersApi = {
+  async getProfile(): Promise<ApiResponse<UserProfileResponse>> {
+    return apiClient.get<UserProfileResponse>('/users/me');
+  },
+
+  async updateProfile(payload: UpdateProfilePayload): Promise<ApiResponse<UserProfileResponse>> {
+    return apiClient.patch<UserProfileResponse>('/users/me', payload);
+  },
+
+  async getLinkedAccounts(): Promise<ApiResponse<LinkedStellarAccount[]>> {
+    return apiClient.get<LinkedStellarAccount[]>('/users/me/accounts');
+  },
+
+  async linkStellarAccount(
+    payload: LinkStellarAccountPayload,
+  ): Promise<ApiResponse<LinkedStellarAccount>> {
+    return apiClient.post<LinkedStellarAccount>('/users/me/accounts', payload);
+  },
+
+  async removeLinkedAccount(accountId: string): Promise<ApiResponse<void>> {
+    return apiClient.delete<void>(`/users/me/accounts/${accountId}`);
   },
 };
 

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -12,6 +12,7 @@
         "@expo/webpack-config": "^19.0.0",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "expo": "~54.0.31",
+        "expo-barcode-scanner": "^13.0.1",
         "expo-constants": "~18.0.13",
         "expo-dev-client": "^6.0.20",
         "expo-linking": "~8.0.11",
@@ -8467,6 +8468,18 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-barcode-scanner": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/expo-barcode-scanner/-/expo-barcode-scanner-13.0.1.tgz",
+      "integrity": "sha512-xBGLT1An2gpAMIQRTLU3oHydKohX8r8F9/ait1Fk9Vgd0GraFZbP4IiT7nHMlaw4H6E7Muucf7vXpGV6u7d4HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~4.7.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-constants": {
       "version": "18.0.13",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
@@ -8576,6 +8589,15 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.7.0.tgz",
+      "integrity": "sha512-cx+MxxsAMGl9AiWnQUzrkJMJH4eNOGlu7XkLGnAXSJrRoIiciGaKqzeaD326IyCTV+Z1fXvIliSgNW+DscvD8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-json-utils": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -16,6 +16,7 @@
     "@expo/webpack-config": "^19.0.0",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "expo": "~54.0.31",
+    "expo-barcode-scanner": "^13.0.1",
     "expo-constants": "~18.0.13",
     "expo-dev-client": "^6.0.20",
     "expo-linking": "~8.0.11",


### PR DESCRIPTION
Closes Pulsefy/Lumenpulse#421

## Summary
- added Settings entry points for Manage Accounts and Notification Settings
- added a Manage Accounts sub-screen with QR-based Stellar account linking and removal
- added a Notification Settings sub-screen with granular Price, News, and Security alert toggles
- synced linked-account and notification preference changes immediately with backend APIs
- added backend user preference persistence, profile update support, and a migration for notification settings storage

## Validation
- `cd apps/backend && npm test -- users.controller.spec.ts --runInBand`
- `cd apps/backend && npm run build`
- `cd apps/mobile && npm run tsc`
- `cd apps/mobile && npx eslint "app/(tabs)/settings.tsx" "app/settings/manage-accounts.tsx" "app/settings/notification-settings.tsx" "app/auth/login.tsx" "lib/api.ts"`

## Notes
- full `cd apps/mobile && npm run lint` is still blocked by pre-existing repo-wide CRLF/prettier violations in unrelated files
- QR/device runtime testing and the requested Manage Accounts screenshot were not captured in this environment

Screenshot: attached Manage Accounts screen showing QR-based add flow and linked-account list state.
<img width="474" height="844" alt="image" src="https://github.com/user-attachments/assets/9ca85d1d-e2df-4a93-a304-14e67bc9f70c" />

