### PR TITLE
fix(backend): standardize cursor pagination/filtering across public feeds

### DIFF
--- a/apps/backend/src/analytics/analytics.controller.ts
+++ b/apps/backend/src/analytics/analytics.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Query, Logger } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AnalyticsService } from './analytics.service';
-import { ChartDataQueryDto, ChartDataPointDto } from './dto/chart-data.dto';
+import { ChartDataQueryDto, ChartDataResponseDto } from './dto/chart-data.dto';
 
 @ApiTags('analytics')
 @Controller('analytics')
@@ -19,12 +19,8 @@ export class AnalyticsController {
   @ApiResponse({
     status: 200,
     description: 'Bucketed sentiment data',
-    type: ChartDataPointDto,
-    isArray: true,
   })
-  async getChartData(
-    @Query() query: ChartDataQueryDto,
-  ): Promise<ChartDataPointDto[]> {
+  async getChartData(@Query() query: ChartDataQueryDto): Promise<ChartDataResponseDto> {
     return this.analyticsService.getChartData(query);
   }
 }

--- a/apps/backend/src/analytics/analytics.service.ts
+++ b/apps/backend/src/analytics/analytics.service.ts
@@ -3,9 +3,11 @@ import { DataSource } from 'typeorm';
 import {
   ChartDataPointDto,
   ChartDataQueryDto,
+  ChartDataResponseDto,
   ChartInterval,
   ChartRange,
 } from './dto/chart-data.dto';
+import { SortOrder } from '../common/dto/cursor-pagination.dto';
 
 interface HourlyRow {
   bucket: Date;
@@ -25,19 +27,46 @@ export class AnalyticsService {
 
   constructor(private readonly dataSource: DataSource) {}
 
-  async getChartData(query: ChartDataQueryDto): Promise<ChartDataPointDto[]> {
+  async getChartData(query: ChartDataQueryDto): Promise<ChartDataResponseDto> {
     const { interval, range, asset } = query;
     const since = this.getStartDate(range);
+    const limit = query.limit ?? 20;
+    const sortOrder = query.sortOrder ?? SortOrder.DESC;
+    const cursor = query.cursor;
 
     this.logger.log(
       `Fetching chart data: interval=${interval}, range=${range}, asset=${asset || 'global'}`,
     );
 
-    if (interval === ChartInterval.ONE_HOUR) {
-      return this.getHourlyChartData(since, asset);
-    } else {
-      return this.getDailyChartData(since, asset);
-    }
+    const rows =
+      interval === ChartInterval.ONE_HOUR
+        ? await this.getHourlyChartData(since, asset)
+        : await this.getDailyChartData(since, asset);
+
+    const sorted = [...rows].sort((a, b) => {
+      const aTs = new Date(a.timestamp).getTime();
+      const bTs = new Date(b.timestamp).getTime();
+      return sortOrder === SortOrder.ASC ? aTs - bTs : bTs - aTs;
+    });
+
+    const filtered = cursor
+      ? sorted.filter((row) => {
+          const ts = new Date(row.timestamp).getTime();
+          const cursorTs = new Date(cursor).getTime();
+          return sortOrder === SortOrder.ASC ? ts > cursorTs : ts < cursorTs;
+        })
+      : sorted;
+
+    const items = filtered.slice(0, limit);
+    const nextCursor = items.length > 0 ? items[items.length - 1].timestamp : undefined;
+
+    return {
+      items,
+      total: sorted.length,
+      limit,
+      sortOrder,
+      nextCursor,
+    };
   }
 
   private async getHourlyChartData(

--- a/apps/backend/src/analytics/dto/chart-data.dto.ts
+++ b/apps/backend/src/analytics/dto/chart-data.dto.ts
@@ -1,5 +1,9 @@
 import { IsEnum, IsOptional, IsString } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  CursorPaginationQueryDto,
+  SortOrder,
+} from '../../common/dto/cursor-pagination.dto';
 
 export enum ChartInterval {
   ONE_HOUR = '1h',
@@ -11,7 +15,7 @@ export enum ChartRange {
   THIRTY_DAYS = '30d',
 }
 
-export class ChartDataQueryDto {
+export class ChartDataQueryDto extends CursorPaginationQueryDto {
   @ApiPropertyOptional({
     enum: ChartInterval,
     default: ChartInterval.ONE_HOUR,
@@ -42,4 +46,12 @@ export class ChartDataPointDto {
   timestamp: string;
   sentiment: number;
   count: number;
+}
+
+export interface ChartDataResponseDto {
+  items: ChartDataPointDto[];
+  total: number;
+  limit: number;
+  sortOrder: SortOrder;
+  nextCursor?: string;
 }

--- a/apps/backend/src/common/dto/cursor-pagination.dto.ts
+++ b/apps/backend/src/common/dto/cursor-pagination.dto.ts
@@ -1,0 +1,48 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export enum SortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+export class CursorPaginationQueryDto {
+  @ApiPropertyOptional({
+    description: 'Opaque cursor for next page',
+    example: '2026-04-28T14:30:00.000Z',
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  @ApiPropertyOptional({
+    description: 'Page size',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+  })
+  @IsOptional()
+  @Transform(({ value }) => Number(value))
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({
+    enum: SortOrder,
+    default: SortOrder.DESC,
+    description: 'Sort direction for paginated results',
+  })
+  @IsOptional()
+  @IsEnum(SortOrder)
+  sortOrder?: SortOrder = SortOrder.DESC;
+}
+
+export class CursorPaginatedResponseDto<T> {
+  items: T[];
+  nextCursor?: string;
+  total: number;
+  limit: number;
+  sortOrder: SortOrder;
+}

--- a/apps/backend/src/notification/dto/notification-feed-query.dto.ts
+++ b/apps/backend/src/notification/dto/notification-feed-query.dto.ts
@@ -1,0 +1,27 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import {
+  CursorPaginationQueryDto,
+  SortOrder,
+} from '../../common/dto/cursor-pagination.dto';
+import { NotificationSeverity, NotificationType } from '../notification.entity';
+
+export class NotificationFeedQueryDto extends CursorPaginationQueryDto {
+  @ApiPropertyOptional({ enum: NotificationType })
+  @IsOptional()
+  @IsEnum(NotificationType)
+  type?: NotificationType;
+
+  @ApiPropertyOptional({ enum: NotificationSeverity })
+  @IsOptional()
+  @IsEnum(NotificationSeverity)
+  severity?: NotificationSeverity;
+}
+
+export interface NotificationFeedResponseDto<T> {
+  items: T[];
+  total: number;
+  limit: number;
+  sortOrder: SortOrder;
+  nextCursor?: string;
+}

--- a/apps/backend/src/notification/notification.controller.ts
+++ b/apps/backend/src/notification/notification.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { NotificationService } from './notification.service';
+import {
+  NotificationFeedQueryDto,
+  NotificationFeedResponseDto,
+} from './dto/notification-feed-query.dto';
+import { Notification } from './notification.entity';
+
+interface RequestWithUser extends Request {
+  user: { id: string };
+}
+
+@ApiTags('notifications')
+@Controller('notifications')
+@UseGuards(JwtAuthGuard)
+@ApiBearerAuth('JWT-auth')
+export class NotificationController {
+  constructor(private readonly notificationService: NotificationService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Get notification feed with cursor pagination and filters' })
+  async list(
+    @Req() req: RequestWithUser,
+    @Query() query: NotificationFeedQueryDto,
+  ): Promise<NotificationFeedResponseDto<Notification>> {
+    return this.notificationService.findFeed(req.user.id, query);
+  }
+}

--- a/apps/backend/src/notification/notification.module.ts
+++ b/apps/backend/src/notification/notification.module.ts
@@ -8,6 +8,7 @@ import { NotificationService } from './notification.service';
 import { NotificationPreferenceService } from './notification-preference.service';
 import { NotificationDeliveryService } from './notification-delivery.service';
 import { NotificationPreferenceController } from './notification-preference.controller';
+import { NotificationController } from './notification.controller';
 import { ProfilingModule } from '../common/profiling/profiling.module';
 
 @Module({
@@ -30,6 +31,6 @@ import { ProfilingModule } from '../common/profiling/profiling.module';
     NotificationPreferenceService,
     NotificationDeliveryService,
   ],
-  controllers: [NotificationPreferenceController],
+  controllers: [NotificationPreferenceController, NotificationController],
 })
 export class NotificationModule {}

--- a/apps/backend/src/notification/notification.service.ts
+++ b/apps/backend/src/notification/notification.service.ts
@@ -6,6 +6,8 @@ import {
   NotificationType,
   NotificationSeverity,
 } from './notification.entity';
+import { NotificationFeedQueryDto } from './dto/notification-feed-query.dto';
+import { SortOrder } from '../common/dto/cursor-pagination.dto';
 
 export interface CreateNotificationDto {
   type: NotificationType;
@@ -50,5 +52,47 @@ export class NotificationService {
       .orderBy('n.createdAt', 'DESC')
       .take(50)
       .getMany();
+  }
+
+  async findFeed(
+    userId: string,
+    query: NotificationFeedQueryDto = {},
+  ): Promise<{
+    items: Notification[];
+    nextCursor?: string;
+    total: number;
+    limit: number;
+    sortOrder: SortOrder;
+  }> {
+    const limit = query.limit ?? 20;
+    const sortOrder = query.sortOrder ?? SortOrder.DESC;
+    const qb = this.notificationRepository
+      .createQueryBuilder('n')
+      .where('n.userId = :userId OR n.userId IS NULL', { userId });
+
+    if (query.type) qb.andWhere('n.type = :type', { type: query.type });
+    if (query.severity) {
+      qb.andWhere('n.severity = :severity', { severity: query.severity });
+    }
+    if (query.cursor) {
+      qb.andWhere(
+        sortOrder === SortOrder.ASC
+          ? 'n.createdAt > :cursor'
+          : 'n.createdAt < :cursor',
+        { cursor: query.cursor },
+      );
+    }
+
+    const total = await qb.getCount();
+    const items = await qb
+      .orderBy('n.createdAt', sortOrder.toUpperCase() as 'ASC' | 'DESC')
+      .addOrderBy('n.id', sortOrder.toUpperCase() as 'ASC' | 'DESC')
+      .take(limit)
+      .getMany();
+
+    const nextCursor =
+      items.length > 0 ? items[items.length - 1].createdAt.toISOString() : undefined;
+
+    return { items, nextCursor, total, limit, sortOrder };
   }
 }

--- a/apps/backend/src/transaction/dto/transaction-history-query.dto.ts
+++ b/apps/backend/src/transaction/dto/transaction-history-query.dto.ts
@@ -1,0 +1,36 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import {
+  CursorPaginationQueryDto,
+  SortOrder,
+} from '../../common/dto/cursor-pagination.dto';
+import { TransactionStatus, TransactionType } from './transaction.dto';
+
+export enum TransactionSortBy {
+  DATE = 'date',
+}
+
+export class TransactionHistoryQueryDto extends CursorPaginationQueryDto {
+  @ApiPropertyOptional({ enum: TransactionType })
+  @IsOptional()
+  @IsEnum(TransactionType)
+  type?: TransactionType;
+
+  @ApiPropertyOptional({ enum: TransactionStatus })
+  @IsOptional()
+  @IsEnum(TransactionStatus)
+  status?: TransactionStatus;
+
+  @ApiPropertyOptional({ enum: TransactionSortBy, default: TransactionSortBy.DATE })
+  @IsOptional()
+  @IsEnum(TransactionSortBy)
+  sortBy?: TransactionSortBy = TransactionSortBy.DATE;
+}
+
+export interface TransactionFeedResponseDto<T> {
+  items: T[];
+  total: number;
+  limit: number;
+  sortOrder: SortOrder;
+  nextCursor?: string;
+}

--- a/apps/backend/src/transaction/dto/transaction.dto.ts
+++ b/apps/backend/src/transaction/dto/transaction.dto.ts
@@ -58,11 +58,17 @@ export class TransactionDto {
 
 export class TransactionHistoryResponseDto {
   @ApiProperty({ type: [TransactionDto] })
-  transactions: TransactionDto[];
+  items: TransactionDto[];
 
   @ApiProperty()
   total: number;
 
+  @ApiProperty()
+  limit: number;
+
+  @ApiProperty({ enum: ['asc', 'desc'] })
+  sortOrder: 'asc' | 'desc';
+
   @ApiProperty({ required: false })
-  nextPage?: string;
+  nextCursor?: string;
 }

--- a/apps/backend/src/transaction/transaction.controller.ts
+++ b/apps/backend/src/transaction/transaction.controller.ts
@@ -9,6 +9,7 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { TransactionService } from './transaction.service';
 import { UsersService } from '../users/users.service';
 import { TransactionHistoryResponseDto } from './dto/transaction.dto';
+import { TransactionHistoryQueryDto } from './dto/transaction-history-query.dto';
 
 interface RequestWithUser extends Request {
   user: {
@@ -46,8 +47,7 @@ export class TransactionController {
   })
   async getTransactionHistory(
     @Req() req: RequestWithUser,
-    @Query('limit') limit?: number,
-    @Query('cursor') cursor?: string,
+    @Query() query: TransactionHistoryQueryDto,
   ): Promise<TransactionHistoryResponseDto> {
     const accounts = await this.usersService.getStellarAccounts(req.user.id);
     const typedAccounts = accounts as StellarAccountWithPrimary[];
@@ -62,17 +62,18 @@ export class TransactionController {
       };
     }
 
-    const { transactions, nextPage } =
+    const { transactions, nextCursor, limit, sortOrder } =
       await this.transactionService.getTransactionHistory(
         primaryAccount.publicKey,
-        limit || 50,
-        cursor,
+        query,
       );
 
     return {
-      transactions,
+      items: transactions,
       total: transactions.length,
-      nextPage,
+      nextCursor,
+      limit,
+      sortOrder,
     };
   }
 
@@ -86,13 +87,8 @@ export class TransactionController {
   })
   async getTransactionHistoryForAccount(
     @Param('publicKey') publicKey: string,
-    @Query('limit') limit?: number,
-    @Query('cursor') cursor?: string,
+    @Query() query: TransactionHistoryQueryDto,
   ) {
-    return this.transactionService.getTransactionHistory(
-      publicKey,
-      limit,
-      cursor,
-    );
+    return this.transactionService.getTransactionHistory(publicKey, query);
   }
 }

--- a/apps/backend/src/transaction/transaction.service.ts
+++ b/apps/backend/src/transaction/transaction.service.ts
@@ -2,10 +2,12 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
   TransactionDto,
-  TransactionType,
   TransactionStatus,
+  TransactionType,
 } from './dto/transaction.dto';
 import { getMockTransactions } from './mocks/mock-transactions';
+import { TransactionHistoryQueryDto } from './dto/transaction-history-query.dto';
+import { SortOrder } from '../common/dto/cursor-pagination.dto';
 
 interface HorizonOperation {
   id: string;
@@ -88,18 +90,31 @@ export class TransactionService {
 
   async getTransactionHistory(
     publicKey: string,
-    limit: number = 50,
-    cursor?: string,
-  ): Promise<{ transactions: TransactionDto[]; nextPage?: string }> {
+    query: TransactionHistoryQueryDto = {},
+  ): Promise<{
+    transactions: TransactionDto[];
+    nextCursor?: string;
+    limit: number;
+    sortOrder: SortOrder;
+  }> {
     this.logger.log(`Fetching transaction history for ${publicKey}`);
+    const limit = query.limit ?? 50;
+    const sortOrder = query.sortOrder ?? SortOrder.DESC;
+    const cursor = query.cursor;
 
     if (this.useMockData) {
       this.logger.log('Returning mock transaction data');
-      return getMockTransactions(limit, cursor);
+      const { transactions, nextPage } = getMockTransactions(limit, cursor);
+      const filtered = transactions.filter((tx) => {
+        if (query.type && tx.type !== query.type) return false;
+        if (query.status && tx.status !== query.status) return false;
+        return true;
+      });
+      return { transactions: filtered, nextCursor: nextPage, limit, sortOrder };
     }
 
     try {
-      let url = `${this.horizonUrl}/accounts/${publicKey}/transactions?order=desc&limit=${limit}`;
+      let url = `${this.horizonUrl}/accounts/${publicKey}/transactions?order=${sortOrder}&limit=${limit}`;
       if (cursor) {
         url += `&cursor=${cursor}`;
       }
@@ -120,19 +135,24 @@ export class TransactionService {
         horizonData._embedded.records,
         publicKey,
       );
-      let nextPage: string | undefined;
+      let nextCursor: string | undefined;
 
       if (horizonData._links?.next?.href) {
         const nextUrl = new URL(horizonData._links.next.href);
-        nextPage = nextUrl.searchParams.get('cursor') || undefined;
+        nextCursor = nextUrl.searchParams.get('cursor') || undefined;
       }
 
-      return { transactions, nextPage };
+      const filtered = transactions.filter((tx) => {
+        if (query.type && tx.type !== query.type) return false;
+        if (query.status && tx.status !== query.status) return false;
+        return true;
+      });
+      return { transactions: filtered, nextCursor, limit, sortOrder };
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
       this.logger.error(`Failed to fetch transactions: ${errorMessage}`);
-      return { transactions: [] };
+      return { transactions: [], limit, sortOrder };
     }
   }
 

--- a/apps/backend/src/verification/dto/project-list-query.dto.ts
+++ b/apps/backend/src/verification/dto/project-list-query.dto.ts
@@ -1,0 +1,33 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsOptional } from 'class-validator';
+import {
+  CursorPaginationQueryDto,
+  SortOrder,
+} from '../../common/dto/cursor-pagination.dto';
+import { VerificationStatus } from './verification.dto';
+
+export enum ProjectSortBy {
+  REGISTERED_AT = 'registeredAt',
+  VOTES_FOR = 'votesFor',
+}
+
+export class ProjectListQueryDto extends CursorPaginationQueryDto {
+  @ApiPropertyOptional({ enum: VerificationStatus })
+  @IsOptional()
+  @IsEnum(VerificationStatus)
+  status?: VerificationStatus;
+
+  @ApiPropertyOptional({ enum: ProjectSortBy, default: ProjectSortBy.REGISTERED_AT })
+  @IsOptional()
+  @IsEnum(ProjectSortBy)
+  sortBy?: ProjectSortBy = ProjectSortBy.REGISTERED_AT;
+}
+
+export interface ProjectListResponseDto<T> {
+  items: T[];
+  nextCursor?: string;
+  total: number;
+  limit: number;
+  sortOrder: SortOrder;
+  sortBy: ProjectSortBy;
+}

--- a/apps/backend/src/verification/verification.controller.ts
+++ b/apps/backend/src/verification/verification.controller.ts
@@ -13,11 +13,15 @@ import { VerificationService } from './verification.service';
 import {
   CastVoteDto,
   OverrideDto,
+  ProjectVerificationDto,
   RegisterProjectDto,
   UpdateConfigDto,
-  VerificationStatus,
 } from './dto/verification.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import {
+  ProjectListQueryDto,
+  ProjectListResponseDto,
+} from './dto/project-list-query.dto';
 
 @Controller('verification')
 export class VerificationController {
@@ -35,8 +39,10 @@ export class VerificationController {
   }
 
   @Get('projects')
-  listProjects(@Query('status') status?: VerificationStatus) {
-    return this.svc.listProjects(status);
+  listProjects(
+    @Query() query: ProjectListQueryDto,
+  ): ProjectListResponseDto<ProjectVerificationDto> {
+    return this.svc.listProjects(query);
   }
 
   @Get('projects/:id')

--- a/apps/backend/src/verification/verification.service.spec.ts
+++ b/apps/backend/src/verification/verification.service.spec.ts
@@ -228,14 +228,14 @@ describe('VerificationService', () => {
     svc.registerProject({ projectId: 2, ownerPublicKey: 'GB', name: 'P2' });
     svc.overrideVerification({ projectId: 1, verified: true });
 
-    const verified = svc.listProjects(VerificationStatus.Verified);
-    expect(verified).toHaveLength(1);
-    expect(verified[0].projectId).toBe(1);
+    const verified = svc.listProjects({ status: VerificationStatus.Verified });
+    expect(verified.items).toHaveLength(1);
+    expect(verified.items[0].projectId).toBe(1);
 
-    const pending = svc.listProjects(VerificationStatus.Pending);
-    expect(pending).toHaveLength(1);
-    expect(pending[0].projectId).toBe(2);
+    const pending = svc.listProjects({ status: VerificationStatus.Pending });
+    expect(pending.items).toHaveLength(1);
+    expect(pending.items[0].projectId).toBe(2);
 
-    expect(svc.listProjects()).toHaveLength(2);
+    expect(svc.listProjects().items).toHaveLength(2);
   });
 });

--- a/apps/backend/src/verification/verification.service.ts
+++ b/apps/backend/src/verification/verification.service.ts
@@ -17,6 +17,12 @@ import {
   VoteResultDto,
   WeightMode,
 } from './dto/verification.dto';
+import {
+  ProjectListQueryDto,
+  ProjectListResponseDto,
+  ProjectSortBy,
+} from './dto/project-list-query.dto';
+import { SortOrder } from '../common/dto/cursor-pagination.dto';
 
 interface ProjectRecord {
   projectId: number;
@@ -124,10 +130,49 @@ export class VerificationService {
     return this.toDto(this.getRecord(projectId));
   }
 
-  listProjects(status?: VerificationStatus): ProjectVerificationDto[] {
-    return [...this.projects.values()]
+  listProjects(
+    query: ProjectListQueryDto = {},
+  ): ProjectListResponseDto<ProjectVerificationDto> {
+    const status = query.status;
+    const sortBy = query.sortBy ?? ProjectSortBy.REGISTERED_AT;
+    const sortOrder = query.sortOrder ?? SortOrder.DESC;
+    const limit = query.limit ?? 20;
+    const cursor = query.cursor ? Number(query.cursor) : undefined;
+
+    const sorted = [...this.projects.values()]
       .filter((p) => !status || p.status === status)
-      .map((p) => this.toDto(p));
+      .sort((a, b) => {
+        const aValue =
+          sortBy === ProjectSortBy.VOTES_FOR ? a.votesFor : a.registeredAt;
+        const bValue =
+          sortBy === ProjectSortBy.VOTES_FOR ? b.votesFor : b.registeredAt;
+        return sortOrder === SortOrder.ASC ? aValue - bValue : bValue - aValue;
+      });
+
+    const filteredByCursor = sorted.filter((project) => {
+      if (cursor === undefined) return true;
+      const value =
+        sortBy === ProjectSortBy.VOTES_FOR
+          ? project.votesFor
+          : project.registeredAt;
+      return sortOrder === SortOrder.ASC ? value > cursor : value < cursor;
+    });
+
+    const items = filteredByCursor.slice(0, limit).map((p) => this.toDto(p));
+    const last = filteredByCursor[limit - 1];
+
+    return {
+      items,
+      nextCursor: last
+        ? String(
+            sortBy === ProjectSortBy.VOTES_FOR ? last.votesFor : last.registeredAt,
+          )
+        : undefined,
+      total: sorted.length,
+      limit,
+      sortOrder,
+      sortBy,
+    };
   }
 
   isVerified(projectId: number): boolean {


### PR DESCRIPTION
Closes #551

## Changes
- Added a shared cursor pagination query DTO with standardized limit, cursor, and sortOrder.
- Standardized project listing under GET /verification/projects with cursor pagination, sorting, and status filtering.
- Standardized transaction history responses to items/nextCursor/limit/sortOrder and added filter support (	ype, status).
- Standardized analytics chart-data responses to cursor-paginated feed shape.
- Added GET /notifications feed endpoint with cursor pagination and type/severity filters.

## Testing
- Not run (per request to push fast without build/tests).