### PR TITLE
feat(onchain): add milestone-gated dynamic vesting to vesting-wallet

### DIFF
--- a/apps/onchain/Cargo.lock
+++ b/apps/onchain/Cargo.lock
@@ -2179,6 +2179,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vesting-wallet"
 version = "0.0.0"
 dependencies = [
+ "crowdfund_vault",
  "soroban-sdk 23.5.2",
 ]
 

--- a/apps/onchain/contracts/vesting-wallet/Cargo.toml
+++ b/apps/onchain/contracts/vesting-wallet/Cargo.toml
@@ -10,6 +10,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
+crowdfund_vault = { path = "../crowdfund_vault" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/apps/onchain/contracts/vesting-wallet/Cargo.toml
+++ b/apps/onchain/contracts/vesting-wallet/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
-crowdfund_vault = { path = "../crowdfund_vault" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+crowdfund_vault = { path = "../crowdfund_vault" }

--- a/apps/onchain/contracts/vesting-wallet/src/lib.rs
+++ b/apps/onchain/contracts/vesting-wallet/src/lib.rs
@@ -5,10 +5,13 @@ mod events;
 mod storage;
 mod token;
 
+use crowdfund_vault::CrowdfundVaultContractClient;
 use errors::VestingError;
 use events::{AdminChangedEvent, UpgradedEvent};
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
-use storage::{DataKey, VestingData, LEDGER_BUMP, LEDGER_THRESHOLD};
+use storage::{
+    DataKey, MilestoneLink, MilestoneRequirement, VestingData, LEDGER_BUMP, LEDGER_THRESHOLD,
+};
 use token::transfer;
 
 #[contract]
@@ -16,10 +19,20 @@ pub struct VestingWalletContract;
 
 #[contractimpl]
 impl VestingWalletContract {
+    fn milestone_completed(env: &Env, vesting: &VestingData) -> bool {
+        match &vesting.milestone_requirement {
+            MilestoneRequirement::External(link) => {
+                let vault_client = CrowdfundVaultContractClient::new(env, &link.vault_contract);
+                vault_client.is_milestone_approved(&link.project_id, &link.milestone_id)
+            }
+            MilestoneRequirement::None => true,
+        }
+    }
+
     /// Helper function to calculate claimable amount for a vesting schedule
     /// This is used by both get_claimable and claim to ensure consistency
-    fn calculate_claimable_amount(current_time: u64, vesting: &VestingData) -> i128 {
-        if current_time < vesting.start_time {
+    fn calculate_claimable_amount(env: &Env, current_time: u64, vesting: &VestingData) -> i128 {
+        if !Self::milestone_completed(env, vesting) || current_time < vesting.start_time {
             // Vesting hasn't started yet
             0
         } else if current_time >= vesting.start_time + vesting.duration {
@@ -64,6 +77,47 @@ impl VestingWalletContract {
         amount: i128,
         start_time: u64,
         duration: u64,
+    ) -> Result<(), VestingError> {
+        Self::create_vesting_internal(
+            env,
+            admin,
+            beneficiary,
+            amount,
+            start_time,
+            duration,
+            MilestoneRequirement::None,
+        )
+    }
+
+    /// Create a vesting schedule that is gated by an external crowdfund vault milestone.
+    pub fn create_vesting_with_milestone(
+        env: Env,
+        admin: Address,
+        beneficiary: Address,
+        amount: i128,
+        start_time: u64,
+        duration: u64,
+        milestone_link: MilestoneLink,
+    ) -> Result<(), VestingError> {
+        Self::create_vesting_internal(
+            env,
+            admin,
+            beneficiary,
+            amount,
+            start_time,
+            duration,
+            MilestoneRequirement::External(milestone_link),
+        )
+    }
+
+    fn create_vesting_internal(
+        env: Env,
+        admin: Address,
+        beneficiary: Address,
+        amount: i128,
+        start_time: u64,
+        duration: u64,
+        milestone_requirement: MilestoneRequirement,
     ) -> Result<(), VestingError> {
         // Check if contract is initialized
         let stored_admin: Address = env
@@ -111,6 +165,11 @@ impl VestingWalletContract {
 
         let contract_address = env.current_contract_address();
 
+        if let MilestoneRequirement::External(link) = &milestone_requirement {
+            let vault_client = CrowdfundVaultContractClient::new(&env, &link.vault_contract);
+            let _ = vault_client.is_milestone_approved(&link.project_id, &link.milestone_id);
+        }
+
         // If vesting already exists, return remaining tokens to admin
         // (total_amount - claimed_amount)
         if let Some(existing_vesting) = env
@@ -139,6 +198,7 @@ impl VestingWalletContract {
             start_time,
             duration,
             claimed_amount: 0,
+            milestone_requirement,
         };
 
         // Store vesting data
@@ -191,7 +251,7 @@ impl VestingWalletContract {
         let current_time = env.ledger().timestamp();
 
         // Calculate available amount using the helper function
-        let available_amount = Self::calculate_claimable_amount(current_time, &vesting);
+        let available_amount = Self::calculate_claimable_amount(&env, current_time, &vesting);
 
         // Check if there's anything to claim
         if available_amount <= 0 {
@@ -262,7 +322,7 @@ impl VestingWalletContract {
         let current_time = env.ledger().timestamp();
 
         // Calculate claimable amount using the helper function
-        let claimable_amount = Self::calculate_claimable_amount(current_time, &vesting);
+        let claimable_amount = Self::calculate_claimable_amount(&env, current_time, &vesting);
 
         Ok(claimable_amount)
     }
@@ -298,7 +358,7 @@ impl VestingWalletContract {
         let current_time = env.ledger().timestamp();
 
         // Calculate available amount using the helper function
-        let available_amount = Self::calculate_claimable_amount(current_time, &vesting);
+        let available_amount = Self::calculate_claimable_amount(&env, current_time, &vesting);
 
         Ok(available_amount)
     }

--- a/apps/onchain/contracts/vesting-wallet/src/lib.rs
+++ b/apps/onchain/contracts/vesting-wallet/src/lib.rs
@@ -4,8 +4,8 @@ mod errors;
 mod events;
 mod storage;
 mod token;
+mod vault_interface;
 
-use crowdfund_vault::CrowdfundVaultContractClient;
 use errors::VestingError;
 use events::{AdminChangedEvent, UpgradedEvent};
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
@@ -13,6 +13,7 @@ use storage::{
     DataKey, MilestoneLink, MilestoneRequirement, VestingData, LEDGER_BUMP, LEDGER_THRESHOLD,
 };
 use token::transfer;
+use vault_interface::CrowdfundVaultClient;
 
 #[contract]
 pub struct VestingWalletContract;
@@ -22,7 +23,7 @@ impl VestingWalletContract {
     fn milestone_completed(env: &Env, vesting: &VestingData) -> bool {
         match &vesting.milestone_requirement {
             MilestoneRequirement::External(link) => {
-                let vault_client = CrowdfundVaultContractClient::new(env, &link.vault_contract);
+                let vault_client = CrowdfundVaultClient::new(env, &link.vault_contract);
                 vault_client.is_milestone_approved(&link.project_id, &link.milestone_id)
             }
             MilestoneRequirement::None => true,
@@ -166,7 +167,7 @@ impl VestingWalletContract {
         let contract_address = env.current_contract_address();
 
         if let MilestoneRequirement::External(link) = &milestone_requirement {
-            let vault_client = CrowdfundVaultContractClient::new(&env, &link.vault_contract);
+            let vault_client = CrowdfundVaultClient::new(&env, &link.vault_contract);
             let _ = vault_client.is_milestone_approved(&link.project_id, &link.milestone_id);
         }
 

--- a/apps/onchain/contracts/vesting-wallet/src/storage.rs
+++ b/apps/onchain/contracts/vesting-wallet/src/storage.rs
@@ -16,10 +16,26 @@ pub enum DataKey {
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MilestoneLink {
+    pub vault_contract: Address,
+    pub project_id: u64,
+    pub milestone_id: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MilestoneRequirement {
+    None,
+    External(MilestoneLink),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VestingData {
     pub beneficiary: Address,
     pub total_amount: i128,
     pub start_time: u64,
     pub duration: u64,
     pub claimed_amount: i128,
+    pub milestone_requirement: MilestoneRequirement,
 }

--- a/apps/onchain/contracts/vesting-wallet/src/test.rs
+++ b/apps/onchain/contracts/vesting-wallet/src/test.rs
@@ -1,6 +1,9 @@
 use crate::errors::VestingError;
+use crate::storage::{MilestoneLink, MilestoneRequirement};
 use crate::{VestingWalletContract, VestingWalletContractClient};
+use crowdfund_vault::{CrowdfundVaultContract, CrowdfundVaultContractClient};
 use soroban_sdk::{
+    symbol_short,
     testutils::{Address as _, Ledger},
     token::{StellarAssetClient, TokenClient},
     Address, Env,
@@ -40,6 +43,27 @@ fn setup_test<'a>(
     let client = VestingWalletContractClient::new(env, &contract_id);
 
     (client, admin, beneficiary, token_client, contract_id)
+}
+
+fn setup_vault_project<'a>(
+    env: &Env,
+    admin: &Address,
+    token_address: &Address,
+) -> (CrowdfundVaultContractClient<'a>, Address, u64) {
+    let owner = Address::generate(env);
+    let vault_id = env.register(CrowdfundVaultContract, ());
+    let vault_client = CrowdfundVaultContractClient::new(env, &vault_id);
+
+    vault_client.initialize(admin);
+
+    let project_id = vault_client.create_project(
+        &owner,
+        &symbol_short!("VestProj"),
+        &1_000_000,
+        token_address,
+    );
+
+    (vault_client, vault_id, project_id)
 }
 
 #[test]
@@ -101,6 +125,43 @@ fn test_create_vesting() {
 
     // Verify tokens were transferred to contract
     assert_eq!(token_client.balance(&contract_id), amount);
+}
+
+#[test]
+fn test_create_vesting_with_milestone_stores_link() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, beneficiary, token_client, _) = setup_test(&env);
+    let (_, vault_id, project_id) = setup_vault_project(&env, &admin, &token_client.address);
+
+    client.initialize(&admin, &token_client.address);
+
+    let current_time = env.ledger().timestamp();
+    let start_time = current_time + 1000;
+    let duration = 10_000;
+    let amount: i128 = 1_000_000;
+    let milestone_id = 0u32;
+    let milestone_link = MilestoneLink {
+        vault_contract: vault_id.clone(),
+        project_id,
+        milestone_id,
+    };
+
+    client.create_vesting_with_milestone(
+        &admin,
+        &beneficiary,
+        &amount,
+        &start_time,
+        &duration,
+        &milestone_link,
+    );
+
+    let vesting = client.get_vesting(&beneficiary);
+    assert_eq!(
+        vesting.milestone_requirement,
+        MilestoneRequirement::External(milestone_link)
+    );
 }
 
 #[test]
@@ -222,6 +283,60 @@ fn test_claim_before_start_time() {
 
     // Verify available amount is 0
     assert_eq!(client.get_available_amount(&beneficiary), 0);
+}
+
+#[test]
+fn test_claim_requires_completed_vault_milestone() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, beneficiary, token_client, _) = setup_test(&env);
+    let (vault_client, vault_id, project_id) =
+        setup_vault_project(&env, &admin, &token_client.address);
+
+    client.initialize(&admin, &token_client.address);
+
+    let current_time = env.ledger().timestamp();
+    let start_time = current_time + 100;
+    let duration = 10_000;
+    let amount: i128 = 1_000_000;
+    let milestone_id = 0u32;
+    let milestone_link = MilestoneLink {
+        vault_contract: vault_id,
+        project_id,
+        milestone_id,
+    };
+
+    client.create_vesting_with_milestone(
+        &admin,
+        &beneficiary,
+        &amount,
+        &start_time,
+        &duration,
+        &milestone_link,
+    );
+
+    env.ledger().set_timestamp(start_time + duration / 2);
+
+    assert_eq!(client.get_claimable(&beneficiary), 0);
+    assert_eq!(client.get_available_amount(&beneficiary), 0);
+    assert_eq!(
+        client.try_claim(&beneficiary),
+        Err(Ok(VestingError::NothingToClaim))
+    );
+
+    vault_client.approve_milestone(&admin, &project_id, &milestone_id);
+
+    assert_eq!(client.get_claimable(&beneficiary), amount / 2);
+
+    let first_claim = client.claim(&beneficiary);
+    assert_eq!(first_claim, amount / 2);
+
+    env.ledger().set_timestamp(start_time + duration + 1);
+
+    let second_claim = client.claim(&beneficiary);
+    assert_eq!(second_claim, amount / 2);
+    assert_eq!(token_client.balance(&beneficiary), amount);
 }
 
 #[test]

--- a/apps/onchain/contracts/vesting-wallet/src/vault_interface.rs
+++ b/apps/onchain/contracts/vesting-wallet/src/vault_interface.rs
@@ -1,0 +1,7 @@
+use soroban_sdk::{contractclient, Env};
+
+#[allow(dead_code)]
+#[contractclient(name = "CrowdfundVaultClient")]
+pub trait CrowdfundVaultTrait {
+    fn is_milestone_approved(env: Env, project_id: u64, milestone_id: u32) -> bool;
+}

--- a/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_claim_before_start_time.1.json
+++ b/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_claim_before_start_time.1.json
@@ -357,6 +357,18 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "start_time"
                       },
                       "val": {

--- a/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_claim_multiple_times.1.json
+++ b/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_claim_multiple_times.1.json
@@ -461,6 +461,18 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "start_time"
                       },
                       "val": {

--- a/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_claim_partial_vesting.1.json
+++ b/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_claim_partial_vesting.1.json
@@ -410,6 +410,18 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "start_time"
                       },
                       "val": {

--- a/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_claim_unauthorized.1.json
+++ b/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_claim_unauthorized.1.json
@@ -356,6 +356,18 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "start_time"
                       },
                       "val": {

--- a/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_create_vesting.1.json
+++ b/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_create_vesting.1.json
@@ -357,6 +357,18 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "start_time"
                       },
                       "val": {

--- a/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_get_available_amount_linear_calculation.1.json
+++ b/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_get_available_amount_linear_calculation.1.json
@@ -357,6 +357,18 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "start_time"
                       },
                       "val": {

--- a/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_get_claimable_consistency_with_claim.1.json
+++ b/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_get_claimable_consistency_with_claim.1.json
@@ -409,6 +409,18 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "start_time"
                       },
                       "val": {

--- a/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_get_claimable_view_method.1.json
+++ b/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_get_claimable_view_method.1.json
@@ -415,6 +415,18 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "start_time"
                       },
                       "val": {

--- a/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_multiple_beneficiaries.1.json
+++ b/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_multiple_beneficiaries.1.json
@@ -513,6 +513,18 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "start_time"
                       },
                       "val": {
@@ -595,6 +607,18 @@
                       },
                       "val": {
                         "u64": "10000"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
                       }
                     },
                     {

--- a/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_ttl_extended_after_read_write.1.json
+++ b/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_ttl_extended_after_read_write.1.json
@@ -357,6 +357,18 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "start_time"
                       },
                       "val": {

--- a/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_update_vesting.1.json
+++ b/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_update_vesting.1.json
@@ -441,6 +441,18 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "start_time"
                       },
                       "val": {

--- a/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_vesting_entry_accessible_after_ledger_advance.1.json
+++ b/apps/onchain/contracts/vesting-wallet/test_snapshots/test/test_vesting_entry_accessible_after_ledger_advance.1.json
@@ -356,6 +356,18 @@
                     },
                     {
                       "key": {
+                        "symbol": "milestone_requirement"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "symbol": "None"
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "start_time"
                       },
                       "val": {


### PR DESCRIPTION
## Summary
Implements performance-based dynamic vesting for `vesting-wallet`.
Closes #430 

## Changes
- Added optional external milestone linkage to vesting schedules.
- Integrated `vesting-wallet` with `crowdfund_vault` using a cross-contract milestone approval check.
- Preserved existing time-based vesting behavior for schedules without milestone requirements.
- Added tests covering milestone link persistence and claim blocking until milestone completion.

## Result
Team tokens can now remain locked until a required project milestone is completed in the vault, while still following the normal vesting timeline once that condition is met.