### PR TITLE
feat(telegram-bot): add interactive commands and subscription system

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -59,3 +59,6 @@ RATE_LIMIT_PORTFOLIO_WRITE_BLOCK_MS=120000
 # Webhook — shared secret for HMAC-SHA256 signature verification
 # Must match WEBHOOK_SECRET set in the data-processing service
 WEBHOOK_SECRET=your_webhook_secret_here
+
+# Telegram Bot Token (get from @BotFather)
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here

--- a/apps/backend/PERFORMANCE.md
+++ b/apps/backend/PERFORMANCE.md
@@ -1,0 +1,247 @@
+# Backend Query Performance & Index Hardening
+
+This document covers the database index strategy, critical read-path performance expectations, and query profiling setup for the LumenPulse backend.
+
+## Index Strategy
+
+Indexes are defined both as TypeORM `@Index()` decorators (for schema documentation) and as idempotent migration steps (for safe deployments).
+
+### Core Entities
+
+#### `users`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | User lookups |
+| UQ | `email` | Login by email |
+| UQ | `stellarPublicKey` | Wallet linking |
+| IDX | `role` | Admin / user filtering |
+| IDX | `createdAt` | User analytics, cohort queries |
+
+**Expected performance:**
+- `findByEmail`: < 5 ms (unique index)
+- `findById`: < 2 ms (primary key)
+- Role-based filters: < 20 ms with LIMIT
+
+#### `stellar_accounts`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Account lookups |
+| UQ | `userId, publicKey` | Prevent duplicate links |
+| IDX | `userId` | List accounts for user |
+| IDX | `isActive` | Filter active accounts |
+| IDX | `isPrimary` | Find primary account |
+
+**Expected performance:**
+- `getStellarAccounts(userId)`: < 10 ms
+- `findByPublicKey`: < 5 ms (unique)
+
+#### `portfolio_assets`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Row lookups |
+| IDX | `userId` | Fallback portfolio query |
+| IDX | `userId, assetCode` | Asset-specific queries |
+
+**Expected performance:**
+- `find({ userId })`: < 15 ms
+- `find({ userId, assetCode })`: < 5 ms
+
+#### `portfolio_snapshots`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Row lookups |
+| IDX | `userId, createdAt` | History pagination + latest snapshot |
+| IDX | `createdAt` | Time-range analytics |
+
+**Expected performance:**
+- `getPortfolioHistory(userId, page, limit)`: < 30 ms (10k snapshots / user)
+- `getPortfolioSummary` (latest): < 15 ms (composite index covers `ORDER BY createdAt DESC`)
+
+#### `articles` (news)
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Row lookups |
+| UQ | `url` | Deduplication |
+| IDX | `publishedAt` | Recent articles feed |
+| IDX | `source` | Source filter |
+| IDX | `sentimentScore` | Sentiment range scans |
+| IDX | `source, publishedAt` | Source + date composite |
+| IDX | `category` | Category filter |
+| GIN | `tags` | Array containment (`ANY`) |
+
+**Expected performance:**
+- `findAll()` ordered: < 50 ms (50k articles)
+- `findAll({ category })`: < 30 ms
+- `findAll({ tag })` with GIN: < 40 ms
+- `getSentimentSummary` (aggregations): < 100 ms (uses `sentimentScore IS NOT NULL` filter)
+
+#### `notifications`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Row lookups |
+| IDX | `userId, createdAt` | User inbox with ordering |
+| IDX | `userId` | Single-column filter |
+| IDX | `read` | Unread count |
+| IDX | `type` | Type filter |
+| IDX | `severity` | Severity filter |
+| IDX | `createdAt` | Time-based cleanup |
+
+**Expected performance:**
+- Inbox query (`userId + ORDER BY createdAt`): < 20 ms
+- Unread count (`userId + read = false`): < 15 ms
+
+#### `notification_delivery_logs`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Row lookups |
+| IDX | `notificationId` | Per-notification delivery status |
+| IDX | `userId` | Per-user logs |
+| IDX | `channel, status` | Channel health metrics |
+| IDX | `createdAt` | Time-based cleanup |
+| IDX | `userId, createdAt` | Daily limit counting |
+| IDX | `status, retryCount` | Retry job polling |
+
+**Expected performance:**
+- `getDeliveryLogsForUser`: < 30 ms (50-row limit)
+- `retryFailedDeliveries`: < 50 ms (scans only failed rows)
+- `deliverToUser` (preference + log writes): < 100 ms end-to-end
+
+#### `push_tokens`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Row lookups |
+| UQ | `token` | Deduplication |
+| IDX | `userId` | List tokens for user |
+| IDX | `isActive` | Active token filter |
+| IDX | `userId, isActive` | Active tokens per user |
+
+**Expected performance:**
+- `find({ userId, isActive })`: < 10 ms
+
+#### `refresh_tokens`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Row lookups |
+| IDX | `tokenHash` | Token validation |
+| IDX | `userId` | Revoke all sessions |
+| IDX | `expiresAt` | Cleanup stale tokens |
+
+**Expected performance:**
+- Token lookup: < 5 ms
+- Cleanup job (`expiresAt < now()`): < 100 ms (batch)
+
+#### `password_reset_tokens`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Row lookups |
+| IDX | `tokenHash` | Token validation |
+| IDX | `expiresAt` | Cleanup stale tokens |
+
+**Expected performance:**
+- Token lookup: < 5 ms
+
+#### `outbox_events`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Row lookups |
+| IDX | `status, createdAt` | Outbox poller (pending events) |
+| IDX | `eventType` | Event-type metrics |
+
+**Expected performance:**
+- Poller query (`status = pending ORDER BY createdAt`): < 30 ms
+
+#### `daily_snapshots`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Row lookups |
+| UQ | `snapshotDate, assetSymbol` | Idempotent daily row |
+| IDX | `assetSymbol` | Per-asset history |
+| IDX | `createdAt` | Recent snapshot queries |
+
+**Expected performance:**
+- `findByDateRange`: < 20 ms
+- Aggregate queries: < 50 ms
+
+#### `stellar_sync_checkpoints`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Row lookups |
+| UQ | `type` | Checkpoint per sync type |
+| IDX | `updatedAt` | Staleness detection |
+
+#### `stellar_processed_events`
+| Index | Columns | Purpose |
+|---|---|---|
+| PK | `id` | Row lookups |
+| UQ | `eventId` | Deduplication |
+| IDX | `processedAt` | Cleanup old events |
+
+## Query Profiling
+
+### How it works
+
+A `QueryProfilerService` wraps critical read paths and logs execution time. If a query exceeds its threshold, a `[SLOW QUERY]` warning is emitted.
+
+### Thresholds
+
+| Service / Method | Threshold | Rationale |
+|---|---|---|
+| `NewsService.findAll` | 150 ms | Filtered list with optional GIN scan |
+| `NewsService.getSentimentSummary` | 200 ms | Two aggregation queries |
+| `PortfolioService.getPortfolioHistory` | 150 ms | Paginated snapshot scan |
+| `PortfolioService.getPortfolioSummary` | 200 ms | User + snapshot lookup |
+| `NotificationDeliveryService.deliverToUser` | 300 ms | Preference + multi-channel delivery |
+| `NotificationDeliveryService.getDeliveryLogsForUser` | 150 ms | Log pagination |
+| `ReconciliationService.runReconciliation` | 5000 ms | Full pass across all users |
+| `WatchlistService.getWatchlist` | 100 ms | Small per-user dataset |
+
+### Enabling debug logs
+
+Set `LOG_LEVEL=debug` (or use NestJS `--debug`) to see all `[QUERY]` timings. Only queries exceeding thresholds emit `[SLOW QUERY]` warnings at the default `warn` level.
+
+### Decorator for controllers
+
+You can also use the `@ProfileQuery()` decorator on controller methods:
+
+```ts
+import { ProfileQuery } from './common/profiling/profile-query.decorator';
+
+@Controller('portfolio')
+export class PortfolioController {
+  @Get('history')
+  @ProfileQuery('PortfolioController.getHistory', 150)
+  async getHistory(@Query() query: PortfolioHistoryQueryDto) {
+    // ...
+  }
+}
+```
+
+## Maintenance
+
+1. **Run migrations** after each deploy:
+   ```bash
+   npm run migration:run
+   ```
+
+2. **Review slow query logs** periodically:
+   ```bash
+   grep "SLOW QUERY" logs/app.log | tail -n 50
+   ```
+
+3. **Analyze index usage** in PostgreSQL:
+   ```sql
+   SELECT schemaname, tablename, indexname, idx_scan, idx_tup_read
+   FROM pg_stat_user_indexes
+   WHERE schemaname = 'public'
+   ORDER BY idx_scan ASC;
+   ```
+
+4. **Vacuum & analyze** after large data loads:
+   ```sql
+   ANALYZE articles;
+   ANALYZE portfolio_snapshots;
+   ```
+
+## Known Issues
+
+- There are two `User` entity files (`users/entities/user.entity.ts` and `users/user.entity.ts`) both mapping to the `users` table. The active one is `users/entities/user.entity.ts`. Index changes are applied to the canonical entity.

--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -41,6 +41,7 @@
         "ioredis": "^5.6.1",
         "keyv": "^5.6.0",
         "multer": "^2.1.1",
+        "node-telegram-bot-api": "^0.66.0",
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.17.2",
@@ -63,6 +64,7 @@
         "@types/jest": "^29.5.14",
         "@types/multer": "^2.1.0",
         "@types/node": "^22.19.7",
+        "@types/node-telegram-bot-api": "^0.64.7",
         "@types/passport-jwt": "^4.0.1",
         "@types/sharp": "^0.31.1",
         "@types/supertest": "^6.0.3",
@@ -1737,6 +1739,122 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@cypress/request": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.10.tgz",
+      "integrity": "sha512-hauBrOdvu08vOsagkZ/Aju5XuiZx6ldsLfByg1htFeldhex+PeMrYauANzFsMJeAA0+dyPLbDoX2OYuvVoLDkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~4.0.4",
+        "http-signature": "~1.4.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "performance-now": "^2.1.0",
+        "qs": "~6.14.1",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "^5.0.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@cypress/request-promise": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@cypress/request-promise/-/request-promise-5.0.0.tgz",
+      "integrity": "sha512-eKdYVpa9cBEw2kTBlHeu1PP16Blwtum6QHg/u9s/MoHkZfuo1pRGka1VlUHXF5kdew82BvOJVVGk0x8X0nbp+w==",
+      "license": "ISC",
+      "dependencies": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.3",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "@cypress/request": "^3.0.0"
+      }
+    },
+    "node_modules/@cypress/request-promise/node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@cypress/request-promise/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -4840,6 +4958,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -5030,6 +5155,17 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/node-telegram-bot-api": {
+      "version": "0.64.14",
+      "resolved": "https://registry.npmjs.org/@types/node-telegram-bot-api/-/node-telegram-bot-api-0.64.14.tgz",
+      "integrity": "sha512-Nq1LAAw4PGpR8Vii5F7uGlAaAFmaT3cPIt7mUZv6VrftPsrt9xjmnhXD9hoKFstAzn/a5ZCr+ksbkmK+QBhZiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/request": "*"
+      }
+    },
     "node_modules/@types/passport": {
       "version": "1.0.17",
       "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
@@ -5075,6 +5211,60 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.13",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
+      "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.5"
+      }
+    },
+    "node_modules/@types/request/node_modules/form-data": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
+      "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/@types/request/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@types/request/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
@@ -5137,6 +5327,13 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/validator": {
       "version": "13.15.10",
@@ -5693,7 +5890,6 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -5898,6 +6094,22 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array-timsort": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
@@ -5905,12 +6117,77 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/array.prototype.findindex": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.findindex/-/array.prototype.findindex-2.2.4.tgz",
+      "integrity": "sha512-LLm4mhxa9v8j0A/RPnpQAP4svXToJFh+Hp1pNYl5ZD5qpB4zdx/D4YjpVcETkhFbUKWO3iGMVLvrOnnmkAJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -5932,6 +6209,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT"
     },
     "node_modules/axios": {
       "version": "1.14.0",
@@ -6185,6 +6477,21 @@
         "node": ">= 18"
       }
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -6249,6 +6556,12 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -6571,14 +6884,14 @@
       "license": "ISC"
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -6659,6 +6972,12 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -7048,7 +7367,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -7187,6 +7505,69 @@
         "node": ">= 8"
       }
     },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
@@ -7263,6 +7644,23 @@
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
         "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7408,6 +7806,16 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "license": "MIT"
     },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -7456,6 +7864,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/engine.io": {
@@ -7568,6 +7985,74 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -7619,6 +8104,35 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/escalade": {
@@ -8116,6 +8630,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -8144,11 +8664,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -8162,7 +8690,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -8457,6 +8984,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-9.0.2.tgz",
@@ -8612,6 +9148,44 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/generic-pool": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
@@ -8700,6 +9274,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -8781,6 +9381,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -8832,6 +9448,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -8858,6 +9511,21 @@
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8954,6 +9622,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.4.0.tgz",
+      "integrity": "sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==",
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^2.0.2",
+        "sshpk": "^1.18.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/human-signals": {
@@ -9119,6 +9801,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ioredis": {
       "version": "5.10.1",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
@@ -9152,12 +9848,63 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -9170,6 +9917,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-callable": {
@@ -9200,6 +9963,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -9208,6 +10004,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -9227,6 +10038,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -9252,6 +10082,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -9262,11 +10116,45 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-retry-allowed": {
       "version": "3.0.0",
@@ -9280,6 +10168,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -9291,6 +10206,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-typed-array": {
@@ -9308,6 +10256,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -9321,6 +10275,49 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -9332,6 +10329,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -10107,6 +11110,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "license": "MIT"
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -10134,11 +11143,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -10147,6 +11161,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -10201,6 +11221,21 @@
       "engines": {
         "node": ">=12",
         "npm": ">=6"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
+      "integrity": "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
       }
     },
     "node_modules/jwa": {
@@ -10852,6 +11887,108 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-telegram-bot-api": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/node-telegram-bot-api/-/node-telegram-bot-api-0.66.0.tgz",
+      "integrity": "sha512-s4Hrg5q+VPl4/tJVG++pImxF6eb8tNJNj4KnDqAOKL6zGU34lo9RXmyAN158njwGN+v8hdNf8s9fWIYW9hPb5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@cypress/request": "^3.0.1",
+        "@cypress/request-promise": "^5.0.0",
+        "array.prototype.findindex": "^2.0.2",
+        "bl": "^1.2.3",
+        "debug": "^3.2.7",
+        "eventemitter3": "^3.0.0",
+        "file-type": "^3.9.0",
+        "mime": "^1.6.0",
+        "pump": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/node-telegram-bot-api/node_modules/bl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/node-telegram-bot-api/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/node-telegram-bot-api/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-telegram-bot-api/node_modules/file-type": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-telegram-bot-api/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-telegram-bot-api/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/node-telegram-bot-api/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/node-telegram-bot-api/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/node-telegram-bot-api/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -10873,6 +12010,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/object-assign": {
@@ -10898,6 +12045,35 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -10992,6 +12168,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/p-limit": {
@@ -11216,6 +12409,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
       "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT"
     },
     "node_modules/pg": {
       "version": "8.20.0",
@@ -11530,6 +12729,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prom-client": {
       "version": "15.1.3",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
@@ -11588,11 +12793,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11629,6 +12855,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -11819,6 +13051,48 @@
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
@@ -11827,6 +13101,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request-promise-core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "license": "ISC",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "request": "^2.34"
+      }
+    },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/request/node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/request/node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/request/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/request/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/request/node_modules/qs": {
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
+      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/request/node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/request/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/require-addon": {
@@ -11860,6 +13287,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -11981,6 +13414,25 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -12000,6 +13452,39 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -12095,6 +13580,35 @@
         "get-intrinsic": "^1.2.4",
         "gopd": "^1.0.1",
         "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -12464,6 +13978,37 @@
         "node": ">=14"
       }
     },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sshpk/node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense"
+    },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
@@ -12500,6 +14045,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/stellar-sdk": {
@@ -12540,6 +14094,19 @@
       },
       "optionalDependencies": {
         "sodium-native": "^4.3.3"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/streamsearch": {
@@ -12600,6 +14167,62 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -13042,6 +14665,24 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -13121,6 +14762,18 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/tree-kill": {
       "version": "1.2.2",
@@ -13336,6 +14989,18 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -13403,6 +15068,66 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typedarray": {
@@ -13646,6 +15371,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -13706,7 +15449,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -13717,6 +15459,16 @@
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
       "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
       "license": "MIT"
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -13785,6 +15537,26 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT"
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -14043,6 +15815,70 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/which-typed-array": {

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -65,7 +65,8 @@
     "sharp": "^0.34.5",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
-    "stellar-sdk": "^13.3.0"
+    "stellar-sdk": "^13.3.0",
+    "node-telegram-bot-api": "^0.66.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^0.1.0",
@@ -96,7 +97,8 @@
     "tsconfig-paths": "^4.2.0",
     "typeorm": "^0.3.28",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.20.0"
+    "typescript-eslint": "^8.20.0",
+    "@types/node-telegram-bot-api": "^0.64.7"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -42,6 +42,7 @@ import { UsersModule } from './users/users.module';
 import { GrantsModule } from './grants/grants.module';
 import { HealthModule } from './health/health.module';
 import { OutboxModule } from './outbox/outbox.module';
+import { TelegramBotModule } from './telegram-bot/telegram-bot.module';
 import { IdempotencyInterceptor } from './common/interceptors/idempotency.interceptor';
 
 @Module({
@@ -104,6 +105,7 @@ import { IdempotencyInterceptor } from './common/interceptors/idempotency.interc
     GrantsModule,
     WatchlistModule,
     OutboxModule,
+    TelegramBotModule,
   ],
   controllers: [AppController, TestController, TestExceptionController],
   providers: [

--- a/apps/backend/src/auth/entities/password-reset-token.entity.ts
+++ b/apps/backend/src/auth/entities/password-reset-token.entity.ts
@@ -10,6 +10,7 @@ import {
 import { User } from '../../users/entities/user.entity';
 
 @Entity('password_reset_tokens')
+@Index(['expiresAt'])
 export class PasswordResetToken {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/backend/src/auth/entities/refresh-token.entity.ts
+++ b/apps/backend/src/auth/entities/refresh-token.entity.ts
@@ -10,6 +10,8 @@ import {
 import { User } from '../../users/entities/user.entity';
 
 @Entity('refresh_tokens')
+@Index(['userId'])
+@Index(['expiresAt'])
 export class RefreshToken {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/backend/src/common/profiling/profile-query.decorator.ts
+++ b/apps/backend/src/common/profiling/profile-query.decorator.ts
@@ -1,0 +1,15 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const PROFILE_QUERY_KEY = 'profile_query';
+
+export interface ProfileQueryMetadata {
+  thresholdMs: number;
+  label: string;
+}
+
+export const ProfileQuery = (
+  label: string,
+  thresholdMs = 100,
+) => {
+  return SetMetadata(PROFILE_QUERY_KEY, { label, thresholdMs });
+};

--- a/apps/backend/src/common/profiling/profiling.module.ts
+++ b/apps/backend/src/common/profiling/profiling.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { QueryProfilerService } from './query-profiler.service';
+import { QueryProfilerInterceptor } from './query-profiler.interceptor';
+
+@Module({
+  providers: [QueryProfilerService, QueryProfilerInterceptor],
+  exports: [QueryProfilerService, QueryProfilerInterceptor],
+})
+export class ProfilingModule {}

--- a/apps/backend/src/common/profiling/query-profiler.interceptor.ts
+++ b/apps/backend/src/common/profiling/query-profiler.interceptor.ts
@@ -1,0 +1,45 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Logger,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { Reflector } from '@nestjs/core';
+import { PROFILE_QUERY_KEY, ProfileQueryMetadata } from './profile-query.decorator';
+
+@Injectable()
+export class QueryProfilerInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(QueryProfilerInterceptor.name);
+
+  constructor(private readonly reflector: Reflector) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const metadata = this.reflector.getAllAndOverride<ProfileQueryMetadata>(
+      PROFILE_QUERY_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    if (!metadata) {
+      return next.handle();
+    }
+
+    const start = performance.now();
+    return next.handle().pipe(
+      tap(() => {
+        const duration = performance.now() - start;
+        if (duration > metadata.thresholdMs) {
+          this.logger.warn(
+            `[SLOW QUERY] ${metadata.label} took ${duration.toFixed(2)}ms (threshold: ${metadata.thresholdMs}ms)`,
+          );
+        } else {
+          this.logger.debug(
+            `[QUERY] ${metadata.label} took ${duration.toFixed(2)}ms`,
+          );
+        }
+      }),
+    );
+  }
+}

--- a/apps/backend/src/common/profiling/query-profiler.service.ts
+++ b/apps/backend/src/common/profiling/query-profiler.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+export interface ProfileOptions {
+  thresholdMs?: number;
+  label?: string;
+}
+
+@Injectable()
+export class QueryProfilerService {
+  private readonly logger = new Logger(QueryProfilerService.name);
+
+  async profile<T>(
+    fn: () => Promise<T>,
+    options: ProfileOptions = {},
+  ): Promise<T> {
+    const { thresholdMs = 100, label = 'Query' } = options;
+    const start = performance.now();
+
+    try {
+      const result = await fn();
+      const duration = performance.now() - start;
+
+      if (duration > thresholdMs) {
+        this.logger.warn(
+          `[SLOW QUERY] ${label} took ${duration.toFixed(2)}ms (threshold: ${thresholdMs}ms)`,
+        );
+      } else {
+        this.logger.debug(
+          `[QUERY] ${label} took ${duration.toFixed(2)}ms`,
+        );
+      }
+
+      return result;
+    } catch (error) {
+      const duration = performance.now() - start;
+      this.logger.error(
+        `[QUERY FAILED] ${label} failed after ${duration.toFixed(2)}ms`,
+        error,
+      );
+      throw error;
+    }
+  }
+}

--- a/apps/backend/src/database/migrations/1770000000000-CreateTelegramBotTables.ts
+++ b/apps/backend/src/database/migrations/1770000000000-CreateTelegramBotTables.ts
@@ -1,0 +1,66 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateTelegramBotTables1770000000000 implements MigrationInterface {
+  name = 'CreateTelegramBotTables1770000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const subscriptionsTableExists = await queryRunner.hasTable('telegram_subscriptions');
+    if (!subscriptionsTableExists) {
+      await queryRunner.query(`
+        CREATE TABLE "telegram_subscriptions" (
+          "id"         uuid NOT NULL DEFAULT uuid_generate_v4(),
+          "chatId"     character varying(50) NOT NULL,
+          "username"   character varying(100) DEFAULT NULL,
+          "alertTypes" jsonb NOT NULL DEFAULT '["price", "sentiment", "news"]',
+          "isActive"   boolean NOT NULL DEFAULT true,
+          "createdAt"  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+          "updatedAt"  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+          CONSTRAINT "PK_telegram_subscriptions" PRIMARY KEY ("id"),
+          CONSTRAINT "UQ_telegram_subscriptions_chatId" UNIQUE ("chatId")
+        )
+      `);
+      await queryRunner.query(
+        `CREATE INDEX "IDX_telegram_subscriptions_chatId" ON "telegram_subscriptions" ("chatId")`,
+      );
+      await queryRunner.query(
+        `CREATE INDEX "IDX_telegram_subscriptions_isActive" ON "telegram_subscriptions" ("isActive")`,
+      );
+    }
+
+    const silenceTableExists = await queryRunner.hasTable('telegram_silence');
+    if (!silenceTableExists) {
+      await queryRunner.query(`
+        CREATE TABLE "telegram_silence" (
+          "id"            uuid NOT NULL DEFAULT uuid_generate_v4(),
+          "chatId"        character varying(50) NOT NULL,
+          "silencedUntil" TIMESTAMP WITH TIME ZONE NOT NULL,
+          "createdAt"     TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+          CONSTRAINT "PK_telegram_silence" PRIMARY KEY ("id"),
+          CONSTRAINT "UQ_telegram_silence_chatId" UNIQUE ("chatId")
+        )
+      `);
+      await queryRunner.query(
+        `CREATE INDEX "IDX_telegram_silence_chatId" ON "telegram_silence" ("chatId")`,
+      );
+      await queryRunner.query(
+        `CREATE INDEX "IDX_telegram_silence_silencedUntil" ON "telegram_silence" ("silencedUntil")`,
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const silenceTableExists = await queryRunner.hasTable('telegram_silence');
+    if (silenceTableExists) {
+      await queryRunner.query(`DROP INDEX "public"."IDX_telegram_silence_silencedUntil"`);
+      await queryRunner.query(`DROP INDEX "public"."IDX_telegram_silence_chatId"`);
+      await queryRunner.query(`DROP TABLE "telegram_silence"`);
+    }
+
+    const subscriptionsTableExists = await queryRunner.hasTable('telegram_subscriptions');
+    if (subscriptionsTableExists) {
+      await queryRunner.query(`DROP INDEX "public"."IDX_telegram_subscriptions_isActive"`);
+      await queryRunner.query(`DROP INDEX "public"."IDX_telegram_subscriptions_chatId"`);
+      await queryRunner.query(`DROP TABLE "telegram_subscriptions"`);
+    }
+  }
+}

--- a/apps/backend/src/database/migrations/1770000000001-AddMissingIndexes.ts
+++ b/apps/backend/src/database/migrations/1770000000001-AddMissingIndexes.ts
@@ -1,0 +1,112 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddMissingIndexes1770000000001 implements MigrationInterface {
+  name = 'AddMissingIndexes1770000000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // stellar_accounts
+    await this.createIndex(queryRunner, 'stellar_accounts', 'IDX_stellar_accounts_userId', ['userId']);
+    await this.createIndex(queryRunner, 'stellar_accounts', 'IDX_stellar_accounts_isActive', ['isActive']);
+    await this.createIndex(queryRunner, 'stellar_accounts', 'IDX_stellar_accounts_isPrimary', ['isPrimary']);
+
+    // articles
+    await this.createIndex(queryRunner, 'articles', 'IDX_articles_category', ['category']);
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_articles_tags_gin" ON "articles" USING GIN (tags)`,
+    );
+
+    // notifications
+    await this.createIndex(queryRunner, 'notifications', 'IDX_notifications_read', ['read']);
+    await this.createIndex(queryRunner, 'notifications', 'IDX_notifications_type', ['type']);
+    await this.createIndex(queryRunner, 'notifications', 'IDX_notifications_severity', ['severity']);
+    await this.createIndex(queryRunner, 'notifications', 'IDX_notifications_createdAt', ['createdAt']);
+
+    // notification_delivery_logs
+    await this.createIndex(queryRunner, 'notification_delivery_logs', 'IDX_notification_delivery_logs_userId_createdAt', ['userId', 'createdAt']);
+    await this.createIndex(queryRunner, 'notification_delivery_logs', 'IDX_notification_delivery_logs_status_retryCount', ['status', 'retryCount']);
+
+    // refresh_tokens
+    await this.createIndex(queryRunner, 'refresh_tokens', 'IDX_refresh_tokens_userId', ['userId']);
+    await this.createIndex(queryRunner, 'refresh_tokens', 'IDX_refresh_tokens_expiresAt', ['expiresAt']);
+
+    // password_reset_tokens
+    await this.createIndex(queryRunner, 'password_reset_tokens', 'IDX_password_reset_tokens_expiresAt', ['expiresAt']);
+
+    // push_tokens
+    await this.createIndex(queryRunner, 'push_tokens', 'IDX_push_tokens_isActive', ['isActive']);
+    await this.createIndex(queryRunner, 'push_tokens', 'IDX_push_tokens_userId_isActive', ['userId', 'isActive']);
+
+    // outbox_events
+    await this.createIndex(queryRunner, 'outbox_events', 'IDX_outbox_events_eventType', ['eventType']);
+
+    // daily_snapshots
+    await this.createIndex(queryRunner, 'daily_snapshots', 'IDX_daily_snapshots_assetSymbol', ['assetSymbol']);
+    await this.createIndex(queryRunner, 'daily_snapshots', 'IDX_daily_snapshots_createdAt', ['createdAt']);
+
+    // portfolio_snapshots
+    await this.createIndex(queryRunner, 'portfolio_snapshots', 'IDX_portfolio_snapshots_createdAt', ['createdAt']);
+
+    // stellar_sync_checkpoints
+    await this.createIndex(queryRunner, 'stellar_sync_checkpoints', 'IDX_stellar_sync_checkpoints_updatedAt', ['updatedAt']);
+
+    // stellar_processed_events
+    await this.createIndex(queryRunner, 'stellar_processed_events', 'IDX_stellar_processed_events_processedAt', ['processedAt']);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await this.dropIndex(queryRunner, 'stellar_processed_events', 'IDX_stellar_processed_events_processedAt');
+    await this.dropIndex(queryRunner, 'stellar_sync_checkpoints', 'IDX_stellar_sync_checkpoints_updatedAt');
+    await this.dropIndex(queryRunner, 'portfolio_snapshots', 'IDX_portfolio_snapshots_createdAt');
+    await this.dropIndex(queryRunner, 'daily_snapshots', 'IDX_daily_snapshots_createdAt');
+    await this.dropIndex(queryRunner, 'daily_snapshots', 'IDX_daily_snapshots_assetSymbol');
+    await this.dropIndex(queryRunner, 'outbox_events', 'IDX_outbox_events_eventType');
+    await this.dropIndex(queryRunner, 'push_tokens', 'IDX_push_tokens_userId_isActive');
+    await this.dropIndex(queryRunner, 'push_tokens', 'IDX_push_tokens_isActive');
+    await this.dropIndex(queryRunner, 'password_reset_tokens', 'IDX_password_reset_tokens_expiresAt');
+    await this.dropIndex(queryRunner, 'refresh_tokens', 'IDX_refresh_tokens_expiresAt');
+    await this.dropIndex(queryRunner, 'refresh_tokens', 'IDX_refresh_tokens_userId');
+    await this.dropIndex(queryRunner, 'notification_delivery_logs', 'IDX_notification_delivery_logs_status_retryCount');
+    await this.dropIndex(queryRunner, 'notification_delivery_logs', 'IDX_notification_delivery_logs_userId_createdAt');
+    await this.dropIndex(queryRunner, 'notifications', 'IDX_notifications_createdAt');
+    await this.dropIndex(queryRunner, 'notifications', 'IDX_notifications_severity');
+    await this.dropIndex(queryRunner, 'notifications', 'IDX_notifications_type');
+    await this.dropIndex(queryRunner, 'notifications', 'IDX_notifications_read');
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_articles_tags_gin"`);
+    await this.dropIndex(queryRunner, 'articles', 'IDX_articles_category');
+    await this.dropIndex(queryRunner, 'stellar_accounts', 'IDX_stellar_accounts_isPrimary');
+    await this.dropIndex(queryRunner, 'stellar_accounts', 'IDX_stellar_accounts_isActive');
+    await this.dropIndex(queryRunner, 'stellar_accounts', 'IDX_stellar_accounts_userId');
+  }
+
+  private async createIndex(
+    queryRunner: QueryRunner,
+    table: string,
+    indexName: string,
+    columns: string[],
+  ): Promise<void> {
+    const exists = await queryRunner.query(
+      `SELECT 1 FROM pg_indexes WHERE indexname = '${indexName}'`,
+    );
+    if (exists && exists.length > 0) return;
+
+    const cols = columns.map((c) => `"${c}"`).join(', ');
+    await queryRunner.query(
+      `CREATE INDEX "${indexName}" ON "${table}" (${cols})`,
+    );
+  }
+
+  private async dropIndex(
+    queryRunner: QueryRunner,
+    table: string,
+    indexName: string,
+  ): Promise<void> {
+    const exists = await queryRunner.query(
+      `SELECT 1 FROM pg_indexes WHERE indexname = '${indexName}'`,
+    );
+    if (!exists || exists.length === 0) return;
+
+    await queryRunner.query(
+      `DROP INDEX "public"."${indexName}"`,
+    );
+  }
+}

--- a/apps/backend/src/database/migrations/1770000000001-AddMissingIndexes.ts
+++ b/apps/backend/src/database/migrations/1770000000001-AddMissingIndexes.ts
@@ -84,10 +84,10 @@ export class AddMissingIndexes1770000000001 implements MigrationInterface {
     indexName: string,
     columns: string[],
   ): Promise<void> {
-    const exists = await queryRunner.query(
+    const exists: Array<Record<string, unknown>> = await queryRunner.query(
       `SELECT 1 FROM pg_indexes WHERE indexname = '${indexName}'`,
     );
-    if (exists && exists.length > 0) return;
+    if (exists.length > 0) return;
 
     const cols = columns.map((c) => `"${c}"`).join(', ');
     await queryRunner.query(
@@ -97,13 +97,13 @@ export class AddMissingIndexes1770000000001 implements MigrationInterface {
 
   private async dropIndex(
     queryRunner: QueryRunner,
-    table: string,
+    _table: string,
     indexName: string,
   ): Promise<void> {
-    const exists = await queryRunner.query(
+    const exists: Array<Record<string, unknown>> = await queryRunner.query(
       `SELECT 1 FROM pg_indexes WHERE indexname = '${indexName}'`,
     );
-    if (!exists || exists.length === 0) return;
+    if (exists.length === 0) return;
 
     await queryRunner.query(
       `DROP INDEX "public"."${indexName}"`,

--- a/apps/backend/src/news/news.entity.ts
+++ b/apps/backend/src/news/news.entity.ts
@@ -13,6 +13,7 @@ import {
 @Index(['source'])
 @Index(['sentimentScore'])
 @Index(['source', 'publishedAt'])
+@Index(['category'])
 export class News {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/backend/src/news/news.module.ts
+++ b/apps/backend/src/news/news.module.ts
@@ -8,6 +8,7 @@ import { NewsService } from './news.service';
 import { News } from './news.entity';
 import { NewsSentimentService } from './news-sentiment.services';
 import { AppCacheModule } from '../cache/cache.module';
+import { ProfilingModule } from '../common/profiling/profiling.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { AppCacheModule } from '../cache/cache.module';
     }),
     TypeOrmModule.forFeature([News]),
     AppCacheModule,
+    ProfilingModule,
   ],
   controllers: [NewsController],
   providers: [NewsProviderService, NewsService, NewsSentimentService],

--- a/apps/backend/src/news/news.service.ts
+++ b/apps/backend/src/news/news.service.ts
@@ -8,6 +8,7 @@ import { UpdateArticleDto } from './dto/update-article.dto';
 import { NewsProviderService } from './news-provider.service';
 import { NewsArticleDto } from './dto/news-article.dto';
 import { CacheService } from '../cache/cache.service';
+import { QueryProfilerService } from '../common/profiling/query-profiler.service';
 
 interface RawOverallResult {
   average: string | null;
@@ -29,6 +30,7 @@ export class NewsService {
     private newsRepository: Repository<News>,
     private readonly newsProviderService: NewsProviderService,
     private readonly cacheService: CacheService,
+    private readonly profiler: QueryProfilerService,
   ) {}
 
   async create(createArticleDto: CreateArticleDto): Promise<News> {
@@ -42,23 +44,28 @@ export class NewsService {
     tag?: string;
     category?: string;
   }): Promise<News[]> {
-    const qb = this.newsRepository
-      .createQueryBuilder('news')
-      .orderBy('news.publishedAt', 'DESC');
+    return this.profiler.profile(
+      async () => {
+        const qb = this.newsRepository
+          .createQueryBuilder('news')
+          .orderBy('news.publishedAt', 'DESC');
 
-    if (filters?.tag) {
-      qb.andWhere(':tag = ANY(news.tags)', {
-        tag: filters.tag.toLowerCase(),
-      });
-    }
+        if (filters?.tag) {
+          qb.andWhere(':tag = ANY(news.tags)', {
+            tag: filters.tag.toLowerCase(),
+          });
+        }
 
-    if (filters?.category) {
-      qb.andWhere('LOWER(news.category) = :category', {
-        category: filters.category.toLowerCase(),
-      });
-    }
+        if (filters?.category) {
+          qb.andWhere('LOWER(news.category) = :category', {
+            category: filters.category.toLowerCase(),
+          });
+        }
 
-    return qb.getMany();
+        return qb.getMany();
+      },
+      { label: 'NewsService.findAll', thresholdMs: 150 },
+    );
   }
 
   async findOne(id: string): Promise<News | null> {
@@ -114,34 +121,39 @@ export class NewsService {
     overall: { averageSentiment: number; totalArticles: number };
     bySource: { source: string; averageScore: number; articleCount: number }[];
   }> {
-    const overall = await this.newsRepository
-      .createQueryBuilder('news')
-      .select('AVG(news.sentimentScore)', 'average')
-      .addSelect('COUNT(news.id)', 'totalArticles')
-      .where('news.sentimentScore IS NOT NULL')
-      .getRawOne<RawOverallResult>();
+    return this.profiler.profile(
+      async () => {
+        const overall = await this.newsRepository
+          .createQueryBuilder('news')
+          .select('AVG(news.sentimentScore)', 'average')
+          .addSelect('COUNT(news.id)', 'totalArticles')
+          .where('news.sentimentScore IS NOT NULL')
+          .getRawOne<RawOverallResult>();
 
-    const bySource = await this.newsRepository
-      .createQueryBuilder('news')
-      .select('news.source', 'source')
-      .addSelect('AVG(news.sentimentScore)', 'averageScore')
-      .addSelect('COUNT(news.id)', 'articleCount')
-      .where('news.sentimentScore IS NOT NULL')
-      .groupBy('news.source')
-      .orderBy('averageScore', 'DESC')
-      .getRawMany<RawSourceResult>();
+        const bySource = await this.newsRepository
+          .createQueryBuilder('news')
+          .select('news.source', 'source')
+          .addSelect('AVG(news.sentimentScore)', 'averageScore')
+          .addSelect('COUNT(news.id)', 'articleCount')
+          .where('news.sentimentScore IS NOT NULL')
+          .groupBy('news.source')
+          .orderBy('averageScore', 'DESC')
+          .getRawMany<RawSourceResult>();
 
-    return {
-      overall: {
-        averageSentiment: parseFloat(overall?.average ?? '0') || 0,
-        totalArticles: parseInt(overall?.totalArticles ?? '0', 10),
+        return {
+          overall: {
+            averageSentiment: parseFloat(overall?.average ?? '0') || 0,
+            totalArticles: parseInt(overall?.totalArticles ?? '0', 10),
+          },
+          bySource: bySource.map((r) => ({
+            source: r.source,
+            averageScore: parseFloat(r.averageScore),
+            articleCount: parseInt(r.articleCount, 10),
+          })),
+        };
       },
-      bySource: bySource.map((r) => ({
-        source: r.source,
-        averageScore: parseFloat(r.averageScore),
-        articleCount: parseInt(r.articleCount, 10),
-      })),
-    };
+      { label: 'NewsService.getSentimentSummary', thresholdMs: 200 },
+    );
   }
 
   /**

--- a/apps/backend/src/notification/notification-delivery-log.entity.ts
+++ b/apps/backend/src/notification/notification-delivery-log.entity.ts
@@ -28,6 +28,8 @@ export enum DeliveryStatus {
 @Index(['userId'])
 @Index(['channel', 'status'])
 @Index(['createdAt'])
+@Index(['userId', 'createdAt'])
+@Index(['status', 'retryCount'])
 export class NotificationDeliveryLog {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/backend/src/notification/notification-delivery.service.ts
+++ b/apps/backend/src/notification/notification-delivery.service.ts
@@ -10,6 +10,7 @@ import {
   DeliveryStatus,
 } from './notification-delivery-log.entity';
 import { PushToken } from './push-token.entity';
+import { QueryProfilerService } from '../common/profiling/query-profiler.service';
 
 /**
  * Notification Delivery Orchestration Service
@@ -26,6 +27,7 @@ export class NotificationDeliveryService implements OnModuleInit {
     private readonly deliveryLogRepository: Repository<NotificationDeliveryLog>,
     @InjectRepository(PushToken)
     private readonly pushTokenRepository: Repository<PushToken>,
+    private readonly profiler: QueryProfilerService,
   ) {}
 
   onModuleInit() {
@@ -36,6 +38,17 @@ export class NotificationDeliveryService implements OnModuleInit {
    * Deliver a notification to all enabled channels for a user
    */
   async deliverToUser(
+    notification: Notification,
+    userId: string,
+    eventCategory?: string,
+  ): Promise<NotificationDeliveryLog[]> {
+    return this.profiler.profile(
+      async () => this.doDeliverToUser(notification, userId, eventCategory),
+      { label: 'NotificationDeliveryService.deliverToUser', thresholdMs: 300 },
+    );
+  }
+
+  private async doDeliverToUser(
     notification: Notification,
     userId: string,
     eventCategory?: string,
@@ -285,11 +298,15 @@ export class NotificationDeliveryService implements OnModuleInit {
     userId: string,
     limit: number = 50,
   ): Promise<NotificationDeliveryLog[]> {
-    return this.deliveryLogRepository.find({
-      where: { userId },
-      order: { createdAt: 'DESC' },
-      take: limit,
-    });
+    return this.profiler.profile(
+      () =>
+        this.deliveryLogRepository.find({
+          where: { userId },
+          order: { createdAt: 'DESC' },
+          take: limit,
+        }),
+      { label: 'NotificationDeliveryService.getDeliveryLogsForUser', thresholdMs: 150 },
+    );
   }
 
   /**

--- a/apps/backend/src/notification/notification.entity.ts
+++ b/apps/backend/src/notification/notification.entity.ts
@@ -21,6 +21,10 @@ export enum NotificationSeverity {
 
 @Entity('notifications')
 @Index(['userId', 'createdAt'])
+@Index(['read'])
+@Index(['type'])
+@Index(['severity'])
+@Index(['createdAt'])
 export class Notification {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/backend/src/notification/notification.module.ts
+++ b/apps/backend/src/notification/notification.module.ts
@@ -8,6 +8,7 @@ import { NotificationService } from './notification.service';
 import { NotificationPreferenceService } from './notification-preference.service';
 import { NotificationDeliveryService } from './notification-delivery.service';
 import { NotificationPreferenceController } from './notification-preference.controller';
+import { ProfilingModule } from '../common/profiling/profiling.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { NotificationPreferenceController } from './notification-preference.cont
       NotificationPreference,
       NotificationDeliveryLog,
     ]),
+    ProfilingModule,
   ],
   providers: [
     NotificationService,

--- a/apps/backend/src/notification/push-token.entity.ts
+++ b/apps/backend/src/notification/push-token.entity.ts
@@ -19,6 +19,8 @@ export enum PushTokenPlatform {
 @Entity('push_tokens')
 @Index(['userId'])
 @Index(['token'], { unique: true })
+@Index(['isActive'])
+@Index(['userId', 'isActive'])
 export class PushToken {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/backend/src/outbox/outbox-event.entity.ts
+++ b/apps/backend/src/outbox/outbox-event.entity.ts
@@ -14,6 +14,7 @@ export enum OutboxEventStatus {
 
 @Entity('outbox_events')
 @Index('IDX_outbox_events_status_created', ['status', 'createdAt'])
+@Index(['eventType'])
 export class OutboxEvent {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/backend/src/portfolio/entities/portfolio-snapshot.entity.ts
+++ b/apps/backend/src/portfolio/entities/portfolio-snapshot.entity.ts
@@ -11,6 +11,7 @@ import { User } from '../../users/entities/user.entity';
 
 @Entity('portfolio_snapshots')
 @Index(['userId', 'createdAt'])
+@Index(['createdAt'])
 export class PortfolioSnapshot {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/backend/src/portfolio/portfolio.module.ts
+++ b/apps/backend/src/portfolio/portfolio.module.ts
@@ -22,6 +22,7 @@ import { PortfolioSnapshotWorker } from './queue/portfolio-snapshot.worker';
 import { ExchangeRatesModule } from '../exchange-rates/exchange-rates.module';
 import { StellarModule } from '../stellar/stellar.module';
 import { PriceModule } from '../price/price.module';
+import { ProfilingModule } from '../common/profiling/profiling.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { PriceModule } from '../price/price.module';
     ExchangeRatesModule,
     StellarModule,
     PriceModule,
+    ProfilingModule,
   ],
   controllers: [PortfolioController],
   providers: [

--- a/apps/backend/src/portfolio/portfolio.service.ts
+++ b/apps/backend/src/portfolio/portfolio.service.ts
@@ -23,6 +23,7 @@ import { calculatePortfolioPerformance } from './utils/portfolio-performance.uti
 import { PortfolioSnapshotQueueService } from './queue/portfolio-snapshot.queue.service';
 import { PortfolioSnapshotBatchStatus } from './queue/portfolio-snapshot.types';
 import { ExchangeRatesService } from '../exchange-rates/exchange-rates.service';
+import { QueryProfilerService } from '../common/profiling/query-profiler.service';
 
 @Injectable()
 export class PortfolioService {
@@ -40,6 +41,7 @@ export class PortfolioService {
     private readonly stellarService: StellarService,
     private readonly priceService: PriceService,
     private readonly snapshotQueueService: PortfolioSnapshotQueueService,
+    private readonly profiler: QueryProfilerService,
   ) {}
 
   /**
@@ -134,12 +136,16 @@ export class PortfolioService {
   ): Promise<PortfolioHistoryResponseDto> {
     const skip = (page - 1) * limit;
 
-    const [snapshots, total] = await this.snapshotRepository.findAndCount({
-      where: { userId },
-      order: { createdAt: 'DESC' },
-      skip,
-      take: limit,
-    });
+    const [snapshots, total] = await this.profiler.profile(
+      () =>
+        this.snapshotRepository.findAndCount({
+          where: { userId },
+          order: { createdAt: 'DESC' },
+          skip,
+          take: limit,
+        }),
+      { label: 'PortfolioService.getPortfolioHistory', thresholdMs: 150 },
+    );
 
     const snapshotDtos: PortfolioSnapshotDto[] = snapshots.map((snapshot) => ({
       id: snapshot.id,
@@ -167,47 +173,52 @@ export class PortfolioService {
   ): Promise<PortfolioSummaryResponseDto> {
     this.logger.log(`Fetching portfolio summary for user ${userId}`);
 
-    // Check if user has any linked Stellar accounts
-    const user = await this.userRepository.findOne({
-      where: { id: userId },
-      relations: ['stellarAccounts'],
-    });
+    return this.profiler.profile(
+      async () => {
+        // Check if user has any linked Stellar accounts
+        const user = await this.userRepository.findOne({
+          where: { id: userId },
+          relations: ['stellarAccounts'],
+        });
 
-    const hasLinkedAccount =
-      user?.stellarAccounts && user.stellarAccounts.length > 0;
+        const hasLinkedAccount =
+          user?.stellarAccounts && user.stellarAccounts.length > 0;
 
-    if (!hasLinkedAccount) {
-      this.logger.log(`User ${userId} has no linked Stellar accounts`);
-      return {
-        totalValueUsd: '0.00',
-        assets: [],
-        lastUpdated: null,
-        hasLinkedAccount: false,
-      };
-    }
+        if (!hasLinkedAccount) {
+          this.logger.log(`User ${userId} has no linked Stellar accounts`);
+          return {
+            totalValueUsd: '0.00',
+            assets: [],
+            lastUpdated: null,
+            hasLinkedAccount: false,
+          };
+        }
 
-    // User has linked accounts, try to get the latest snapshot
-    const latestSnapshot = await this.snapshotRepository.findOne({
-      where: { userId },
-      order: { createdAt: 'DESC' },
-    });
+        // User has linked accounts, try to get the latest snapshot
+        const latestSnapshot = await this.snapshotRepository.findOne({
+          where: { userId },
+          order: { createdAt: 'DESC' },
+        });
 
-    if (!latestSnapshot) {
-      // User has accounts but no snapshot yet
-      return {
-        totalValueUsd: '0.00',
-        assets: [],
-        lastUpdated: null,
-        hasLinkedAccount: true, // Important: set to true even without snapshot
-      };
-    }
+        if (!latestSnapshot) {
+          // User has accounts but no snapshot yet
+          return {
+            totalValueUsd: '0.00',
+            assets: [],
+            lastUpdated: null,
+            hasLinkedAccount: true, // Important: set to true even without snapshot
+          };
+        }
 
-    return {
-      totalValueUsd: latestSnapshot.totalValueUsd,
-      assets: latestSnapshot.assetBalances,
-      lastUpdated: latestSnapshot.createdAt,
-      hasLinkedAccount: true,
-    };
+        return {
+          totalValueUsd: latestSnapshot.totalValueUsd,
+          assets: latestSnapshot.assetBalances,
+          lastUpdated: latestSnapshot.createdAt,
+          hasLinkedAccount: true,
+        };
+      },
+      { label: 'PortfolioService.getPortfolioSummary', thresholdMs: 200 },
+    );
   }
 
   /**

--- a/apps/backend/src/reconciliation/reconciliation.module.ts
+++ b/apps/backend/src/reconciliation/reconciliation.module.ts
@@ -7,11 +7,13 @@ import { ReconciliationController } from './reconciliation.controller';
 import { PortfolioAsset } from '../portfolio/portfolio-asset.entity';
 import { User } from '../users/entities/user.entity';
 import { PortfolioModule } from '../portfolio/portfolio.module';
+import { ProfilingModule } from '../common/profiling/profiling.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([ReconciliationJob, PortfolioAsset, User]),
     PortfolioModule,
+    ProfilingModule,
   ],
   providers: [ReconciliationService, ReconciliationScheduler],
   controllers: [ReconciliationController],

--- a/apps/backend/src/reconciliation/reconciliation.service.ts
+++ b/apps/backend/src/reconciliation/reconciliation.service.ts
@@ -9,6 +9,7 @@ import {
   ReconciliationJob,
   ReconciliationStatus,
 } from './entities/reconciliation-job.entity';
+import { QueryProfilerService } from '../common/profiling/query-profiler.service';
 
 /** Tolerance for floating-point drift (0.0000001 XLM) */
 const DRIFT_THRESHOLD = 1e-7;
@@ -25,6 +26,7 @@ export class ReconciliationService {
     @InjectRepository(User)
     private readonly userRepo: Repository<User>,
     private readonly stellarBalanceService: StellarBalanceService,
+    private readonly profiler: QueryProfilerService,
   ) {}
 
   /**
@@ -33,6 +35,15 @@ export class ReconciliationService {
    * and repairs inconsistencies by updating the stored records.
    */
   async runReconciliation(
+    triggeredBy = 'scheduled',
+  ): Promise<ReconciliationJob> {
+    return this.profiler.profile(
+      async () => this.doRunReconciliation(triggeredBy),
+      { label: 'ReconciliationService.runReconciliation', thresholdMs: 5000 },
+    );
+  }
+
+  private async doRunReconciliation(
     triggeredBy = 'scheduled',
   ): Promise<ReconciliationJob> {
     const job = await this.jobRepo.save(

--- a/apps/backend/src/snapshot/entities/daily-snapshot.entity.ts
+++ b/apps/backend/src/snapshot/entities/daily-snapshot.entity.ts
@@ -20,6 +20,8 @@ import {
 @Index('UQ_daily_snapshots_date_asset', ['snapshotDate', 'assetSymbol'], {
   unique: true,
 })
+@Index(['assetSymbol'])
+@Index(['createdAt'])
 export class DailySnapshot {
   @PrimaryGeneratedColumn('uuid')
   id!: string;

--- a/apps/backend/src/stellar-sync/entities/checkpoint.entity.ts
+++ b/apps/backend/src/stellar-sync/entities/checkpoint.entity.ts
@@ -6,6 +6,7 @@ import {
 } from 'typeorm';
 
 @Entity('stellar_sync_checkpoints')
+@Index(['updatedAt'])
 export class StellarSyncCheckpoint {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/backend/src/stellar-sync/entities/checkpoint.entity.ts
+++ b/apps/backend/src/stellar-sync/entities/checkpoint.entity.ts
@@ -3,6 +3,7 @@ import {
   Column,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
+  Index,
 } from 'typeorm';
 
 @Entity('stellar_sync_checkpoints')

--- a/apps/backend/src/stellar-sync/entities/processed-event.entity.ts
+++ b/apps/backend/src/stellar-sync/entities/processed-event.entity.ts
@@ -6,6 +6,7 @@ import {
 } from 'typeorm';
 
 @Entity('stellar_processed_events')
+@Index(['processedAt'])
 export class StellarProcessedEvent {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/backend/src/stellar-sync/entities/processed-event.entity.ts
+++ b/apps/backend/src/stellar-sync/entities/processed-event.entity.ts
@@ -3,6 +3,7 @@ import {
   Column,
   PrimaryGeneratedColumn,
   CreateDateColumn,
+  Index,
 } from 'typeorm';
 
 @Entity('stellar_processed_events')

--- a/apps/backend/src/telegram-bot/index.ts
+++ b/apps/backend/src/telegram-bot/index.ts
@@ -1,0 +1,4 @@
+export { TelegramBotModule } from './telegram-bot.module';
+export { TelegramBotService } from './telegram-bot.service';
+export { TelegramSubscription, TelegramAlertType } from './telegram-subscription.entity';
+export { TelegramSilence } from './telegram-silence.entity';

--- a/apps/backend/src/telegram-bot/telegram-bot.controller.ts
+++ b/apps/backend/src/telegram-bot/telegram-bot.controller.ts
@@ -1,0 +1,37 @@
+import {
+  Controller,
+  Post,
+  Body,
+  Logger,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { TelegramBotService } from './telegram-bot.service';
+import { TelegramAlertType } from './telegram-subscription.entity';
+
+class SendAlertDto {
+  alertType: TelegramAlertType;
+  message: string;
+}
+
+@Controller('telegram-bot')
+export class TelegramBotController {
+  private readonly logger = new Logger(TelegramBotController.name);
+
+  constructor(
+    private readonly telegramBotService: TelegramBotService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * Admin endpoint to broadcast an alert to all subscribed chats.
+   * In production, this should be protected by admin authentication.
+   */
+  @Post('broadcast')
+  @HttpCode(HttpStatus.OK)
+  async broadcast(@Body() dto: SendAlertDto) {
+    await this.telegramBotService.broadcastAlert(dto.alertType, dto.message);
+    return { success: true, message: 'Broadcast sent' };
+  }
+}

--- a/apps/backend/src/telegram-bot/telegram-bot.module.ts
+++ b/apps/backend/src/telegram-bot/telegram-bot.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TelegramBotService } from './telegram-bot.service';
+import { TelegramBotController } from './telegram-bot.controller';
+import { TelegramSubscription } from './telegram-subscription.entity';
+import { TelegramSilence } from './telegram-silence.entity';
+import { PriceModule } from '../price/price.module';
+import { SentimentModule } from '../sentiment/sentiment.module';
+import { NewsModule } from '../news/news.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([TelegramSubscription, TelegramSilence]),
+    PriceModule,
+    SentimentModule,
+    NewsModule,
+  ],
+  providers: [TelegramBotService],
+  controllers: [TelegramBotController],
+  exports: [TelegramBotService],
+})
+export class TelegramBotModule {}

--- a/apps/backend/src/telegram-bot/telegram-bot.service.ts
+++ b/apps/backend/src/telegram-bot/telegram-bot.service.ts
@@ -1,0 +1,411 @@
+import {
+  Injectable,
+  Logger,
+  OnModuleInit,
+  OnModuleDestroy,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThan } from 'typeorm';
+import TelegramBot, { Message } from 'node-telegram-bot-api';
+import { TelegramSubscription, TelegramAlertType } from './telegram-subscription.entity';
+import { TelegramSilence } from './telegram-silence.entity';
+import { PriceService } from '../price/price.service';
+import { SentimentService } from '../sentiment/sentiment.service';
+import { NewsService } from '../news/news.service';
+
+@Injectable()
+export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(TelegramBotService.name);
+  private bot: TelegramBot | null = null;
+
+  constructor(
+    private readonly configService: ConfigService,
+    @InjectRepository(TelegramSubscription)
+    private readonly subscriptionRepository: Repository<TelegramSubscription>,
+    @InjectRepository(TelegramSilence)
+    private readonly silenceRepository: Repository<TelegramSilence>,
+    private readonly priceService: PriceService,
+    private readonly sentimentService: SentimentService,
+    private readonly newsService: NewsService,
+  ) {}
+
+  onModuleInit() {
+    const token = this.configService.get<string>('TELEGRAM_BOT_TOKEN');
+    if (!token) {
+      this.logger.warn(
+        'TELEGRAM_BOT_TOKEN not set. Telegram bot will not be started.',
+      );
+      return;
+    }
+
+    this.bot = new TelegramBot(token, { polling: true });
+    this.registerHandlers();
+    this.logger.log('Telegram bot started with polling');
+  }
+
+  onModuleDestroy() {
+    if (this.bot) {
+      this.bot.stopPolling();
+      this.logger.log('Telegram bot stopped');
+    }
+  }
+
+  private registerHandlers() {
+    if (!this.bot) return;
+
+    this.bot.onText(/\/start/, (msg) => this.handleStart(msg));
+    this.bot.onText(/\/status/, (msg) => this.handleStatus(msg));
+    this.bot.onText(/\/price (.+)/, (msg, match) => this.handlePrice(msg, match));
+    this.bot.onText(/\/price$/, (msg) => this.handlePrice(msg, null));
+    this.bot.onText(/\/sentiment/, (msg) => this.handleSentiment(msg));
+    this.bot.onText(/\/trend/, (msg) => this.handleTrend(msg));
+    this.bot.onText(/\/subscribe (.+)/, (msg, match) => this.handleSubscribe(msg, match));
+    this.bot.onText(/\/subscribe$/, (msg) => this.handleSubscribe(msg, null));
+    this.bot.onText(/\/unsubscribe (.+)/, (msg, match) => this.handleUnsubscribe(msg, match));
+    this.bot.onText(/\/unsubscribe$/, (msg) => this.handleUnsubscribe(msg, null));
+    this.bot.onText(/\/silence (.+)/, (msg, match) => this.handleSilence(msg, match));
+    this.bot.onText(/\/silence$/, (msg) => this.handleSilence(msg, null));
+    this.bot.onText(/\/unsilence/, (msg) => this.handleUnsilence(msg));
+    this.bot.onText(/\/subscriptions/, (msg) => this.handleSubscriptions(msg));
+    this.bot.onText(/\/help/, (msg) => this.handleHelp(msg));
+
+    this.bot.on('polling_error', (error) => {
+      this.logger.error('Telegram polling error', error);
+    });
+  }
+
+  private getChatId(msg: Message): string {
+    return msg.chat.id.toString();
+  }
+
+  private async sendMessage(chatId: string, text: string) {
+    if (!this.bot) return;
+    try {
+      await this.bot.sendMessage(chatId, text, { parse_mode: 'Markdown' });
+    } catch (error) {
+      this.logger.error(`Failed to send message to ${chatId}`, error);
+    }
+  }
+
+  private async handleStart(msg: Message) {
+    const chatId = this.getChatId(msg);
+    const username = msg.from?.username ?? null;
+
+    let sub = await this.subscriptionRepository.findOne({ where: { chatId } });
+    if (!sub) {
+      sub = this.subscriptionRepository.create({
+        chatId,
+        username,
+        alertTypes: Object.values(TelegramAlertType),
+        isActive: true,
+      });
+      await this.subscriptionRepository.save(sub);
+    } else {
+      sub.isActive = true;
+      sub.username = username;
+      await this.subscriptionRepository.save(sub);
+    }
+
+    await this.sendMessage(
+      chatId,
+      'Welcome to LumenPulse Bot! 🚀\n\n' +
+        'You are now subscribed to all alerts.\n' +
+        'Use /help to see available commands.',
+    );
+  }
+
+  private async handleStatus(msg: Message) {
+    const chatId = this.getChatId(msg);
+    const sub = await this.subscriptionRepository.findOne({ where: { chatId } });
+
+    if (!sub || !sub.isActive) {
+      await this.sendMessage(
+        chatId,
+        'You are not subscribed. Use /start to subscribe.',
+      );
+      return;
+    }
+
+    const silenced = await this.isSilenced(chatId);
+
+    const statusText =
+      '*Bot Status* ✅\n\n' +
+      `Username: ${sub.username ?? 'N/A'}\n` +
+      `Active: ${sub.isActive ? 'Yes' : 'No'}\n` +
+      `Silenced: ${silenced ? 'Yes' : 'No'}\n` +
+      `Alerts: ${sub.alertTypes.join(', ')}`;
+
+    await this.sendMessage(chatId, statusText);
+  }
+
+  private async handlePrice(msg: Message, match: RegExpExecArray | null) {
+    const chatId = this.getChatId(msg);
+    const asset = match?.[1]?.trim().toUpperCase() ?? 'XLM';
+
+    try {
+      const price = await this.priceService.getCurrentPrice(asset);
+      if (price === 0) {
+        await this.sendMessage(chatId, `Price for *${asset}* is not available.`);
+        return;
+      }
+
+      await this.sendMessage(
+        chatId,
+        `*Current Price* 💰\n\n${asset}: $${price.toFixed(4)}`,
+      );
+    } catch (error) {
+      this.logger.error('Price command error', error);
+      await this.sendMessage(chatId, 'Failed to fetch price. Please try again later.');
+    }
+  }
+
+  private async handleSentiment(msg: Message) {
+    const chatId = this.getChatId(msg);
+
+    try {
+      const summary = await this.newsService.getSentimentSummary();
+      const sentimentText = this.formatSentimentSummary(summary);
+      await this.sendMessage(chatId, sentimentText);
+    } catch (error) {
+      this.logger.error('Sentiment command error', error);
+      await this.sendMessage(chatId, 'Failed to fetch sentiment. Please try again later.');
+    }
+  }
+
+  private formatSentimentSummary(summary: {
+    overall: { averageSentiment: number; totalArticles: number };
+    bySource: { source: string; averageScore: number; articleCount: number }[];
+  }): string {
+    const avg = summary.overall.averageSentiment;
+    let sentimentEmoji = '😐';
+    if (avg > 0.3) sentimentEmoji = '😄';
+    if (avg < -0.3) sentimentEmoji = '😟';
+
+    let text =
+      `*Market Sentiment* ${sentimentEmoji}\n\n` +
+      `Overall: ${avg.toFixed(2)} (${summary.overall.totalArticles} articles)\n\n` +
+      '*By Source:*\n';
+
+    for (const source of summary.bySource.slice(0, 5)) {
+      text += `- ${source.source}: ${source.averageScore.toFixed(2)} (${source.articleCount})\n`;
+    }
+
+    return text;
+  }
+
+  private async handleTrend(msg: Message) {
+    const chatId = this.getChatId(msg);
+
+    try {
+      const [price, summary] = await Promise.all([
+        this.priceService.getCurrentPrice('XLM'),
+        this.newsService.getSentimentSummary(),
+      ]);
+
+      const avg = summary.overall.averageSentiment;
+      let trend = 'Neutral 📊';
+      if (avg > 0.3 && price > 0.12) trend = 'Bullish 📈';
+      if (avg < -0.3 || price < 0.1) trend = 'Bearish 📉';
+
+      const text =
+        `*Market Trend* ${trend}\n\n` +
+        `XLM Price: $${price.toFixed(4)}\n` +
+        `Sentiment: ${avg.toFixed(2)}\n` +
+        `Articles: ${summary.overall.totalArticles}\n\n` +
+        '_Trend is based on price + sentiment combined._';
+
+      await this.sendMessage(chatId, text);
+    } catch (error) {
+      this.logger.error('Trend command error', error);
+      await this.sendMessage(chatId, 'Failed to fetch trend. Please try again later.');
+    }
+  }
+
+  private async handleSubscribe(msg: Message, match: RegExpExecArray | null) {
+    const chatId = this.getChatId(msg);
+    const typeInput = match?.[1]?.trim().toLowerCase() ?? '';
+
+    const validTypes = Object.values(TelegramAlertType).map((t) => t.toLowerCase());
+    if (!validTypes.includes(typeInput)) {
+      await this.sendMessage(
+        chatId,
+        `Invalid alert type: *${typeInput}*\n\n` +
+          `Valid types: ${validTypes.join(', ')}\n\n` +
+          'Use /subscriptions to see your current subscriptions.',
+      );
+      return;
+    }
+
+    const alertType = typeInput as TelegramAlertType;
+    let sub = await this.subscriptionRepository.findOne({ where: { chatId } });
+
+    if (!sub) {
+      sub = this.subscriptionRepository.create({
+        chatId,
+        username: msg.from?.username ?? null,
+        alertTypes: [alertType],
+        isActive: true,
+      });
+    } else {
+      if (!sub.alertTypes.includes(alertType)) {
+        sub.alertTypes.push(alertType);
+      }
+    }
+
+    await this.subscriptionRepository.save(sub);
+    await this.sendMessage(chatId, `Subscribed to *${alertType}* alerts ✅`);
+  }
+
+  private async handleUnsubscribe(msg: Message, match: RegExpExecArray | null) {
+    const chatId = this.getChatId(msg);
+    const typeInput = match?.[1]?.trim().toLowerCase() ?? '';
+
+    const validTypes = Object.values(TelegramAlertType).map((t) => t.toLowerCase());
+    if (!validTypes.includes(typeInput)) {
+      await this.sendMessage(
+        chatId,
+        `Invalid alert type: *${typeInput}*\n\n` +
+          `Valid types: ${validTypes.join(', ')}`,
+      );
+      return;
+    }
+
+    const alertType = typeInput as TelegramAlertType;
+    const sub = await this.subscriptionRepository.findOne({ where: { chatId } });
+
+    if (!sub) {
+      await this.sendMessage(chatId, 'You are not subscribed. Use /start to subscribe.');
+      return;
+    }
+
+    sub.alertTypes = sub.alertTypes.filter((t) => t !== alertType);
+    await this.subscriptionRepository.save(sub);
+    await this.sendMessage(chatId, `Unsubscribed from *${alertType}* alerts ❌`);
+  }
+
+  private async handleSilence(msg: Message, match: RegExpExecArray | null) {
+    const chatId = this.getChatId(msg);
+    const hoursStr = match?.[1]?.trim() ?? '';
+    const hours = parseInt(hoursStr, 10);
+
+    if (Number.isNaN(hours) || hours <= 0 || hours > 168) {
+      await this.sendMessage(
+        chatId,
+        'Usage: /silence <hours>\n\n' +
+          'Example: /silence 4 (mutes for 4 hours)\n' +
+          'Maximum: 168 hours (7 days)',
+      );
+      return;
+    }
+
+    const until = new Date(Date.now() + hours * 60 * 60 * 1000);
+
+    let silence = await this.silenceRepository.findOne({ where: { chatId } });
+    if (!silence) {
+      silence = this.silenceRepository.create({ chatId, silencedUntil: until });
+    } else {
+      silence.silencedUntil = until;
+    }
+
+    await this.silenceRepository.save(silence);
+    await this.sendMessage(
+      chatId,
+      `🔇 Alerts silenced for *${hours}* hour(s).\n` +
+        `Until: ${until.toLocaleString()}\n\n` +
+        'Use /unsilence to re-enable alerts early.',
+    );
+  }
+
+  private async handleUnsilence(msg: Message) {
+    const chatId = this.getChatId(msg);
+    const silence = await this.silenceRepository.findOne({ where: { chatId } });
+
+    if (!silence) {
+      await this.sendMessage(chatId, 'You are not currently silenced.');
+      return;
+    }
+
+    await this.silenceRepository.remove(silence);
+    await this.sendMessage(chatId, '🔔 Alerts re-enabled!');
+  }
+
+  private async handleSubscriptions(msg: Message) {
+    const chatId = this.getChatId(msg);
+    const sub = await this.subscriptionRepository.findOne({ where: { chatId } });
+
+    if (!sub || !sub.isActive) {
+      await this.sendMessage(
+        chatId,
+        'You are not subscribed. Use /start to subscribe.',
+      );
+      return;
+    }
+
+    const silenced = await this.isSilenced(chatId);
+
+    const text =
+      `*Your Subscriptions* 📋\n\n` +
+      `Alerts: ${sub.alertTypes.length > 0 ? sub.alertTypes.join(', ') : 'None'}\n` +
+      `Silenced: ${silenced ? 'Yes' : 'No'}\n\n` +
+      'Use /subscribe <type> or /unsubscribe <type> to manage.';
+
+    await this.sendMessage(chatId, text);
+  }
+
+  private async handleHelp(msg: Message) {
+    const chatId = this.getChatId(msg);
+    const helpText =
+      '*LumenPulse Bot Commands* 🤖\n\n' +
+      '/start - Subscribe to alerts\n' +
+      '/status - Check your subscription status\n' +
+      '/price <asset> - Get current price (default: XLM)\n' +
+      '/sentiment - Get market sentiment summary\n' +
+      '/trend - Get combined market trend\n' +
+      '/subscribe <type> - Subscribe to alert type\n' +
+      '/unsubscribe <type> - Unsubscribe from alert type\n' +
+      '/subscriptions - List your subscriptions\n' +
+      '/silence <hours> - Mute alerts for X hours\n' +
+      '/unsilence - Re-enable alerts\n' +
+      '/help - Show this help message\n\n' +
+      '*Alert types:* price, sentiment, news, portfolio, system';
+
+    await this.sendMessage(chatId, helpText);
+  }
+
+  private async isSilenced(chatId: string): Promise<boolean> {
+    const silence = await this.silenceRepository.findOne({
+      where: {
+        chatId,
+        silencedUntil: MoreThan(new Date()),
+      },
+    });
+    return !!silence;
+  }
+
+  /**
+   * Deliver an alert to all subscribed and non-silenced chats for the given alert type.
+   */
+  async broadcastAlert(
+    alertType: TelegramAlertType,
+    message: string,
+  ): Promise<void> {
+    const subs = await this.subscriptionRepository.find({
+      where: { isActive: true },
+    });
+
+    for (const sub of subs) {
+      if (!sub.alertTypes.includes(alertType)) continue;
+      if (await this.isSilenced(sub.chatId)) continue;
+
+      await this.sendMessage(sub.chatId, message);
+    }
+  }
+
+  /**
+   * Send a message to a specific chat (used by webhook or other services).
+   */
+  async sendToChat(chatId: string, message: string): Promise<void> {
+    await this.sendMessage(chatId, message);
+  }
+}

--- a/apps/backend/src/telegram-bot/telegram-bot.service.ts
+++ b/apps/backend/src/telegram-bot/telegram-bot.service.ts
@@ -46,7 +46,7 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
 
   onModuleDestroy() {
     if (this.bot) {
-      this.bot.stopPolling();
+      void this.bot.stopPolling();
       this.logger.log('Telegram bot stopped');
     }
   }
@@ -54,21 +54,21 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
   private registerHandlers() {
     if (!this.bot) return;
 
-    this.bot.onText(/\/start/, (msg) => this.handleStart(msg));
-    this.bot.onText(/\/status/, (msg) => this.handleStatus(msg));
-    this.bot.onText(/\/price (.+)/, (msg, match) => this.handlePrice(msg, match));
-    this.bot.onText(/\/price$/, (msg) => this.handlePrice(msg, null));
-    this.bot.onText(/\/sentiment/, (msg) => this.handleSentiment(msg));
-    this.bot.onText(/\/trend/, (msg) => this.handleTrend(msg));
-    this.bot.onText(/\/subscribe (.+)/, (msg, match) => this.handleSubscribe(msg, match));
-    this.bot.onText(/\/subscribe$/, (msg) => this.handleSubscribe(msg, null));
-    this.bot.onText(/\/unsubscribe (.+)/, (msg, match) => this.handleUnsubscribe(msg, match));
-    this.bot.onText(/\/unsubscribe$/, (msg) => this.handleUnsubscribe(msg, null));
-    this.bot.onText(/\/silence (.+)/, (msg, match) => this.handleSilence(msg, match));
-    this.bot.onText(/\/silence$/, (msg) => this.handleSilence(msg, null));
-    this.bot.onText(/\/unsilence/, (msg) => this.handleUnsilence(msg));
-    this.bot.onText(/\/subscriptions/, (msg) => this.handleSubscriptions(msg));
-    this.bot.onText(/\/help/, (msg) => this.handleHelp(msg));
+    this.bot.onText(/\/start/, (msg) => { void this.handleStart(msg); });
+    this.bot.onText(/\/status/, (msg) => { void this.handleStatus(msg); });
+    this.bot.onText(/\/price (.+)/, (msg, match) => { void this.handlePrice(msg, match); });
+    this.bot.onText(/\/price$/, (msg) => { void this.handlePrice(msg, null); });
+    this.bot.onText(/\/sentiment/, (msg) => { void this.handleSentiment(msg); });
+    this.bot.onText(/\/trend/, (msg) => { void this.handleTrend(msg); });
+    this.bot.onText(/\/subscribe (.+)/, (msg, match) => { void this.handleSubscribe(msg, match); });
+    this.bot.onText(/\/subscribe$/, (msg) => { void this.handleSubscribe(msg, null); });
+    this.bot.onText(/\/unsubscribe (.+)/, (msg, match) => { void this.handleUnsubscribe(msg, match); });
+    this.bot.onText(/\/unsubscribe$/, (msg) => { void this.handleUnsubscribe(msg, null); });
+    this.bot.onText(/\/silence (.+)/, (msg, match) => { void this.handleSilence(msg, match); });
+    this.bot.onText(/\/silence$/, (msg) => { void this.handleSilence(msg, null); });
+    this.bot.onText(/\/unsilence/, (msg) => { void this.handleUnsilence(msg); });
+    this.bot.onText(/\/subscriptions/, (msg) => { void this.handleSubscriptions(msg); });
+    this.bot.onText(/\/help/, (msg) => { void this.handleHelp(msg); });
 
     this.bot.on('polling_error', (error) => {
       this.logger.error('Telegram polling error', error);

--- a/apps/backend/src/telegram-bot/telegram-silence.entity.ts
+++ b/apps/backend/src/telegram-bot/telegram-silence.entity.ts
@@ -1,0 +1,23 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('telegram_silence')
+@Index(['chatId'], { unique: true })
+export class TelegramSilence {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  chatId: string;
+
+  @Column({ type: 'timestamptz' })
+  silencedUntil: Date;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/apps/backend/src/telegram-bot/telegram-subscription.entity.ts
+++ b/apps/backend/src/telegram-bot/telegram-subscription.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum TelegramAlertType {
+  PRICE = 'price',
+  SENTIMENT = 'sentiment',
+  NEWS = 'news',
+  PORTFOLIO = 'portfolio',
+  SYSTEM = 'system',
+}
+
+@Entity('telegram_subscriptions')
+@Index(['chatId'], { unique: true })
+export class TelegramSubscription {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 50, unique: true })
+  chatId: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  username: string | null;
+
+  @Column({
+    type: 'jsonb',
+    default: [
+      TelegramAlertType.PRICE,
+      TelegramAlertType.SENTIMENT,
+      TelegramAlertType.NEWS,
+    ],
+  })
+  alertTypes: TelegramAlertType[];
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/apps/backend/src/users/entities/stellar-account.entity.ts
+++ b/apps/backend/src/users/entities/stellar-account.entity.ts
@@ -12,6 +12,9 @@ import { User } from './user.entity';
 
 @Entity('stellar_accounts')
 @Index(['userId', 'publicKey'], { unique: true })
+@Index(['userId'])
+@Index(['isActive'])
+@Index(['isPrimary'])
 export class StellarAccount {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/backend/src/watchlist/watchlist.module.ts
+++ b/apps/backend/src/watchlist/watchlist.module.ts
@@ -4,9 +4,10 @@ import { WatchlistItem } from './watchlist-item.entity';
 import { User } from '../users/entities/user.entity';
 import { WatchlistService } from './watchlist.service';
 import { WatchlistController } from './watchlist.controller';
+import { ProfilingModule } from '../common/profiling/profiling.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([WatchlistItem, User])],
+  imports: [TypeOrmModule.forFeature([WatchlistItem, User]), ProfilingModule],
   controllers: [WatchlistController],
   providers: [WatchlistService],
   exports: [WatchlistService, TypeOrmModule],

--- a/apps/backend/src/watchlist/watchlist.service.ts
+++ b/apps/backend/src/watchlist/watchlist.service.ts
@@ -7,6 +7,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { WatchlistItem, WatchlistItemType } from './watchlist-item.entity';
+import { QueryProfilerService } from '../common/profiling/query-profiler.service';
 import {
   AddToWatchlistDto,
   UpdateWatchlistDto,
@@ -21,6 +22,7 @@ export class WatchlistService {
   constructor(
     @InjectRepository(WatchlistItem)
     private readonly watchlistRepository: Repository<WatchlistItem>,
+    private readonly profiler: QueryProfilerService,
   ) {}
 
   /**
@@ -93,10 +95,14 @@ export class WatchlistService {
       where.type = type;
     }
 
-    const [items, total] = await this.watchlistRepository.findAndCount({
-      where,
-      order: { sortOrder: 'ASC', createdAt: 'DESC' },
-    });
+    const [items, total] = await this.profiler.profile(
+      () =>
+        this.watchlistRepository.findAndCount({
+          where,
+          order: { sortOrder: 'ASC', createdAt: 'DESC' },
+        }),
+      { label: 'WatchlistService.getWatchlist', thresholdMs: 100 },
+    );
 
     return {
       items: items.map((item) => this.toResponseDto(item)),


### PR DESCRIPTION
closes #566 
closes #459 

## Summary
Extend the Telegram Alert Bot from "push-only" to fully interactive with per-user subscriptions and a silence/mute mechanism.

## What's New
### Interactive Commands
| Command | Description |
|---|---|
| `/start` | Subscribe to default alerts |
| `/status` | View bot subscription & silence status |
| `/price <asset>` | Get current asset price (default: XLM) |
| `/sentiment` | Market sentiment summary from news DB |
| `/trend` | Combined price + sentiment trend analysis |
| `/subscribe <type>` | Subscribe to alert type |
| `/unsubscribe <type>` | Unsubscribe from alert type |
| `/subscriptions` | List current subscriptions |
| `/silence <hours>` | Mute alerts for X hours (max 7 days) |
| `/unsilence` | Re-enable alerts early |
| `/help` | Show all available commands |

### Data Model
- `telegram_subscriptions` — stores chatId, username, active alert types, and subscription status
- `telegram_silence` — stores chatId and `silencedUntil` timestamp for mute logic

### Architecture
- `TelegramBotService` handles all `node-telegram-bot-api` polling and command routing
- `TelegramBotController` exposes a `POST /telegram-bot/broadcast` admin endpoint
- `TelegramBotModule` integrates with `PriceModule`, `SentimentModule`, and `NewsModule`

## Acceptance Criteria
- [x] Command handlers for `/sentiment` and `/trend`
- [x] Simple DB-backed subscription list (who gets which alerts)
- [x] "Silence" command to mute alerts for X hours

## Migration
Run:
```bash
npm install
npm run migration:run

closes #566 
closes #459 