### PR TITLE
feat(portfolio): add materialized snapshots for fast reads (#558)

### DIFF
--- a/apps/backend/package-lock.json
+++ b/apps/backend/package-lock.json
@@ -64,7 +64,7 @@
         "@types/jest": "^29.5.14",
         "@types/multer": "^2.1.0",
         "@types/node": "^22.19.7",
-        "@types/node-telegram-bot-api": "^0.64.7",
+        "@types/node-telegram-bot-api": "^0.64.14",
         "@types/passport-jwt": "^4.0.1",
         "@types/sharp": "^0.31.1",
         "@types/supertest": "^6.0.3",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -56,6 +56,7 @@
     "ioredis": "^5.6.1",
     "keyv": "^5.6.0",
     "multer": "^2.1.1",
+    "node-telegram-bot-api": "^0.66.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.17.2",
@@ -65,8 +66,7 @@
     "sharp": "^0.34.5",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
-    "stellar-sdk": "^13.3.0",
-    "node-telegram-bot-api": "^0.66.0"
+    "stellar-sdk": "^13.3.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^0.1.0",
@@ -79,6 +79,7 @@
     "@types/jest": "^29.5.14",
     "@types/multer": "^2.1.0",
     "@types/node": "^22.19.7",
+    "@types/node-telegram-bot-api": "^0.64.14",
     "@types/passport-jwt": "^4.0.1",
     "@types/sharp": "^0.31.1",
     "@types/supertest": "^6.0.3",
@@ -97,8 +98,7 @@
     "tsconfig-paths": "^4.2.0",
     "typeorm": "^0.3.28",
     "typescript": "^5.7.3",
-    "typescript-eslint": "^8.20.0",
-    "@types/node-telegram-bot-api": "^0.64.7"
+    "typescript-eslint": "^8.20.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/apps/backend/src/common/interceptors/idempotency.interceptor.spec.ts
+++ b/apps/backend/src/common/interceptors/idempotency.interceptor.spec.ts
@@ -32,12 +32,20 @@ describe('IdempotencyInterceptor', () => {
 
   it('should return cached result if key and body hash match', async () => {
     const body = { amount: 100 };
-    const context = createMockContext('POST', { 'idempotency-key': 'test-key' }, body);
+    const context = createMockContext(
+      'POST',
+      { 'idempotency-key': 'test-key' },
+      body,
+    );
     const next: CallHandler = { handle: jest.fn() };
-    
+
     // @ts-expect-error - accessing private method for test
     const bodyHash = interceptor.calculateHash(body);
-    const cachedResponse = { statusCode: 201, body: { success: true }, bodyHash };
+    const cachedResponse = {
+      statusCode: 201,
+      body: { success: true },
+      bodyHash,
+    };
 
     mockCacheService.get.mockResolvedValue(cachedResponse);
 
@@ -48,10 +56,18 @@ describe('IdempotencyInterceptor', () => {
 
   it('should throw UnprocessableEntity if body hash mismatch', async () => {
     const body = { amount: 100 };
-    const context = createMockContext('POST', { 'idempotency-key': 'test-key' }, body);
+    const context = createMockContext(
+      'POST',
+      { 'idempotency-key': 'test-key' },
+      body,
+    );
     const next: CallHandler = { handle: jest.fn() };
-    
-    const cachedResponse = { statusCode: 201, body: { success: true }, bodyHash: 'different-hash' };
+
+    const cachedResponse = {
+      statusCode: 201,
+      body: { success: true },
+      bodyHash: 'different-hash',
+    };
 
     mockCacheService.get.mockResolvedValue(cachedResponse);
 
@@ -61,8 +77,14 @@ describe('IdempotencyInterceptor', () => {
   });
 
   it('should clear lock on error', async () => {
-    const context = createMockContext('POST', { 'idempotency-key': 'test-key' }, {});
-    const next: CallHandler = { handle: () => throwError(() => new Error('Failed')) };
+    const context = createMockContext(
+      'POST',
+      { 'idempotency-key': 'test-key' },
+      {},
+    );
+    const next: CallHandler = {
+      handle: () => throwError(() => new Error('Failed')),
+    };
 
     mockCacheService.get.mockResolvedValue(null);
 
@@ -76,7 +98,11 @@ describe('IdempotencyInterceptor', () => {
     expect(mockCacheService.del).toHaveBeenCalled();
   });
 
-  function createMockContext(method: string, headers: Record<string, string>, body: unknown): ExecutionContext {
+  function createMockContext(
+    method: string,
+    headers: Record<string, string>,
+    body: unknown,
+  ): ExecutionContext {
     return {
       switchToHttp: () => ({
         getRequest: () => ({

--- a/apps/backend/src/common/interceptors/idempotency.interceptor.ts
+++ b/apps/backend/src/common/interceptors/idempotency.interceptor.ts
@@ -61,9 +61,9 @@ export class IdempotencyInterceptor implements NestInterceptor {
     const bodyHash = this.calculateHash(request.body);
     const cacheKey = `idempotency:${request.path}:${idempotencyKey}`;
 
-    const cachedResult = await this.cacheService.get<IdempotencyResult | string>(
-      cacheKey,
-    );
+    const cachedResult = await this.cacheService.get<
+      IdempotencyResult | string
+    >(cacheKey);
 
     if (cachedResult) {
       if (cachedResult === 'IN_PROGRESS') {
@@ -105,7 +105,9 @@ export class IdempotencyInterceptor implements NestInterceptor {
           this.cacheService
             .set(cacheKey, result, ttl)
             .catch((err: Error) =>
-              this.logger.error(`Failed to cache idempotency result: ${err.message}`),
+              this.logger.error(
+                `Failed to cache idempotency result: ${err.message}`,
+              ),
             );
         },
         error: () => {
@@ -113,7 +115,9 @@ export class IdempotencyInterceptor implements NestInterceptor {
           this.cacheService
             .del(cacheKey)
             .catch((err: Error) =>
-              this.logger.error(`Failed to release idempotency lock: ${err.message}`),
+              this.logger.error(
+                `Failed to release idempotency lock: ${err.message}`,
+              ),
             );
         },
       }),

--- a/apps/backend/src/common/profiling/profile-query.decorator.ts
+++ b/apps/backend/src/common/profiling/profile-query.decorator.ts
@@ -7,9 +7,6 @@ export interface ProfileQueryMetadata {
   label: string;
 }
 
-export const ProfileQuery = (
-  label: string,
-  thresholdMs = 100,
-) => {
+export const ProfileQuery = (label: string, thresholdMs = 100) => {
   return SetMetadata(PROFILE_QUERY_KEY, { label, thresholdMs });
 };

--- a/apps/backend/src/common/profiling/query-profiler.interceptor.ts
+++ b/apps/backend/src/common/profiling/query-profiler.interceptor.ts
@@ -8,7 +8,10 @@ import {
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { Reflector } from '@nestjs/core';
-import { PROFILE_QUERY_KEY, ProfileQueryMetadata } from './profile-query.decorator';
+import {
+  PROFILE_QUERY_KEY,
+  ProfileQueryMetadata,
+} from './profile-query.decorator';
 
 @Injectable()
 export class QueryProfilerInterceptor implements NestInterceptor {

--- a/apps/backend/src/common/profiling/query-profiler.service.ts
+++ b/apps/backend/src/common/profiling/query-profiler.service.ts
@@ -25,9 +25,7 @@ export class QueryProfilerService {
           `[SLOW QUERY] ${label} took ${duration.toFixed(2)}ms (threshold: ${thresholdMs}ms)`,
         );
       } else {
-        this.logger.debug(
-          `[QUERY] ${label} took ${duration.toFixed(2)}ms`,
-        );
+        this.logger.debug(`[QUERY] ${label} took ${duration.toFixed(2)}ms`);
       }
 
       return result;

--- a/apps/backend/src/database/migrations/1769900000000-CreateOutboxEvents.ts
+++ b/apps/backend/src/database/migrations/1769900000000-CreateOutboxEvents.ts
@@ -28,9 +28,7 @@ export class CreateOutboxEvents1769900000000 implements MigrationInterface {
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `DROP INDEX "IDX_outbox_events_status_created"`,
-    );
+    await queryRunner.query(`DROP INDEX "IDX_outbox_events_status_created"`);
     await queryRunner.query(`DROP TABLE "outbox_events"`);
     await queryRunner.query(`DROP TYPE "outbox_events_status_enum"`);
   }

--- a/apps/backend/src/database/migrations/1770000000000-CreateTelegramBotTables.ts
+++ b/apps/backend/src/database/migrations/1770000000000-CreateTelegramBotTables.ts
@@ -4,7 +4,9 @@ export class CreateTelegramBotTables1770000000000 implements MigrationInterface 
   name = 'CreateTelegramBotTables1770000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    const subscriptionsTableExists = await queryRunner.hasTable('telegram_subscriptions');
+    const subscriptionsTableExists = await queryRunner.hasTable(
+      'telegram_subscriptions',
+    );
     if (!subscriptionsTableExists) {
       await queryRunner.query(`
         CREATE TABLE "telegram_subscriptions" (
@@ -51,15 +53,25 @@ export class CreateTelegramBotTables1770000000000 implements MigrationInterface 
   public async down(queryRunner: QueryRunner): Promise<void> {
     const silenceTableExists = await queryRunner.hasTable('telegram_silence');
     if (silenceTableExists) {
-      await queryRunner.query(`DROP INDEX "public"."IDX_telegram_silence_silencedUntil"`);
-      await queryRunner.query(`DROP INDEX "public"."IDX_telegram_silence_chatId"`);
+      await queryRunner.query(
+        `DROP INDEX "public"."IDX_telegram_silence_silencedUntil"`,
+      );
+      await queryRunner.query(
+        `DROP INDEX "public"."IDX_telegram_silence_chatId"`,
+      );
       await queryRunner.query(`DROP TABLE "telegram_silence"`);
     }
 
-    const subscriptionsTableExists = await queryRunner.hasTable('telegram_subscriptions');
+    const subscriptionsTableExists = await queryRunner.hasTable(
+      'telegram_subscriptions',
+    );
     if (subscriptionsTableExists) {
-      await queryRunner.query(`DROP INDEX "public"."IDX_telegram_subscriptions_isActive"`);
-      await queryRunner.query(`DROP INDEX "public"."IDX_telegram_subscriptions_chatId"`);
+      await queryRunner.query(
+        `DROP INDEX "public"."IDX_telegram_subscriptions_isActive"`,
+      );
+      await queryRunner.query(
+        `DROP INDEX "public"."IDX_telegram_subscriptions_chatId"`,
+      );
       await queryRunner.query(`DROP TABLE "telegram_subscriptions"`);
     }
   }

--- a/apps/backend/src/database/migrations/1770000000001-AddMissingIndexes.ts
+++ b/apps/backend/src/database/migrations/1770000000001-AddMissingIndexes.ts
@@ -5,77 +5,261 @@ export class AddMissingIndexes1770000000001 implements MigrationInterface {
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     // stellar_accounts
-    await this.createIndex(queryRunner, 'stellar_accounts', 'IDX_stellar_accounts_userId', ['userId']);
-    await this.createIndex(queryRunner, 'stellar_accounts', 'IDX_stellar_accounts_isActive', ['isActive']);
-    await this.createIndex(queryRunner, 'stellar_accounts', 'IDX_stellar_accounts_isPrimary', ['isPrimary']);
+    await this.createIndex(
+      queryRunner,
+      'stellar_accounts',
+      'IDX_stellar_accounts_userId',
+      ['userId'],
+    );
+    await this.createIndex(
+      queryRunner,
+      'stellar_accounts',
+      'IDX_stellar_accounts_isActive',
+      ['isActive'],
+    );
+    await this.createIndex(
+      queryRunner,
+      'stellar_accounts',
+      'IDX_stellar_accounts_isPrimary',
+      ['isPrimary'],
+    );
 
     // articles
-    await this.createIndex(queryRunner, 'articles', 'IDX_articles_category', ['category']);
+    await this.createIndex(queryRunner, 'articles', 'IDX_articles_category', [
+      'category',
+    ]);
     await queryRunner.query(
       `CREATE INDEX IF NOT EXISTS "IDX_articles_tags_gin" ON "articles" USING GIN (tags)`,
     );
 
     // notifications
-    await this.createIndex(queryRunner, 'notifications', 'IDX_notifications_read', ['read']);
-    await this.createIndex(queryRunner, 'notifications', 'IDX_notifications_type', ['type']);
-    await this.createIndex(queryRunner, 'notifications', 'IDX_notifications_severity', ['severity']);
-    await this.createIndex(queryRunner, 'notifications', 'IDX_notifications_createdAt', ['createdAt']);
+    await this.createIndex(
+      queryRunner,
+      'notifications',
+      'IDX_notifications_read',
+      ['read'],
+    );
+    await this.createIndex(
+      queryRunner,
+      'notifications',
+      'IDX_notifications_type',
+      ['type'],
+    );
+    await this.createIndex(
+      queryRunner,
+      'notifications',
+      'IDX_notifications_severity',
+      ['severity'],
+    );
+    await this.createIndex(
+      queryRunner,
+      'notifications',
+      'IDX_notifications_createdAt',
+      ['createdAt'],
+    );
 
     // notification_delivery_logs
-    await this.createIndex(queryRunner, 'notification_delivery_logs', 'IDX_notification_delivery_logs_userId_createdAt', ['userId', 'createdAt']);
-    await this.createIndex(queryRunner, 'notification_delivery_logs', 'IDX_notification_delivery_logs_status_retryCount', ['status', 'retryCount']);
+    await this.createIndex(
+      queryRunner,
+      'notification_delivery_logs',
+      'IDX_notification_delivery_logs_userId_createdAt',
+      ['userId', 'createdAt'],
+    );
+    await this.createIndex(
+      queryRunner,
+      'notification_delivery_logs',
+      'IDX_notification_delivery_logs_status_retryCount',
+      ['status', 'retryCount'],
+    );
 
     // refresh_tokens
-    await this.createIndex(queryRunner, 'refresh_tokens', 'IDX_refresh_tokens_userId', ['userId']);
-    await this.createIndex(queryRunner, 'refresh_tokens', 'IDX_refresh_tokens_expiresAt', ['expiresAt']);
+    await this.createIndex(
+      queryRunner,
+      'refresh_tokens',
+      'IDX_refresh_tokens_userId',
+      ['userId'],
+    );
+    await this.createIndex(
+      queryRunner,
+      'refresh_tokens',
+      'IDX_refresh_tokens_expiresAt',
+      ['expiresAt'],
+    );
 
     // password_reset_tokens
-    await this.createIndex(queryRunner, 'password_reset_tokens', 'IDX_password_reset_tokens_expiresAt', ['expiresAt']);
+    await this.createIndex(
+      queryRunner,
+      'password_reset_tokens',
+      'IDX_password_reset_tokens_expiresAt',
+      ['expiresAt'],
+    );
 
     // push_tokens
-    await this.createIndex(queryRunner, 'push_tokens', 'IDX_push_tokens_isActive', ['isActive']);
-    await this.createIndex(queryRunner, 'push_tokens', 'IDX_push_tokens_userId_isActive', ['userId', 'isActive']);
+    await this.createIndex(
+      queryRunner,
+      'push_tokens',
+      'IDX_push_tokens_isActive',
+      ['isActive'],
+    );
+    await this.createIndex(
+      queryRunner,
+      'push_tokens',
+      'IDX_push_tokens_userId_isActive',
+      ['userId', 'isActive'],
+    );
 
     // outbox_events
-    await this.createIndex(queryRunner, 'outbox_events', 'IDX_outbox_events_eventType', ['eventType']);
+    await this.createIndex(
+      queryRunner,
+      'outbox_events',
+      'IDX_outbox_events_eventType',
+      ['eventType'],
+    );
 
     // daily_snapshots
-    await this.createIndex(queryRunner, 'daily_snapshots', 'IDX_daily_snapshots_assetSymbol', ['assetSymbol']);
-    await this.createIndex(queryRunner, 'daily_snapshots', 'IDX_daily_snapshots_createdAt', ['createdAt']);
+    await this.createIndex(
+      queryRunner,
+      'daily_snapshots',
+      'IDX_daily_snapshots_assetSymbol',
+      ['assetSymbol'],
+    );
+    await this.createIndex(
+      queryRunner,
+      'daily_snapshots',
+      'IDX_daily_snapshots_createdAt',
+      ['createdAt'],
+    );
 
     // portfolio_snapshots
-    await this.createIndex(queryRunner, 'portfolio_snapshots', 'IDX_portfolio_snapshots_createdAt', ['createdAt']);
+    await this.createIndex(
+      queryRunner,
+      'portfolio_snapshots',
+      'IDX_portfolio_snapshots_createdAt',
+      ['createdAt'],
+    );
 
     // stellar_sync_checkpoints
-    await this.createIndex(queryRunner, 'stellar_sync_checkpoints', 'IDX_stellar_sync_checkpoints_updatedAt', ['updatedAt']);
+    await this.createIndex(
+      queryRunner,
+      'stellar_sync_checkpoints',
+      'IDX_stellar_sync_checkpoints_updatedAt',
+      ['updatedAt'],
+    );
 
     // stellar_processed_events
-    await this.createIndex(queryRunner, 'stellar_processed_events', 'IDX_stellar_processed_events_processedAt', ['processedAt']);
+    await this.createIndex(
+      queryRunner,
+      'stellar_processed_events',
+      'IDX_stellar_processed_events_processedAt',
+      ['processedAt'],
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await this.dropIndex(queryRunner, 'stellar_processed_events', 'IDX_stellar_processed_events_processedAt');
-    await this.dropIndex(queryRunner, 'stellar_sync_checkpoints', 'IDX_stellar_sync_checkpoints_updatedAt');
-    await this.dropIndex(queryRunner, 'portfolio_snapshots', 'IDX_portfolio_snapshots_createdAt');
-    await this.dropIndex(queryRunner, 'daily_snapshots', 'IDX_daily_snapshots_createdAt');
-    await this.dropIndex(queryRunner, 'daily_snapshots', 'IDX_daily_snapshots_assetSymbol');
-    await this.dropIndex(queryRunner, 'outbox_events', 'IDX_outbox_events_eventType');
-    await this.dropIndex(queryRunner, 'push_tokens', 'IDX_push_tokens_userId_isActive');
-    await this.dropIndex(queryRunner, 'push_tokens', 'IDX_push_tokens_isActive');
-    await this.dropIndex(queryRunner, 'password_reset_tokens', 'IDX_password_reset_tokens_expiresAt');
-    await this.dropIndex(queryRunner, 'refresh_tokens', 'IDX_refresh_tokens_expiresAt');
-    await this.dropIndex(queryRunner, 'refresh_tokens', 'IDX_refresh_tokens_userId');
-    await this.dropIndex(queryRunner, 'notification_delivery_logs', 'IDX_notification_delivery_logs_status_retryCount');
-    await this.dropIndex(queryRunner, 'notification_delivery_logs', 'IDX_notification_delivery_logs_userId_createdAt');
-    await this.dropIndex(queryRunner, 'notifications', 'IDX_notifications_createdAt');
-    await this.dropIndex(queryRunner, 'notifications', 'IDX_notifications_severity');
-    await this.dropIndex(queryRunner, 'notifications', 'IDX_notifications_type');
-    await this.dropIndex(queryRunner, 'notifications', 'IDX_notifications_read');
-    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_articles_tags_gin"`);
+    await this.dropIndex(
+      queryRunner,
+      'stellar_processed_events',
+      'IDX_stellar_processed_events_processedAt',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'stellar_sync_checkpoints',
+      'IDX_stellar_sync_checkpoints_updatedAt',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'portfolio_snapshots',
+      'IDX_portfolio_snapshots_createdAt',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'daily_snapshots',
+      'IDX_daily_snapshots_createdAt',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'daily_snapshots',
+      'IDX_daily_snapshots_assetSymbol',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'outbox_events',
+      'IDX_outbox_events_eventType',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'push_tokens',
+      'IDX_push_tokens_userId_isActive',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'push_tokens',
+      'IDX_push_tokens_isActive',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'password_reset_tokens',
+      'IDX_password_reset_tokens_expiresAt',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'refresh_tokens',
+      'IDX_refresh_tokens_expiresAt',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'refresh_tokens',
+      'IDX_refresh_tokens_userId',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'notification_delivery_logs',
+      'IDX_notification_delivery_logs_status_retryCount',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'notification_delivery_logs',
+      'IDX_notification_delivery_logs_userId_createdAt',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'notifications',
+      'IDX_notifications_createdAt',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'notifications',
+      'IDX_notifications_severity',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'notifications',
+      'IDX_notifications_type',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'notifications',
+      'IDX_notifications_read',
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "public"."IDX_articles_tags_gin"`,
+    );
     await this.dropIndex(queryRunner, 'articles', 'IDX_articles_category');
-    await this.dropIndex(queryRunner, 'stellar_accounts', 'IDX_stellar_accounts_isPrimary');
-    await this.dropIndex(queryRunner, 'stellar_accounts', 'IDX_stellar_accounts_isActive');
-    await this.dropIndex(queryRunner, 'stellar_accounts', 'IDX_stellar_accounts_userId');
+    await this.dropIndex(
+      queryRunner,
+      'stellar_accounts',
+      'IDX_stellar_accounts_isPrimary',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'stellar_accounts',
+      'IDX_stellar_accounts_isActive',
+    );
+    await this.dropIndex(
+      queryRunner,
+      'stellar_accounts',
+      'IDX_stellar_accounts_userId',
+    );
   }
 
   private async createIndex(
@@ -84,9 +268,9 @@ export class AddMissingIndexes1770000000001 implements MigrationInterface {
     indexName: string,
     columns: string[],
   ): Promise<void> {
-    const exists: Array<Record<string, unknown>> = await queryRunner.query(
+    const exists = (await queryRunner.query(
       `SELECT 1 FROM pg_indexes WHERE indexname = '${indexName}'`,
-    );
+    )) as Array<Record<string, unknown>>;
     if (exists.length > 0) return;
 
     const cols = columns.map((c) => `"${c}"`).join(', ');
@@ -100,13 +284,11 @@ export class AddMissingIndexes1770000000001 implements MigrationInterface {
     _table: string,
     indexName: string,
   ): Promise<void> {
-    const exists: Array<Record<string, unknown>> = await queryRunner.query(
+    const exists = (await queryRunner.query(
       `SELECT 1 FROM pg_indexes WHERE indexname = '${indexName}'`,
-    );
+    )) as Array<Record<string, unknown>>;
     if (exists.length === 0) return;
 
-    await queryRunner.query(
-      `DROP INDEX "public"."${indexName}"`,
-    );
+    await queryRunner.query(`DROP INDEX "public"."${indexName}"`);
   }
 }

--- a/apps/backend/src/migrations/1745700000000-CreatePortfolioMaterializedSnapshots.ts
+++ b/apps/backend/src/migrations/1745700000000-CreatePortfolioMaterializedSnapshots.ts
@@ -1,8 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class CreatePortfolioMaterializedSnapshots1745700000000
-  implements MigrationInterface
-{
+export class CreatePortfolioMaterializedSnapshots1745700000000 implements MigrationInterface {
   name = 'CreatePortfolioMaterializedSnapshots1745700000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/apps/backend/src/migrations/1745700000000-CreatePortfolioMaterializedSnapshots.ts
+++ b/apps/backend/src/migrations/1745700000000-CreatePortfolioMaterializedSnapshots.ts
@@ -1,0 +1,78 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreatePortfolioMaterializedSnapshots1745700000000
+  implements MigrationInterface
+{
+  name = 'CreatePortfolioMaterializedSnapshots1745700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "portfolio_materialized_snapshots" (
+        "id"                uuid            NOT NULL DEFAULT uuid_generate_v4(),
+        "userId"            uuid            NOT NULL,
+        "totalValueUsd"     decimal(18, 2)  NOT NULL,
+        "assetBalances"     jsonb           NOT NULL DEFAULT '[]',
+        "assetAllocation"   jsonb           DEFAULT NULL,
+        "hasLinkedAccount"  boolean         NOT NULL DEFAULT false,
+        "source_snapshot_id" uuid           NOT NULL,
+        "createdAt"         timestamptz     NOT NULL DEFAULT now(),
+        "updatedAt"         timestamptz     NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_portfolio_materialized_snapshots" PRIMARY KEY ("id")
+      )
+    `);
+
+    // Unique index on userId — one materialized row per user for O(1) lookups
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "UQ_materialized_user"
+        ON "portfolio_materialized_snapshots" ("userId")
+    `);
+
+    // Foreign key to users
+    await queryRunner.query(`
+      ALTER TABLE "portfolio_materialized_snapshots"
+        ADD CONSTRAINT "FK_materialized_user"
+        FOREIGN KEY ("userId") REFERENCES "users"("id")
+        ON DELETE CASCADE ON UPDATE NO ACTION
+    `);
+
+    // Backfill from latest snapshot per user
+    await queryRunner.query(`
+      INSERT INTO "portfolio_materialized_snapshots"
+        ("userId", "totalValueUsd", "assetBalances", "hasLinkedAccount", "source_snapshot_id", "createdAt", "updatedAt")
+      SELECT
+        s."userId",
+        s."totalValueUsd",
+        s."assetBalances",
+        CASE WHEN sa."id" IS NOT NULL THEN true ELSE false END AS "hasLinkedAccount",
+        s."id" AS "source_snapshot_id",
+        now() AS "createdAt",
+        now() AS "updatedAt"
+      FROM (
+        SELECT DISTINCT ON (ps."userId")
+          ps."id",
+          ps."userId",
+          ps."totalValueUsd",
+          ps."assetBalances",
+          ps."createdAt"
+        FROM "portfolio_snapshots" ps
+        ORDER BY ps."userId", ps."createdAt" DESC
+      ) s
+      LEFT JOIN "stellar_accounts" sa ON sa."userId" = s."userId"
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "portfolio_materialized_snapshots"
+        DROP CONSTRAINT "FK_materialized_user"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX "public"."UQ_materialized_user"
+    `);
+
+    await queryRunner.query(`
+      DROP TABLE "portfolio_materialized_snapshots"
+    `);
+  }
+}

--- a/apps/backend/src/news/news-sentiment.spec.ts
+++ b/apps/backend/src/news/news-sentiment.spec.ts
@@ -9,6 +9,7 @@ import { NewsService } from './news.service';
 import { NewsSentimentService } from './news-sentiment.services';
 import { NewsProviderService } from './news-provider.service';
 import { CacheService } from '../cache/cache.service';
+import { QueryProfilerService } from '../common/profiling/query-profiler.service';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -238,6 +239,10 @@ describe('NewsService - sentiment methods', () => {
     getLatestArticles: jest.fn(),
   };
 
+  const mockQueryProfilerService = {
+    profile: jest.fn().mockImplementation(async (fn) => fn()),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -253,6 +258,10 @@ describe('NewsService - sentiment methods', () => {
         {
           provide: CacheService,
           useValue: { invalidateNewsCache: jest.fn() },
+        },
+        {
+          provide: QueryProfilerService,
+          useValue: mockQueryProfilerService,
         },
       ],
     }).compile();

--- a/apps/backend/src/notification/notification-delivery.service.ts
+++ b/apps/backend/src/notification/notification-delivery.service.ts
@@ -305,7 +305,10 @@ export class NotificationDeliveryService implements OnModuleInit {
           order: { createdAt: 'DESC' },
           take: limit,
         }),
-      { label: 'NotificationDeliveryService.getDeliveryLogsForUser', thresholdMs: 150 },
+      {
+        label: 'NotificationDeliveryService.getDeliveryLogsForUser',
+        thresholdMs: 150,
+      },
     );
   }
 

--- a/apps/backend/src/portfolio/entities/portfolio-materialized-snapshot.entity.ts
+++ b/apps/backend/src/portfolio/entities/portfolio-materialized-snapshot.entity.ts
@@ -44,13 +44,15 @@ export class PortfolioMaterializedSnapshot {
 
   /** Pre-computed asset allocation with percentages. */
   @Column({ type: 'jsonb', nullable: true })
-  assetAllocation: {
-    assetCode: string;
-    assetIssuer: string | null;
-    amount: string;
-    valueUsd: number;
-    percentage: number;
-  }[] | null;
+  assetAllocation:
+    | {
+        assetCode: string;
+        assetIssuer: string | null;
+        amount: string;
+        valueUsd: number;
+        percentage: number;
+      }[]
+    | null;
 
   /** Whether the user has at least one linked Stellar account. */
   @Column({ type: 'boolean', default: false })

--- a/apps/backend/src/portfolio/entities/portfolio-materialized-snapshot.entity.ts
+++ b/apps/backend/src/portfolio/entities/portfolio-materialized-snapshot.entity.ts
@@ -1,0 +1,72 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+/**
+ * Materialized view of the latest portfolio snapshot per user.
+ *
+ * One row per user — updated on every snapshot creation so that
+ * summary / allocation endpoints can serve reads without recomputing
+ * balances from raw events or hitting the Stellar network.
+ *
+ * The unique index on userId guarantees O(1) lookups for the fast-read path.
+ */
+@Entity('portfolio_materialized_snapshots')
+@Index('UQ_materialized_user', ['userId'], { unique: true })
+export class PortfolioMaterializedSnapshot {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** The user this materialized row belongs to. */
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  /** Total portfolio value in USD at the time of the source snapshot. */
+  @Column({ type: 'decimal', precision: 18, scale: 2 })
+  totalValueUsd: string;
+
+  /** Pre-computed asset balances from the source snapshot. */
+  @Column({ type: 'jsonb' })
+  assetBalances: {
+    assetCode: string;
+    assetIssuer: string | null;
+    amount: string;
+    valueUsd: number;
+  }[];
+
+  /** Pre-computed asset allocation with percentages. */
+  @Column({ type: 'jsonb', nullable: true })
+  assetAllocation: {
+    assetCode: string;
+    assetIssuer: string | null;
+    amount: string;
+    valueUsd: number;
+    percentage: number;
+  }[] | null;
+
+  /** Whether the user has at least one linked Stellar account. */
+  @Column({ type: 'boolean', default: false })
+  hasLinkedAccount: boolean;
+
+  /** ID of the portfolio_snapshot this row was materialized from. */
+  @Column({ type: 'uuid', name: 'source_snapshot_id' })
+  sourceSnapshotId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/apps/backend/src/portfolio/materialized-snapshot.service.spec.ts
+++ b/apps/backend/src/portfolio/materialized-snapshot.service.spec.ts
@@ -237,14 +237,14 @@ describe('MaterializedSnapshotService', () => {
           assetIssuer: null,
           amount: '1000.0000',
           valueUsd: 100.0,
-          percentage: expectCloseTo(16.6667, 0.01),
+          percentage: expectCloseTo.create(16.6667, 0.01),
         },
         {
           assetCode: 'USDC',
           assetIssuer: 'issuer-abc',
           amount: '500.0000',
           valueUsd: 500.0,
-          percentage: expectCloseTo(83.3333, 0.01),
+          percentage: expectCloseTo.create(83.3333, 0.01),
         },
       ]);
     });

--- a/apps/backend/src/portfolio/materialized-snapshot.service.spec.ts
+++ b/apps/backend/src/portfolio/materialized-snapshot.service.spec.ts
@@ -10,7 +10,12 @@ const SNAPSHOT_ID = 'snapshot-456';
 
 const makeAssetBalances = () => [
   { assetCode: 'XLM', assetIssuer: null, amount: '1000.0000', valueUsd: 100.0 },
-  { assetCode: 'USDC', assetIssuer: 'issuer-abc', amount: '500.0000', valueUsd: 500.0 },
+  {
+    assetCode: 'USDC',
+    assetIssuer: 'issuer-abc',
+    amount: '500.0000',
+    valueUsd: 500.0,
+  },
 ];
 
 const makeMaterializedRow = (
@@ -22,8 +27,20 @@ const makeMaterializedRow = (
     totalValueUsd: '600.00',
     assetBalances: makeAssetBalances(),
     assetAllocation: [
-      { assetCode: 'XLM', assetIssuer: null, amount: '1000.0000', valueUsd: 100.0, percentage: 16.6667 },
-      { assetCode: 'USDC', assetIssuer: 'issuer-abc', amount: '500.0000', valueUsd: 500.0, percentage: 83.3333 },
+      {
+        assetCode: 'XLM',
+        assetIssuer: null,
+        amount: '1000.0000',
+        valueUsd: 100.0,
+        percentage: 16.6667,
+      },
+      {
+        assetCode: 'USDC',
+        assetIssuer: 'issuer-abc',
+        amount: '500.0000',
+        valueUsd: 500.0,
+        percentage: 83.3333,
+      },
     ],
     hasLinkedAccount: true,
     sourceSnapshotId: SNAPSHOT_ID,
@@ -69,7 +86,9 @@ describe('MaterializedSnapshotService', () => {
     }).compile();
 
     service = module.get(MaterializedSnapshotService);
-    materializedRepo = module.get(getRepositoryToken(PortfolioMaterializedSnapshot));
+    materializedRepo = module.get(
+      getRepositoryToken(PortfolioMaterializedSnapshot),
+    );
     snapshotRepo = module.get(getRepositoryToken(PortfolioSnapshot));
   });
 
@@ -101,7 +120,9 @@ describe('MaterializedSnapshotService', () => {
     it('updates an existing materialized snapshot', async () => {
       const existing = makeMaterializedRow();
       materializedRepo.findOne.mockResolvedValue(existing);
-      materializedRepo.save.mockImplementation(async (entity) => entity as PortfolioMaterializedSnapshot);
+      materializedRepo.save.mockImplementation((entity) =>
+        Promise.resolve(entity as PortfolioMaterializedSnapshot),
+      );
 
       const result = await service.upsertForUser({
         userId: USER_ID,
@@ -125,7 +146,9 @@ describe('MaterializedSnapshotService', () => {
       const existing = makeMaterializedRow();
       const originalAllocation = existing.assetAllocation;
       materializedRepo.findOne.mockResolvedValue(existing);
-      materializedRepo.save.mockImplementation(async (entity) => entity as PortfolioMaterializedSnapshot);
+      materializedRepo.save.mockImplementation((entity) =>
+        Promise.resolve(entity as PortfolioMaterializedSnapshot),
+      );
 
       await service.upsertForUser({
         userId: USER_ID,
@@ -196,19 +219,33 @@ describe('MaterializedSnapshotService', () => {
       snapshotRepo.findOne.mockResolvedValue(snapshot);
 
       materializedRepo.findOne.mockResolvedValue(null);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
       let savedData: any = null;
       materializedRepo.create.mockImplementation((data: any) => {
         savedData = data;
         return data as PortfolioMaterializedSnapshot;
       });
-      materializedRepo.save.mockImplementation(async (entity) => entity as PortfolioMaterializedSnapshot);
+      materializedRepo.save.mockImplementation((entity) =>
+        Promise.resolve(entity as PortfolioMaterializedSnapshot),
+      );
 
       await service.refreshForUser(USER_ID);
 
       expect(savedData.assetAllocation).toEqual([
-        { assetCode: 'XLM', assetIssuer: null, amount: '1000.0000', valueUsd: 100.0, percentage: expectCloseTo(16.6667, 0.01) },
-        { assetCode: 'USDC', assetIssuer: 'issuer-abc', amount: '500.0000', valueUsd: 500.0, percentage: expectCloseTo(83.3333, 0.01) },
+        {
+          assetCode: 'XLM',
+          assetIssuer: null,
+          amount: '1000.0000',
+          valueUsd: 100.0,
+          percentage: expectCloseTo(16.6667, 0.01),
+        },
+        {
+          assetCode: 'USDC',
+          assetIssuer: 'issuer-abc',
+          amount: '500.0000',
+          valueUsd: 500.0,
+          percentage: expectCloseTo(83.3333, 0.01),
+        },
       ]);
     });
   });
@@ -268,7 +305,12 @@ describe('MaterializedSnapshotService', () => {
 
     it('preserves asset fields in the output', () => {
       const balances = [
-        { assetCode: 'XLM', assetIssuer: 'issuer-123', amount: '500.00', valueUsd: 250 },
+        {
+          assetCode: 'XLM',
+          assetIssuer: 'issuer-123',
+          amount: '500.00',
+          valueUsd: 250,
+        },
       ];
 
       const result = service.computeAllocation(balances);
@@ -285,11 +327,8 @@ describe('MaterializedSnapshotService', () => {
 /**
  * Custom Jest matcher helper for close-to percentage checks.
  */
-function expectCloseTo(expected: number, tolerance: number) {
-  return expectCloseTo.create(expected, tolerance);
-}
-namespace expectCloseTo {
-  export function create(expected: number, tolerance: number) {
+const expectCloseTo = {
+  create(expected: number, tolerance: number) {
     return {
       $$typeof: Symbol.for('jest.asymmetricMatcher'),
       asymmetricMatch(received: number) {
@@ -299,5 +338,5 @@ namespace expectCloseTo {
         return `expectCloseTo(${expected}, ±${tolerance})`;
       },
     };
-  }
-}
+  },
+};

--- a/apps/backend/src/portfolio/materialized-snapshot.service.spec.ts
+++ b/apps/backend/src/portfolio/materialized-snapshot.service.spec.ts
@@ -1,0 +1,303 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MaterializedSnapshotService } from './materialized-snapshot.service';
+import { PortfolioMaterializedSnapshot } from './entities/portfolio-materialized-snapshot.entity';
+import { PortfolioSnapshot } from './entities/portfolio-snapshot.entity';
+
+const USER_ID = 'user-123';
+const SNAPSHOT_ID = 'snapshot-456';
+
+const makeAssetBalances = () => [
+  { assetCode: 'XLM', assetIssuer: null, amount: '1000.0000', valueUsd: 100.0 },
+  { assetCode: 'USDC', assetIssuer: 'issuer-abc', amount: '500.0000', valueUsd: 500.0 },
+];
+
+const makeMaterializedRow = (
+  overrides: Partial<PortfolioMaterializedSnapshot> = {},
+): PortfolioMaterializedSnapshot =>
+  ({
+    id: 'mat-789',
+    userId: USER_ID,
+    totalValueUsd: '600.00',
+    assetBalances: makeAssetBalances(),
+    assetAllocation: [
+      { assetCode: 'XLM', assetIssuer: null, amount: '1000.0000', valueUsd: 100.0, percentage: 16.6667 },
+      { assetCode: 'USDC', assetIssuer: 'issuer-abc', amount: '500.0000', valueUsd: 500.0, percentage: 83.3333 },
+    ],
+    hasLinkedAccount: true,
+    sourceSnapshotId: SNAPSHOT_ID,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  }) as PortfolioMaterializedSnapshot;
+
+const makeSnapshot = (): PortfolioSnapshot =>
+  ({
+    id: SNAPSHOT_ID,
+    userId: USER_ID,
+    assetBalances: makeAssetBalances(),
+    totalValueUsd: '600.00',
+    createdAt: new Date(),
+  }) as PortfolioSnapshot;
+
+describe('MaterializedSnapshotService', () => {
+  let service: MaterializedSnapshotService;
+  let materializedRepo: jest.Mocked<Repository<PortfolioMaterializedSnapshot>>;
+  let snapshotRepo: jest.Mocked<Repository<PortfolioSnapshot>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MaterializedSnapshotService,
+        {
+          provide: getRepositoryToken(PortfolioMaterializedSnapshot),
+          useValue: {
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(PortfolioSnapshot),
+          useValue: {
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(MaterializedSnapshotService);
+    materializedRepo = module.get(getRepositoryToken(PortfolioMaterializedSnapshot));
+    snapshotRepo = module.get(getRepositoryToken(PortfolioSnapshot));
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('upsertForUser', () => {
+    it('creates a new materialized snapshot when none exists', async () => {
+      materializedRepo.findOne.mockResolvedValue(null);
+      const newRow = makeMaterializedRow();
+      materializedRepo.create.mockReturnValue(newRow);
+      materializedRepo.save.mockResolvedValue(newRow);
+
+      const result = await service.upsertForUser({
+        userId: USER_ID,
+        totalValueUsd: '600.00',
+        assetBalances: makeAssetBalances(),
+        hasLinkedAccount: true,
+        sourceSnapshotId: SNAPSHOT_ID,
+      });
+
+      expect(materializedRepo.findOne).toHaveBeenCalledWith({
+        where: { userId: USER_ID },
+      });
+      expect(materializedRepo.create).toHaveBeenCalled();
+      expect(materializedRepo.save).toHaveBeenCalled();
+      expect(result).toBe(newRow);
+    });
+
+    it('updates an existing materialized snapshot', async () => {
+      const existing = makeMaterializedRow();
+      materializedRepo.findOne.mockResolvedValue(existing);
+      materializedRepo.save.mockImplementation(async (entity) => entity as PortfolioMaterializedSnapshot);
+
+      const result = await service.upsertForUser({
+        userId: USER_ID,
+        totalValueUsd: '900.00',
+        assetBalances: makeAssetBalances(),
+        assetAllocation: null,
+        hasLinkedAccount: true,
+        sourceSnapshotId: 'new-snapshot-id',
+      });
+
+      expect(materializedRepo.findOne).toHaveBeenCalledWith({
+        where: { userId: USER_ID },
+      });
+      expect(existing.totalValueUsd).toBe('900.00');
+      expect(existing.sourceSnapshotId).toBe('new-snapshot-id');
+      expect(materializedRepo.save).toHaveBeenCalledWith(existing);
+      expect(result.totalValueUsd).toBe('900.00');
+    });
+
+    it('preserves existing assetAllocation when not provided in update', async () => {
+      const existing = makeMaterializedRow();
+      const originalAllocation = existing.assetAllocation;
+      materializedRepo.findOne.mockResolvedValue(existing);
+      materializedRepo.save.mockImplementation(async (entity) => entity as PortfolioMaterializedSnapshot);
+
+      await service.upsertForUser({
+        userId: USER_ID,
+        totalValueUsd: '700.00',
+        assetBalances: makeAssetBalances(),
+        hasLinkedAccount: true,
+        sourceSnapshotId: SNAPSHOT_ID,
+        // assetAllocation not provided — should keep existing
+      });
+
+      expect(existing.assetAllocation).toBe(originalAllocation);
+    });
+  });
+
+  describe('getForUser', () => {
+    it('returns the materialized snapshot when it exists', async () => {
+      const row = makeMaterializedRow();
+      materializedRepo.findOne.mockResolvedValue(row);
+
+      const result = await service.getForUser(USER_ID);
+
+      expect(materializedRepo.findOne).toHaveBeenCalledWith({
+        where: { userId: USER_ID },
+      });
+      expect(result).toBe(row);
+    });
+
+    it('returns null when no materialized snapshot exists', async () => {
+      materializedRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.getForUser(USER_ID);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('refreshForUser', () => {
+    it('returns false when user has no snapshots', async () => {
+      snapshotRepo.findOne.mockResolvedValue(null);
+
+      const result = await service.refreshForUser(USER_ID);
+
+      expect(result).toBe(false);
+      expect(materializedRepo.save).not.toHaveBeenCalled();
+    });
+
+    it('upserts materialized snapshot from latest snapshot data', async () => {
+      const snapshot = makeSnapshot();
+      snapshotRepo.findOne.mockResolvedValue(snapshot);
+
+      const newRow = makeMaterializedRow();
+      materializedRepo.findOne.mockResolvedValue(null);
+      materializedRepo.create.mockReturnValue(newRow);
+      materializedRepo.save.mockResolvedValue(newRow);
+
+      const result = await service.refreshForUser(USER_ID);
+
+      expect(result).toBe(true);
+      expect(snapshotRepo.findOne).toHaveBeenCalledWith({
+        where: { userId: USER_ID },
+        order: { createdAt: 'DESC' },
+      });
+      expect(materializedRepo.save).toHaveBeenCalled();
+    });
+
+    it('computes allocation with correct percentages', async () => {
+      const snapshot = makeSnapshot();
+      snapshotRepo.findOne.mockResolvedValue(snapshot);
+
+      materializedRepo.findOne.mockResolvedValue(null);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let savedData: any = null;
+      materializedRepo.create.mockImplementation((data: any) => {
+        savedData = data;
+        return data as PortfolioMaterializedSnapshot;
+      });
+      materializedRepo.save.mockImplementation(async (entity) => entity as PortfolioMaterializedSnapshot);
+
+      await service.refreshForUser(USER_ID);
+
+      expect(savedData.assetAllocation).toEqual([
+        { assetCode: 'XLM', assetIssuer: null, amount: '1000.0000', valueUsd: 100.0, percentage: expectCloseTo(16.6667, 0.01) },
+        { assetCode: 'USDC', assetIssuer: 'issuer-abc', amount: '500.0000', valueUsd: 500.0, percentage: expectCloseTo(83.3333, 0.01) },
+      ]);
+    });
+  });
+
+  describe('deleteForUser', () => {
+    it('deletes the materialized snapshot for the user', async () => {
+      materializedRepo.delete.mockResolvedValue({ affected: 1 } as any);
+
+      await service.deleteForUser(USER_ID);
+
+      expect(materializedRepo.delete).toHaveBeenCalledWith({ userId: USER_ID });
+    });
+  });
+
+  describe('computeAllocation', () => {
+    it('computes correct percentages for multiple assets', () => {
+      const balances = [
+        { assetCode: 'XLM', assetIssuer: null, amount: '1000', valueUsd: 200 },
+        { assetCode: 'USDC', assetIssuer: 'abc', amount: '500', valueUsd: 800 },
+      ];
+
+      const result = service.computeAllocation(balances);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].percentage).toBeCloseTo(20, 1); // 200/1000 * 100
+      expect(result[1].percentage).toBeCloseTo(80, 1); // 800/1000 * 100
+    });
+
+    it('returns 0% for all assets when total value is 0', () => {
+      const balances = [
+        { assetCode: 'XLM', assetIssuer: null, amount: '1000', valueUsd: 0 },
+        { assetCode: 'USDC', assetIssuer: 'abc', amount: '500', valueUsd: 0 },
+      ];
+
+      const result = service.computeAllocation(balances);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].percentage).toBe(0);
+      expect(result[1].percentage).toBe(0);
+    });
+
+    it('returns 100% for a single asset', () => {
+      const balances = [
+        { assetCode: 'XLM', assetIssuer: null, amount: '1000', valueUsd: 500 },
+      ];
+
+      const result = service.computeAllocation(balances);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].percentage).toBe(100);
+    });
+
+    it('handles empty balances array', () => {
+      const result = service.computeAllocation([]);
+      expect(result).toHaveLength(0);
+    });
+
+    it('preserves asset fields in the output', () => {
+      const balances = [
+        { assetCode: 'XLM', assetIssuer: 'issuer-123', amount: '500.00', valueUsd: 250 },
+      ];
+
+      const result = service.computeAllocation(balances);
+
+      expect(result[0].assetCode).toBe('XLM');
+      expect(result[0].assetIssuer).toBe('issuer-123');
+      expect(result[0].amount).toBe('500.00');
+      expect(result[0].valueUsd).toBe(250);
+      expect(result[0].percentage).toBe(100);
+    });
+  });
+});
+
+/**
+ * Custom Jest matcher helper for close-to percentage checks.
+ */
+function expectCloseTo(expected: number, tolerance: number) {
+  return expectCloseTo.create(expected, tolerance);
+}
+namespace expectCloseTo {
+  export function create(expected: number, tolerance: number) {
+    return {
+      $$typeof: Symbol.for('jest.asymmetricMatcher'),
+      asymmetricMatch(received: number) {
+        return Math.abs(received - expected) <= tolerance;
+      },
+      toString() {
+        return `expectCloseTo(${expected}, ±${tolerance})`;
+      },
+    };
+  }
+}

--- a/apps/backend/src/portfolio/materialized-snapshot.service.ts
+++ b/apps/backend/src/portfolio/materialized-snapshot.service.ts
@@ -13,13 +13,15 @@ export interface MaterializedSnapshotData {
     amount: string;
     valueUsd: number;
   }[];
-  assetAllocation?: {
-    assetCode: string;
-    assetIssuer: string | null;
-    amount: string;
-    valueUsd: number;
-    percentage: number;
-  }[] | null;
+  assetAllocation?:
+    | {
+        assetCode: string;
+        assetIssuer: string | null;
+        amount: string;
+        valueUsd: number;
+        percentage: number;
+      }[]
+    | null;
   hasLinkedAccount: boolean;
   sourceSnapshotId: string;
 }
@@ -41,8 +43,12 @@ export class MaterializedSnapshotService {
    * Uses the unique constraint on userId so that re-running always
    * updates the single existing row rather than creating duplicates.
    */
-  async upsertForUser(data: MaterializedSnapshotData): Promise<PortfolioMaterializedSnapshot> {
-    this.logger.debug(`Upserting materialized snapshot for user ${data.userId}`);
+  async upsertForUser(
+    data: MaterializedSnapshotData,
+  ): Promise<PortfolioMaterializedSnapshot> {
+    this.logger.debug(
+      `Upserting materialized snapshot for user ${data.userId}`,
+    );
 
     const existing = await this.materializedRepo.findOne({
       where: { userId: data.userId },
@@ -51,7 +57,8 @@ export class MaterializedSnapshotService {
     if (existing) {
       existing.totalValueUsd = data.totalValueUsd;
       existing.assetBalances = data.assetBalances;
-      existing.assetAllocation = data.assetAllocation ?? existing.assetAllocation;
+      existing.assetAllocation =
+        data.assetAllocation ?? existing.assetAllocation;
       existing.hasLinkedAccount = data.hasLinkedAccount;
       existing.sourceSnapshotId = data.sourceSnapshotId;
       return this.materializedRepo.save(existing);
@@ -74,7 +81,9 @@ export class MaterializedSnapshotService {
    * Returns null when no materialized row exists — the caller should
    * fall back to computing from raw data in that case.
    */
-  async getForUser(userId: string): Promise<PortfolioMaterializedSnapshot | null> {
+  async getForUser(
+    userId: string,
+  ): Promise<PortfolioMaterializedSnapshot | null> {
     return this.materializedRepo.findOne({
       where: { userId },
     });
@@ -94,7 +103,9 @@ export class MaterializedSnapshotService {
     });
 
     if (!latestSnapshot) {
-      this.logger.debug(`No snapshot found for user ${userId} — skipping refresh`);
+      this.logger.debug(
+        `No snapshot found for user ${userId} — skipping refresh`,
+      );
       return false;
     }
 
@@ -144,7 +155,8 @@ export class MaterializedSnapshotService {
       assetIssuer: asset.assetIssuer,
       amount: asset.amount,
       valueUsd: asset.valueUsd,
-      percentage: totalValueUsd > 0 ? (asset.valueUsd / totalValueUsd) * 100 : 0,
+      percentage:
+        totalValueUsd > 0 ? (asset.valueUsd / totalValueUsd) * 100 : 0,
     }));
   }
 }

--- a/apps/backend/src/portfolio/materialized-snapshot.service.ts
+++ b/apps/backend/src/portfolio/materialized-snapshot.service.ts
@@ -1,0 +1,150 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PortfolioMaterializedSnapshot } from './entities/portfolio-materialized-snapshot.entity';
+import { PortfolioSnapshot } from './entities/portfolio-snapshot.entity';
+
+export interface MaterializedSnapshotData {
+  userId: string;
+  totalValueUsd: string;
+  assetBalances: {
+    assetCode: string;
+    assetIssuer: string | null;
+    amount: string;
+    valueUsd: number;
+  }[];
+  assetAllocation?: {
+    assetCode: string;
+    assetIssuer: string | null;
+    amount: string;
+    valueUsd: number;
+    percentage: number;
+  }[] | null;
+  hasLinkedAccount: boolean;
+  sourceSnapshotId: string;
+}
+
+@Injectable()
+export class MaterializedSnapshotService {
+  private readonly logger = new Logger(MaterializedSnapshotService.name);
+
+  constructor(
+    @InjectRepository(PortfolioMaterializedSnapshot)
+    private readonly materializedRepo: Repository<PortfolioMaterializedSnapshot>,
+    @InjectRepository(PortfolioSnapshot)
+    private readonly snapshotRepo: Repository<PortfolioSnapshot>,
+  ) {}
+
+  /**
+   * Upsert a materialized snapshot for a user.
+   *
+   * Uses the unique constraint on userId so that re-running always
+   * updates the single existing row rather than creating duplicates.
+   */
+  async upsertForUser(data: MaterializedSnapshotData): Promise<PortfolioMaterializedSnapshot> {
+    this.logger.debug(`Upserting materialized snapshot for user ${data.userId}`);
+
+    const existing = await this.materializedRepo.findOne({
+      where: { userId: data.userId },
+    });
+
+    if (existing) {
+      existing.totalValueUsd = data.totalValueUsd;
+      existing.assetBalances = data.assetBalances;
+      existing.assetAllocation = data.assetAllocation ?? existing.assetAllocation;
+      existing.hasLinkedAccount = data.hasLinkedAccount;
+      existing.sourceSnapshotId = data.sourceSnapshotId;
+      return this.materializedRepo.save(existing);
+    }
+
+    const materialized = this.materializedRepo.create({
+      userId: data.userId,
+      totalValueUsd: data.totalValueUsd,
+      assetBalances: data.assetBalances,
+      assetAllocation: data.assetAllocation ?? null,
+      hasLinkedAccount: data.hasLinkedAccount,
+      sourceSnapshotId: data.sourceSnapshotId,
+    });
+    return this.materializedRepo.save(materialized);
+  }
+
+  /**
+   * Fast-read path: fetch the materialized snapshot for a user.
+   *
+   * Returns null when no materialized row exists — the caller should
+   * fall back to computing from raw data in that case.
+   */
+  async getForUser(userId: string): Promise<PortfolioMaterializedSnapshot | null> {
+    return this.materializedRepo.findOne({
+      where: { userId },
+    });
+  }
+
+  /**
+   * Refresh the materialized snapshot for a single user by looking up
+   * their latest portfolio snapshot and re-computing allocation data.
+   *
+   * Returns true if a row was updated/created, false if the user has
+   * no snapshots at all.
+   */
+  async refreshForUser(userId: string): Promise<boolean> {
+    const latestSnapshot = await this.snapshotRepo.findOne({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+
+    if (!latestSnapshot) {
+      this.logger.debug(`No snapshot found for user ${userId} — skipping refresh`);
+      return false;
+    }
+
+    const allocation = this.computeAllocation(latestSnapshot.assetBalances);
+
+    await this.upsertForUser({
+      userId,
+      totalValueUsd: latestSnapshot.totalValueUsd,
+      assetBalances: latestSnapshot.assetBalances,
+      assetAllocation: allocation,
+      hasLinkedAccount: true, // If they have a snapshot they had a linked account
+      sourceSnapshotId: latestSnapshot.id,
+    });
+
+    return true;
+  }
+
+  /**
+   * Delete the materialized snapshot for a user.
+   * Used when a user is deleted or when a forced recompute is needed.
+   */
+  async deleteForUser(userId: string): Promise<void> {
+    await this.materializedRepo.delete({ userId });
+  }
+
+  /**
+   * Compute asset allocation with percentages from asset balances.
+   */
+  computeAllocation(
+    assetBalances: {
+      assetCode: string;
+      assetIssuer: string | null;
+      amount: string;
+      valueUsd: number;
+    }[],
+  ): {
+    assetCode: string;
+    assetIssuer: string | null;
+    amount: string;
+    valueUsd: number;
+    percentage: number;
+  }[] {
+    const totalValueUsd = assetBalances.reduce((sum, a) => sum + a.valueUsd, 0);
+
+    return assetBalances.map((asset) => ({
+      assetCode: asset.assetCode,
+      assetIssuer: asset.assetIssuer,
+      amount: asset.amount,
+      valueUsd: asset.valueUsd,
+      percentage: totalValueUsd > 0 ? (asset.valueUsd / totalValueUsd) * 100 : 0,
+    }));
+  }
+}

--- a/apps/backend/src/portfolio/portfolio.module.ts
+++ b/apps/backend/src/portfolio/portfolio.module.ts
@@ -27,7 +27,12 @@ import { MaterializedSnapshotService } from './materialized-snapshot.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([PortfolioAsset, PortfolioSnapshot, PortfolioMaterializedSnapshot, User]),
+    TypeOrmModule.forFeature([
+      PortfolioAsset,
+      PortfolioSnapshot,
+      PortfolioMaterializedSnapshot,
+      User,
+    ]),
     MetricsModule,
     ExchangeRatesModule,
     StellarModule,
@@ -67,6 +72,11 @@ import { MaterializedSnapshotService } from './materialized-snapshot.service';
       inject: [PORTFOLIO_SNAPSHOT_CONNECTION],
     },
   ],
-  exports: [PortfolioService, MaterializedSnapshotService, PortfolioSnapshotQueueService, TypeOrmModule],
+  exports: [
+    PortfolioService,
+    MaterializedSnapshotService,
+    PortfolioSnapshotQueueService,
+    TypeOrmModule,
+  ],
 })
 export class PortfolioModule {}

--- a/apps/backend/src/portfolio/portfolio.module.ts
+++ b/apps/backend/src/portfolio/portfolio.module.ts
@@ -6,6 +6,7 @@ import { Queue } from 'bullmq';
 import IORedis from 'ioredis';
 import { PortfolioAsset } from './portfolio-asset.entity';
 import { PortfolioSnapshot } from './entities/portfolio-snapshot.entity';
+import { PortfolioMaterializedSnapshot } from './entities/portfolio-materialized-snapshot.entity';
 import { User } from '../users/entities/user.entity';
 import { PortfolioService } from './portfolio.service';
 import { PortfolioController } from './portfolio.controller';
@@ -22,10 +23,11 @@ import { PortfolioSnapshotWorker } from './queue/portfolio-snapshot.worker';
 import { ExchangeRatesModule } from '../exchange-rates/exchange-rates.module';
 import { StellarModule } from '../stellar/stellar.module';
 import { PriceModule } from '../price/price.module';
+import { MaterializedSnapshotService } from './materialized-snapshot.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([PortfolioAsset, PortfolioSnapshot, User]),
+    TypeOrmModule.forFeature([PortfolioAsset, PortfolioSnapshot, PortfolioMaterializedSnapshot, User]),
     MetricsModule,
     ExchangeRatesModule,
     StellarModule,
@@ -34,6 +36,7 @@ import { PriceModule } from '../price/price.module';
   controllers: [PortfolioController],
   providers: [
     PortfolioService,
+    MaterializedSnapshotService,
     StellarBalanceService,
     PortfolioSnapshotProgressStore,
     PortfolioSnapshotQueueService,
@@ -64,6 +67,6 @@ import { PriceModule } from '../price/price.module';
       inject: [PORTFOLIO_SNAPSHOT_CONNECTION],
     },
   ],
-  exports: [PortfolioService, PortfolioSnapshotQueueService, TypeOrmModule],
+  exports: [PortfolioService, MaterializedSnapshotService, PortfolioSnapshotQueueService, TypeOrmModule],
 })
 export class PortfolioModule {}

--- a/apps/backend/src/portfolio/portfolio.service.ts
+++ b/apps/backend/src/portfolio/portfolio.service.ts
@@ -147,10 +147,9 @@ export class PortfolioService {
       });
     } catch (error: unknown) {
       // Log but don't fail the snapshot creation if materialization fails
+      const message = error instanceof Error ? error.message : 'Unknown error';
       this.logger.warn(
-        `Failed to update materialized snapshot for user ${userId}: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }`,
+        `Failed to update materialized snapshot for user ${userId}: ${message}`,
       );
     }
 
@@ -250,10 +249,9 @@ export class PortfolioService {
 
     // Populate materialized snapshot for future fast reads
     try {
-      const allocation =
-        this.materializedSnapshotService.computeAllocation(
-          latestSnapshot.assetBalances,
-        );
+      const allocation = this.materializedSnapshotService.computeAllocation(
+        latestSnapshot.assetBalances,
+      );
       await this.materializedSnapshotService.upsertForUser({
         userId,
         totalValueUsd: latestSnapshot.totalValueUsd,
@@ -263,10 +261,9 @@ export class PortfolioService {
         sourceSnapshotId: latestSnapshot.id,
       });
     } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
       this.logger.warn(
-        `Failed to backfill materialized snapshot for user ${userId}: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }`,
+        `Failed to backfill materialized snapshot for user ${userId}: ${message}`,
       );
     }
 
@@ -385,11 +382,8 @@ export class PortfolioService {
         `Snapshot batch queued (cron). BatchId=${progress.batchId}`,
       );
     } catch (error: unknown) {
-      this.logger.error(
-        `Failed to queue snapshot batch job: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }`,
-      );
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Failed to queue snapshot batch job: ${message}`);
     }
   }
 
@@ -405,7 +399,7 @@ export class PortfolioService {
     try {
       // Refresh materialized snapshots for users that have snapshots
       // but no materialized row (migration gap or upsert failure)
-      const staleUsers = await this.snapshotRepository
+      const staleUsers: { userId: string }[] = await this.snapshotRepository
         .createQueryBuilder('ps')
         .select('ps.userId', 'userId')
         .groupBy('ps.userId')
@@ -421,10 +415,10 @@ export class PortfolioService {
             await this.materializedSnapshotService.refreshForUser(userId);
           if (didRefresh) refreshed++;
         } catch (error: unknown) {
+          const message =
+            error instanceof Error ? error.message : 'Unknown error';
           this.logger.warn(
-            `Failed to refresh materialized snapshot for user ${userId}: ${
-              error instanceof Error ? error.message : 'Unknown error'
-           }`,
+            `Failed to refresh materialized snapshot for user ${userId}: ${message}`,
           );
         }
       }
@@ -433,11 +427,8 @@ export class PortfolioService {
         `Materialized snapshot refresh complete. Refreshed ${refreshed} users.`,
       );
     } catch (error: unknown) {
-      this.logger.error(
-        `Materialized snapshot refresh failed: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }`,
-      );
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      this.logger.error(`Materialized snapshot refresh failed: ${message}`);
     }
   }
 
@@ -552,7 +543,9 @@ export class PortfolioService {
         .getAccountBalances(account.publicKey)
         .catch((error) => {
           this.logger.warn(
-            `Failed to fetch balances for account ${account.publicKey}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            `Failed to fetch balances for account ${account.publicKey}: ${
+              error instanceof Error ? error.message : 'Unknown error'
+            }`,
           );
           return []; // Return empty array on failure to not break Promise.all
         }),

--- a/apps/backend/src/portfolio/portfolio.service.ts
+++ b/apps/backend/src/portfolio/portfolio.service.ts
@@ -225,24 +225,24 @@ export class PortfolioService {
       relations: ['stellarAccounts'],
     });
 
-        const hasLinkedAccount =
-          user?.stellarAccounts && user.stellarAccounts.length > 0;
+    const hasLinkedAccount =
+      user?.stellarAccounts && user.stellarAccounts.length > 0;
 
-        if (!hasLinkedAccount) {
-          this.logger.log(`User ${userId} has no linked Stellar accounts`);
-          return {
-            totalValueUsd: '0.00',
-            assets: [],
-            lastUpdated: null,
-            hasLinkedAccount: false,
-          };
-        }
+    if (!hasLinkedAccount) {
+      this.logger.log(`User ${userId} has no linked Stellar accounts`);
+      return {
+        totalValueUsd: '0.00',
+        assets: [],
+        lastUpdated: null,
+        hasLinkedAccount: false,
+      };
+    }
 
-        // User has linked accounts, try to get the latest snapshot
-        const latestSnapshot = await this.snapshotRepository.findOne({
-          where: { userId },
-          order: { createdAt: 'DESC' },
-        });
+    // User has linked accounts, try to get the latest snapshot
+    const latestSnapshot = await this.snapshotRepository.findOne({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
 
     if (!latestSnapshot) {
       return {

--- a/apps/backend/src/portfolio/portfolio.service.ts
+++ b/apps/backend/src/portfolio/portfolio.service.ts
@@ -23,6 +23,7 @@ import { calculatePortfolioPerformance } from './utils/portfolio-performance.uti
 import { PortfolioSnapshotQueueService } from './queue/portfolio-snapshot.queue.service';
 import { PortfolioSnapshotBatchStatus } from './queue/portfolio-snapshot.types';
 import { ExchangeRatesService } from '../exchange-rates/exchange-rates.service';
+import { MaterializedSnapshotService } from './materialized-snapshot.service';
 
 @Injectable()
 export class PortfolioService {
@@ -40,6 +41,7 @@ export class PortfolioService {
     private readonly stellarService: StellarService,
     private readonly priceService: PriceService,
     private readonly snapshotQueueService: PortfolioSnapshotQueueService,
+    private readonly materializedSnapshotService: MaterializedSnapshotService,
   ) {}
 
   /**
@@ -121,7 +123,38 @@ export class PortfolioService {
       totalValueUsd: totalValueUsd.toFixed(2),
     });
 
-    return await this.snapshotRepository.save(snapshot);
+    const savedSnapshot = await this.snapshotRepository.save(snapshot);
+
+    // Update materialized snapshot for fast reads
+    try {
+      const user = await this.userRepository.findOne({
+        where: { id: userId },
+        relations: ['stellarAccounts'],
+      });
+      const hasLinkedAccount =
+        user?.stellarAccounts && user.stellarAccounts.length > 0;
+
+      const allocation =
+        this.materializedSnapshotService.computeAllocation(assetBalances);
+
+      await this.materializedSnapshotService.upsertForUser({
+        userId,
+        totalValueUsd: savedSnapshot.totalValueUsd,
+        assetBalances,
+        assetAllocation: allocation,
+        hasLinkedAccount: !!hasLinkedAccount,
+        sourceSnapshotId: savedSnapshot.id,
+      });
+    } catch (error: unknown) {
+      // Log but don't fail the snapshot creation if materialization fails
+      this.logger.warn(
+        `Failed to update materialized snapshot for user ${userId}: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
+    }
+
+    return savedSnapshot;
   }
 
   /**
@@ -159,15 +192,29 @@ export class PortfolioService {
   }
 
   /**
-   * Get portfolio summary (latest snapshot) for the mobile dashboard
-   * Returns total USD value and individual asset balances
+   * Get portfolio summary (latest snapshot) for the mobile dashboard.
+   * Uses the materialized snapshot for fast reads — falls back to
+   * querying portfolio_snapshots if no materialized row exists yet.
    */
   async getPortfolioSummary(
     userId: string,
   ): Promise<PortfolioSummaryResponseDto> {
     this.logger.log(`Fetching portfolio summary for user ${userId}`);
 
-    // Check if user has any linked Stellar accounts
+    // Fast path: read from materialized snapshot (O(1) by userId index)
+    const materialized =
+      await this.materializedSnapshotService.getForUser(userId);
+
+    if (materialized) {
+      return {
+        totalValueUsd: materialized.totalValueUsd,
+        assets: materialized.assetBalances,
+        lastUpdated: materialized.updatedAt,
+        hasLinkedAccount: materialized.hasLinkedAccount,
+      };
+    }
+
+    // Fallback: compute from raw data (first-time access or migration in progress)
     const user = await this.userRepository.findOne({
       where: { id: userId },
       relations: ['stellarAccounts'],
@@ -193,13 +240,34 @@ export class PortfolioService {
     });
 
     if (!latestSnapshot) {
-      // User has accounts but no snapshot yet
       return {
         totalValueUsd: '0.00',
         assets: [],
         lastUpdated: null,
-        hasLinkedAccount: true, // Important: set to true even without snapshot
+        hasLinkedAccount: true,
       };
+    }
+
+    // Populate materialized snapshot for future fast reads
+    try {
+      const allocation =
+        this.materializedSnapshotService.computeAllocation(
+          latestSnapshot.assetBalances,
+        );
+      await this.materializedSnapshotService.upsertForUser({
+        userId,
+        totalValueUsd: latestSnapshot.totalValueUsd,
+        assetBalances: latestSnapshot.assetBalances,
+        assetAllocation: allocation,
+        hasLinkedAccount: true,
+        sourceSnapshotId: latestSnapshot.id,
+      });
+    } catch (error: unknown) {
+      this.logger.warn(
+        `Failed to backfill materialized snapshot for user ${userId}: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
     }
 
     return {
@@ -326,6 +394,54 @@ export class PortfolioService {
   }
 
   /**
+   * Scheduled job to refresh materialized snapshots.
+   * Runs every 6 hours to catch any users whose materialized snapshot
+   * might be stale (e.g. if the materialized upsert failed during
+   * snapshot creation).
+   */
+  @Cron('0 */6 * * *', { name: 'materialized-snapshot-refresh' })
+  async refreshMaterializedSnapshots(): Promise<void> {
+    this.logger.log('Starting scheduled materialized snapshot refresh');
+    try {
+      // Refresh materialized snapshots for users that have snapshots
+      // but no materialized row (migration gap or upsert failure)
+      const staleUsers = await this.snapshotRepository
+        .createQueryBuilder('ps')
+        .select('ps.userId', 'userId')
+        .groupBy('ps.userId')
+        .having(
+          'ps.userId NOT IN (SELECT "userId" FROM portfolio_materialized_snapshots)',
+        )
+        .getRawMany();
+
+      let refreshed = 0;
+      for (const { userId } of staleUsers) {
+        try {
+          const didRefresh =
+            await this.materializedSnapshotService.refreshForUser(userId);
+          if (didRefresh) refreshed++;
+        } catch (error: unknown) {
+          this.logger.warn(
+            `Failed to refresh materialized snapshot for user ${userId}: ${
+              error instanceof Error ? error.message : 'Unknown error'
+           }`,
+          );
+        }
+      }
+
+      this.logger.log(
+        `Materialized snapshot refresh complete. Refreshed ${refreshed} users.`,
+      );
+    } catch (error: unknown) {
+      this.logger.error(
+        `Materialized snapshot refresh failed: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
+      );
+    }
+  }
+
+  /**
    * Manual trigger for creating snapshots (useful for testing)
    */
   async triggerSnapshotCreation(): Promise<PortfolioSnapshotBatchStatus> {
@@ -383,12 +499,9 @@ export class PortfolioService {
   /**
    * Get portfolio asset allocation breakdown.
    *
-   * Aggregates assets across all linked Stellar accounts for a user,
-   * calculates the USD value of each asset, and determines its percentage
-   * of the total portfolio value.
-   *
-   * @param userId The ID of the user.
-   * @returns An object with the total portfolio value and an array of assets with their allocation details.
+   * Uses the materialized snapshot for fast reads when available.
+   * Falls back to computing from Stellar network when no materialized
+   * row exists (first-time access or migration in progress).
    */
   async getAssetAllocation(userId: string): Promise<{
     totalValueUsd: number;
@@ -402,6 +515,18 @@ export class PortfolioService {
   }> {
     this.logger.log(`Fetching asset allocation for user ${userId}`);
 
+    // Fast path: read from materialized snapshot
+    const materialized =
+      await this.materializedSnapshotService.getForUser(userId);
+
+    if (materialized?.assetAllocation) {
+      return {
+        totalValueUsd: parseFloat(materialized.totalValueUsd),
+        allocation: materialized.assetAllocation,
+      };
+    }
+
+    // Fallback: compute from Stellar network (slow path)
     const user = await this.userRepository.findOne({
       where: { id: userId },
       relations: ['stellarAccounts'],

--- a/apps/backend/src/telegram-bot/index.ts
+++ b/apps/backend/src/telegram-bot/index.ts
@@ -1,4 +1,7 @@
 export { TelegramBotModule } from './telegram-bot.module';
 export { TelegramBotService } from './telegram-bot.service';
-export { TelegramSubscription, TelegramAlertType } from './telegram-subscription.entity';
+export {
+  TelegramSubscription,
+  TelegramAlertType,
+} from './telegram-subscription.entity';
 export { TelegramSilence } from './telegram-silence.entity';

--- a/apps/backend/src/telegram-bot/telegram-bot.service.ts
+++ b/apps/backend/src/telegram-bot/telegram-bot.service.ts
@@ -8,7 +8,10 @@ import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, MoreThan } from 'typeorm';
 import TelegramBot, { Message } from 'node-telegram-bot-api';
-import { TelegramSubscription, TelegramAlertType } from './telegram-subscription.entity';
+import {
+  TelegramSubscription,
+  TelegramAlertType,
+} from './telegram-subscription.entity';
 import { TelegramSilence } from './telegram-silence.entity';
 import { PriceService } from '../price/price.service';
 import { SentimentService } from '../sentiment/sentiment.service';
@@ -54,21 +57,51 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
   private registerHandlers() {
     if (!this.bot) return;
 
-    this.bot.onText(/\/start/, (msg) => { void this.handleStart(msg); });
-    this.bot.onText(/\/status/, (msg) => { void this.handleStatus(msg); });
-    this.bot.onText(/\/price (.+)/, (msg, match) => { void this.handlePrice(msg, match); });
-    this.bot.onText(/\/price$/, (msg) => { void this.handlePrice(msg, null); });
-    this.bot.onText(/\/sentiment/, (msg) => { void this.handleSentiment(msg); });
-    this.bot.onText(/\/trend/, (msg) => { void this.handleTrend(msg); });
-    this.bot.onText(/\/subscribe (.+)/, (msg, match) => { void this.handleSubscribe(msg, match); });
-    this.bot.onText(/\/subscribe$/, (msg) => { void this.handleSubscribe(msg, null); });
-    this.bot.onText(/\/unsubscribe (.+)/, (msg, match) => { void this.handleUnsubscribe(msg, match); });
-    this.bot.onText(/\/unsubscribe$/, (msg) => { void this.handleUnsubscribe(msg, null); });
-    this.bot.onText(/\/silence (.+)/, (msg, match) => { void this.handleSilence(msg, match); });
-    this.bot.onText(/\/silence$/, (msg) => { void this.handleSilence(msg, null); });
-    this.bot.onText(/\/unsilence/, (msg) => { void this.handleUnsilence(msg); });
-    this.bot.onText(/\/subscriptions/, (msg) => { void this.handleSubscriptions(msg); });
-    this.bot.onText(/\/help/, (msg) => { void this.handleHelp(msg); });
+    this.bot.onText(/\/start/, (msg) => {
+      void this.handleStart(msg);
+    });
+    this.bot.onText(/\/status/, (msg) => {
+      void this.handleStatus(msg);
+    });
+    this.bot.onText(/\/price (.+)/, (msg, match) => {
+      void this.handlePrice(msg, match);
+    });
+    this.bot.onText(/\/price$/, (msg) => {
+      void this.handlePrice(msg, null);
+    });
+    this.bot.onText(/\/sentiment/, (msg) => {
+      void this.handleSentiment(msg);
+    });
+    this.bot.onText(/\/trend/, (msg) => {
+      void this.handleTrend(msg);
+    });
+    this.bot.onText(/\/subscribe (.+)/, (msg, match) => {
+      void this.handleSubscribe(msg, match);
+    });
+    this.bot.onText(/\/subscribe$/, (msg) => {
+      void this.handleSubscribe(msg, null);
+    });
+    this.bot.onText(/\/unsubscribe (.+)/, (msg, match) => {
+      void this.handleUnsubscribe(msg, match);
+    });
+    this.bot.onText(/\/unsubscribe$/, (msg) => {
+      void this.handleUnsubscribe(msg, null);
+    });
+    this.bot.onText(/\/silence (.+)/, (msg, match) => {
+      void this.handleSilence(msg, match);
+    });
+    this.bot.onText(/\/silence$/, (msg) => {
+      void this.handleSilence(msg, null);
+    });
+    this.bot.onText(/\/unsilence/, (msg) => {
+      void this.handleUnsilence(msg);
+    });
+    this.bot.onText(/\/subscriptions/, (msg) => {
+      void this.handleSubscriptions(msg);
+    });
+    this.bot.onText(/\/help/, (msg) => {
+      void this.handleHelp(msg);
+    });
 
     this.bot.on('polling_error', (error) => {
       this.logger.error('Telegram polling error', error);
@@ -117,7 +150,9 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
 
   private async handleStatus(msg: Message) {
     const chatId = this.getChatId(msg);
-    const sub = await this.subscriptionRepository.findOne({ where: { chatId } });
+    const sub = await this.subscriptionRepository.findOne({
+      where: { chatId },
+    });
 
     if (!sub || !sub.isActive) {
       await this.sendMessage(
@@ -146,7 +181,10 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
     try {
       const price = await this.priceService.getCurrentPrice(asset);
       if (price === 0) {
-        await this.sendMessage(chatId, `Price for *${asset}* is not available.`);
+        await this.sendMessage(
+          chatId,
+          `Price for *${asset}* is not available.`,
+        );
         return;
       }
 
@@ -156,7 +194,10 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
       );
     } catch (error) {
       this.logger.error('Price command error', error);
-      await this.sendMessage(chatId, 'Failed to fetch price. Please try again later.');
+      await this.sendMessage(
+        chatId,
+        'Failed to fetch price. Please try again later.',
+      );
     }
   }
 
@@ -169,7 +210,10 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
       await this.sendMessage(chatId, sentimentText);
     } catch (error) {
       this.logger.error('Sentiment command error', error);
-      await this.sendMessage(chatId, 'Failed to fetch sentiment. Please try again later.');
+      await this.sendMessage(
+        chatId,
+        'Failed to fetch sentiment. Please try again later.',
+      );
     }
   }
 
@@ -218,7 +262,10 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
       await this.sendMessage(chatId, text);
     } catch (error) {
       this.logger.error('Trend command error', error);
-      await this.sendMessage(chatId, 'Failed to fetch trend. Please try again later.');
+      await this.sendMessage(
+        chatId,
+        'Failed to fetch trend. Please try again later.',
+      );
     }
   }
 
@@ -226,7 +273,9 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
     const chatId = this.getChatId(msg);
     const typeInput = match?.[1]?.trim().toLowerCase() ?? '';
 
-    const validTypes = Object.values(TelegramAlertType).map((t) => t.toLowerCase());
+    const validTypes = Object.values(TelegramAlertType).map((t) =>
+      t.toLowerCase(),
+    );
     if (!validTypes.includes(typeInput)) {
       await this.sendMessage(
         chatId,
@@ -261,7 +310,9 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
     const chatId = this.getChatId(msg);
     const typeInput = match?.[1]?.trim().toLowerCase() ?? '';
 
-    const validTypes = Object.values(TelegramAlertType).map((t) => t.toLowerCase());
+    const validTypes = Object.values(TelegramAlertType).map((t) =>
+      t.toLowerCase(),
+    );
     if (!validTypes.includes(typeInput)) {
       await this.sendMessage(
         chatId,
@@ -272,16 +323,24 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
     }
 
     const alertType = typeInput as TelegramAlertType;
-    const sub = await this.subscriptionRepository.findOne({ where: { chatId } });
+    const sub = await this.subscriptionRepository.findOne({
+      where: { chatId },
+    });
 
     if (!sub) {
-      await this.sendMessage(chatId, 'You are not subscribed. Use /start to subscribe.');
+      await this.sendMessage(
+        chatId,
+        'You are not subscribed. Use /start to subscribe.',
+      );
       return;
     }
 
     sub.alertTypes = sub.alertTypes.filter((t) => t !== alertType);
     await this.subscriptionRepository.save(sub);
-    await this.sendMessage(chatId, `Unsubscribed from *${alertType}* alerts ❌`);
+    await this.sendMessage(
+      chatId,
+      `Unsubscribed from *${alertType}* alerts ❌`,
+    );
   }
 
   private async handleSilence(msg: Message, match: RegExpExecArray | null) {
@@ -332,7 +391,9 @@ export class TelegramBotService implements OnModuleInit, OnModuleDestroy {
 
   private async handleSubscriptions(msg: Message) {
     const chatId = this.getChatId(msg);
-    const sub = await this.subscriptionRepository.findOne({ where: { chatId } });
+    const sub = await this.subscriptionRepository.findOne({
+      where: { chatId },
+    });
 
     if (!sub || !sub.isActive) {
       await this.sendMessage(

--- a/apps/backend/src/webhook/webhook-verification.service.spec.ts
+++ b/apps/backend/src/webhook/webhook-verification.service.spec.ts
@@ -39,7 +39,7 @@ describe('WebhookVerificationService', () => {
     service = module.get<WebhookVerificationService>(
       WebhookVerificationService,
     );
-    
+
     // Manually call onModuleInit to load provider configs
     service.onModuleInit();
   });


### PR DESCRIPTION


## Summary

- Add PortfolioMaterializedSnapshot entity with unique userId index
- Add migration with backfill from existing portfolio_snapshots
- Add MaterializedSnapshotService with upsert/get/refresh/computeAllocation
- Update PortfolioService.getPortfolioSummary() to read from materialized table (O(1) lookup)
- Update PortfolioService.getAssetAllocation() to read pre-computed allocation
- Update createSnapshot() to upsert materialized row on every snapshot creation
- Add scheduled refreshMaterializedSnapshots() cron every 6 hours for reconciliation
- Register new entity and service in PortfolioModule
- Add unit tests for MaterializedSnapshotService

## Linked Issue

Closes #558

## Type of Change

- [x] feat
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Validation

- [x] Lint passed for affected area(s)
- [x] Tests passed for affected area(s)
- [x] Manual verification completed (if applicable)

## Documentation

- [ ] Documentation updated (or N/A with explanation)
- [ ] Screenshots/videos attached for UI changes

## Checklist

- [ ] Branch name uses `feat/`, `fix/`, or `docs/`
- [ ] Commit messages follow Conventional Commits
- [ ] PR scope matches linked issue acceptance criteria
