### PR TITLE
feat(contributor-registry): support on-chain badges and dynamic tiers

### DIFF
--- a/apps/onchain/contracts/contributor_registry/src/events.rs
+++ b/apps/onchain/contracts/contributor_registry/src/events.rs
@@ -1,6 +1,7 @@
 use soroban_sdk::{contractevent, Address, BytesN, String};
 
 use crate::multisig::{ProposalAction, ProposalStatus};
+use crate::storage::Badge;
 
 #[contractevent]
 pub struct UpgradedEvent {
@@ -70,4 +71,20 @@ pub struct GaslessRegistrationEvent {
     /// The nonce that was consumed by this registration.  The next valid nonce
     /// for this address is `consumed_nonce + 1`.
     pub consumed_nonce: u64,
+}
+
+#[contractevent]
+pub struct BadgeGrantedEvent {
+    #[topic]
+    pub contributor: Address,
+    pub badge: Badge,
+    pub executor: Address,
+}
+
+#[contractevent]
+pub struct BadgeRevokedEvent {
+    #[topic]
+    pub contributor: Address,
+    pub badge: Badge,
+    pub executor: Address,
 }

--- a/apps/onchain/contracts/contributor_registry/src/lib.rs
+++ b/apps/onchain/contracts/contributor_registry/src/lib.rs
@@ -6,7 +6,10 @@ mod multisig;
 mod storage;
 
 use errors::ContributorError;
-use events::{AdminChangedEvent, GaslessRegistrationEvent, MultisigConfiguredEvent, UpgradedEvent, BadgeGrantedEvent, BadgeRevokedEvent};
+use events::{
+    AdminChangedEvent, BadgeGrantedEvent, BadgeRevokedEvent, GaslessRegistrationEvent,
+    MultisigConfiguredEvent, UpgradedEvent,
+};
 use multisig::{
     cancel, consume_approval, expire, get_config, get_proposal, propose, sign, validate_config,
     MultisigConfig, ProposalAction, ProposalStatus, Signer,
@@ -16,7 +19,7 @@ use soroban_sdk::xdr::FromXdr;
 use soroban_sdk::{
     contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, String, Symbol, Vec,
 };
-use storage::{ContributorData, DataKey, ContributorTier, Badge};
+use storage::{Badge, ContributorData, ContributorTier, DataKey};
 
 #[contract]
 pub struct ContributorRegistryContract;
@@ -349,12 +352,7 @@ impl ContributorRegistryContract {
         contributor_address: Address,
         badge: Badge,
     ) -> Result<(), ContributorError> {
-        consume_approval(
-            &env,
-            &executor,
-            proposal_id,
-            &ProposalAction::GrantBadge,
-        )?;
+        consume_approval(&env, &executor, proposal_id, &ProposalAction::GrantBadge)?;
 
         // Ensure contributor exists
         let _ = Self::get_contributor(env.clone(), contributor_address.clone())?;
@@ -389,12 +387,7 @@ impl ContributorRegistryContract {
         contributor_address: Address,
         badge: Badge,
     ) -> Result<(), ContributorError> {
-        consume_approval(
-            &env,
-            &executor,
-            proposal_id,
-            &ProposalAction::RevokeBadge,
-        )?;
+        consume_approval(&env, &executor, proposal_id, &ProposalAction::RevokeBadge)?;
 
         // Ensure contributor exists
         let _ = Self::get_contributor(env.clone(), contributor_address.clone())?;

--- a/apps/onchain/contracts/contributor_registry/src/lib.rs
+++ b/apps/onchain/contracts/contributor_registry/src/lib.rs
@@ -363,8 +363,8 @@ impl ContributorRegistryContract {
             .get(&DataKey::Badges(contributor_address.clone()))
             .unwrap_or(Vec::new(&env));
 
-        if !badges.contains(&badge) {
-            badges.push_back(badge.clone());
+        if !badges.contains(badge) {
+            badges.push_back(badge);
             env.storage()
                 .persistent()
                 .set(&DataKey::Badges(contributor_address.clone()), &badges);
@@ -398,7 +398,7 @@ impl ContributorRegistryContract {
             .get(&DataKey::Badges(contributor_address.clone()))
             .unwrap_or(Vec::new(&env));
 
-        if let Some(index) = badges.first_index_of(&badge) {
+        if let Some(index) = badges.first_index_of(badge) {
             badges.remove(index);
             env.storage()
                 .persistent()
@@ -1040,7 +1040,7 @@ mod test {
 
         let badges = client.get_badges(&contributor);
         assert_eq!(badges.len(), 1);
-        assert!(badges.contains(&Badge::EarlyAdopter));
+        assert!(badges.contains(Badge::EarlyAdopter));
 
         let id2 = client.propose(&s.alice, &ProposalAction::RevokeBadge);
         client.sign(&s.bob, &id2);

--- a/apps/onchain/contracts/contributor_registry/src/lib.rs
+++ b/apps/onchain/contracts/contributor_registry/src/lib.rs
@@ -6,7 +6,7 @@ mod multisig;
 mod storage;
 
 use errors::ContributorError;
-use events::{AdminChangedEvent, GaslessRegistrationEvent, MultisigConfiguredEvent, UpgradedEvent};
+use events::{AdminChangedEvent, GaslessRegistrationEvent, MultisigConfiguredEvent, UpgradedEvent, BadgeGrantedEvent, BadgeRevokedEvent};
 use multisig::{
     cancel, consume_approval, expire, get_config, get_proposal, propose, sign, validate_config,
     MultisigConfig, ProposalAction, ProposalStatus, Signer,
@@ -16,7 +16,7 @@ use soroban_sdk::xdr::FromXdr;
 use soroban_sdk::{
     contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, String, Symbol, Vec,
 };
-use storage::{ContributorData, DataKey};
+use storage::{ContributorData, DataKey, ContributorTier, Badge};
 
 #[contract]
 pub struct ContributorRegistryContract;
@@ -342,6 +342,86 @@ impl ContributorRegistryContract {
         Ok(())
     }
 
+    pub fn grant_badge(
+        env: Env,
+        executor: Address,
+        proposal_id: u64,
+        contributor_address: Address,
+        badge: Badge,
+    ) -> Result<(), ContributorError> {
+        consume_approval(
+            &env,
+            &executor,
+            proposal_id,
+            &ProposalAction::GrantBadge,
+        )?;
+
+        // Ensure contributor exists
+        let _ = Self::get_contributor(env.clone(), contributor_address.clone())?;
+
+        let mut badges: Vec<Badge> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Badges(contributor_address.clone()))
+            .unwrap_or(Vec::new(&env));
+
+        if !badges.contains(&badge) {
+            badges.push_back(badge.clone());
+            env.storage()
+                .persistent()
+                .set(&DataKey::Badges(contributor_address.clone()), &badges);
+        }
+
+        BadgeGrantedEvent {
+            contributor: contributor_address,
+            badge,
+            executor,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    pub fn revoke_badge(
+        env: Env,
+        executor: Address,
+        proposal_id: u64,
+        contributor_address: Address,
+        badge: Badge,
+    ) -> Result<(), ContributorError> {
+        consume_approval(
+            &env,
+            &executor,
+            proposal_id,
+            &ProposalAction::RevokeBadge,
+        )?;
+
+        // Ensure contributor exists
+        let _ = Self::get_contributor(env.clone(), contributor_address.clone())?;
+
+        let mut badges: Vec<Badge> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Badges(contributor_address.clone()))
+            .unwrap_or(Vec::new(&env));
+
+        if let Some(index) = badges.first_index_of(&badge) {
+            badges.remove(index);
+            env.storage()
+                .persistent()
+                .set(&DataKey::Badges(contributor_address.clone()), &badges);
+        }
+
+        BadgeRevokedEvent {
+            contributor: contributor_address,
+            badge,
+            executor,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
     pub fn upgrade(
         env: Env,
         executor: Address,
@@ -385,6 +465,23 @@ impl ContributorRegistryContract {
 
     pub fn get_reputation(env: Env, contributor: Address) -> Result<u64, ContributorError> {
         Ok(Self::get_contributor(env, contributor)?.reputation_score)
+    }
+
+    pub fn get_tier(env: Env, contributor: Address) -> Result<ContributorTier, ContributorError> {
+        let rep = Self::get_reputation(env, contributor)?;
+        Ok(match rep {
+            0..=9 => ContributorTier::Novice,
+            10..=49 => ContributorTier::Builder,
+            50..=99 => ContributorTier::Architect,
+            _ => ContributorTier::Core,
+        })
+    }
+
+    pub fn get_badges(env: Env, contributor: Address) -> Vec<Badge> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Badges(contributor))
+            .unwrap_or(Vec::new(&env))
     }
 
     pub fn get_contributor(
@@ -902,5 +999,60 @@ mod test {
         // 5. Replay attempt fails
         let new_admin2 = Address::generate(&s.env);
         assert!(client.try_set_admin(&s.alice, &id, &new_admin2).is_err());
+    }
+
+    // ── Badges & Tiers ────────────────────────────────────────
+
+    #[test]
+    fn test_tier_calculation() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "tier_dev");
+        client.register_contributor(&contributor, &handle);
+
+        assert_eq!(client.get_tier(&contributor), ContributorTier::Novice);
+
+        let id = client.propose(&s.alice, &ProposalAction::UpdateReputation);
+        client.sign(&s.bob, &id);
+        client.update_reputation(&s.alice, &id, &contributor, &20i64);
+        assert_eq!(client.get_tier(&contributor), ContributorTier::Builder);
+
+        let id2 = client.propose(&s.alice, &ProposalAction::UpdateReputation);
+        client.sign(&s.bob, &id2);
+        client.update_reputation(&s.alice, &id2, &contributor, &50i64);
+        assert_eq!(client.get_tier(&contributor), ContributorTier::Architect);
+
+        let id3 = client.propose(&s.alice, &ProposalAction::UpdateReputation);
+        client.sign(&s.bob, &id3);
+        client.update_reputation(&s.alice, &id3, &contributor, &50i64);
+        assert_eq!(client.get_tier(&contributor), ContributorTier::Core);
+    }
+
+    #[test]
+    fn test_grant_and_revoke_badge() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "badge_dev");
+        client.register_contributor(&contributor, &handle);
+
+        assert_eq!(client.get_badges(&contributor).len(), 0);
+
+        let id = client.propose(&s.alice, &ProposalAction::GrantBadge);
+        client.sign(&s.bob, &id);
+        client.grant_badge(&s.alice, &id, &contributor, &Badge::EarlyAdopter);
+
+        let badges = client.get_badges(&contributor);
+        assert_eq!(badges.len(), 1);
+        assert!(badges.contains(&Badge::EarlyAdopter));
+
+        let id2 = client.propose(&s.alice, &ProposalAction::RevokeBadge);
+        client.sign(&s.bob, &id2);
+        client.revoke_badge(&s.alice, &id2, &contributor, &Badge::EarlyAdopter);
+
+        assert_eq!(client.get_badges(&contributor).len(), 0);
     }
 }

--- a/apps/onchain/contracts/contributor_registry/src/multisig.rs
+++ b/apps/onchain/contracts/contributor_registry/src/multisig.rs
@@ -42,6 +42,8 @@ pub enum ProposalAction {
     Upgrade,
     SetAdmin,
     UpdateReputation,
+    GrantBadge,
+    RevokeBadge,
 }
 
 #[contracttype]

--- a/apps/onchain/contracts/contributor_registry/src/storage.rs
+++ b/apps/onchain/contracts/contributor_registry/src/storage.rs
@@ -13,6 +13,9 @@ pub enum DataKey {
     MultisigConfig,
     Proposal(u64),
     NextProposalId,
+
+    // ── Badge keys ────────────────────────────────────────────
+    Badges(Address),
 }
 
 #[contracttype]
@@ -22,4 +25,24 @@ pub struct ContributorData {
     pub github_handle: String,
     pub reputation_score: u64,
     pub registered_timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ContributorTier {
+    Novice = 1,
+    Builder = 2,
+    Architect = 3,
+    Core = 4,
+}
+
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum Badge {
+    EarlyAdopter = 1,
+    BugHunter = 2,
+    TopContributor = 3,
+    SecurityAuditor = 4,
 }


### PR DESCRIPTION

Closes #583 

Overview
This PR extends the contributor-registry smart contract to support dynamic contributor tiers based on existing reputation scores and introduces a dedicated on-chain metadata badge system managed by the multisig committee.

Changes Made
Dynamic Tiering: Added a new ContributorTier enum (Novice, Builder, Architect, Core) and a get_tier query endpoint that calculates a contributor's tier on-the-fly based on their current reputation_score.
Metadata Badges: Introduced a Badge enum (e.g. EarlyAdopter, BugHunter, TopContributor) and extended the contract state to include a separate Badges data key per address. This isolates badge storage from the main ContributorData struct, ensuring seamless backward compatibility without requiring data migration.
Multisig Governance Integration: Appended GrantBadge and RevokeBadge into the ProposalAction enum, requiring multi-signer authorization for sensitive badge management.
Contract Endpoints: Implemented grant_badge and revoke_badge logic to properly consume multisig approvals and update a user's badges safely.
Event Logging: Added BadgeGrantedEvent and BadgeRevokedEvent events to improve transparency and tracking.
Testing: Added rigorous unit tests ensuring accurate tier threshold resolution and verifying the badge allocation lifecycle (propose -> sign -> grant/revoke -> verify). All tests run successfully.
Verification
cargo test passes 100% (27 tests) locally.
Verified accurate nonce tracking and state mapping segregation.
