### PR TITLE
feat: reputation penalty hooks and delegate claim permissions

### DIFF
--- a/apps/onchain/Cargo.lock
+++ b/apps/onchain/Cargo.lock
@@ -1219,7 +1219,7 @@ dependencies = [
 name = "project_registry"
 version = "0.0.0"
 dependencies = [
- "soroban-sdk",
+ "soroban-sdk 23.5.2",
 ]
 
 [[package]]

--- a/apps/onchain/contracts/contributor_registry/src/events.rs
+++ b/apps/onchain/contracts/contributor_registry/src/events.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{contractevent, Address, BytesN, String};
 
 use crate::multisig::{ProposalAction, ProposalStatus};
-use crate::storage::Badge;
+use crate::storage::{Badge, PenaltySeverity};
 
 #[contractevent]
 pub struct UpgradedEvent {
@@ -86,5 +86,16 @@ pub struct BadgeRevokedEvent {
     #[topic]
     pub contributor: Address,
     pub badge: Badge,
+    pub executor: Address,
+}
+
+#[contractevent]
+pub struct ReputationPenaltyAppliedEvent {
+    #[topic]
+    pub contributor: Address,
+    pub dispute_id: u64,
+    pub severity: PenaltySeverity,
+    pub points_deducted: u64,
+    pub reason: String,
     pub executor: Address,
 }

--- a/apps/onchain/contracts/contributor_registry/src/lib.rs
+++ b/apps/onchain/contracts/contributor_registry/src/lib.rs
@@ -8,7 +8,7 @@ mod storage;
 use errors::ContributorError;
 use events::{
     AdminChangedEvent, BadgeGrantedEvent, BadgeRevokedEvent, GaslessRegistrationEvent,
-    MultisigConfiguredEvent, UpgradedEvent,
+    MultisigConfiguredEvent, ReputationPenaltyAppliedEvent, UpgradedEvent,
 };
 use multisig::{
     cancel, consume_approval, expire, get_config, get_proposal, propose, sign, validate_config,
@@ -19,7 +19,10 @@ use soroban_sdk::xdr::FromXdr;
 use soroban_sdk::{
     contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, String, Symbol, Vec,
 };
-use storage::{Badge, ContributorData, ContributorTier, DataKey, LEDGER_BUMP, LEDGER_THRESHOLD};
+use storage::{
+    Badge, ContributorData, ContributorTier, DataKey, PenaltyRecord, PenaltySeverity, LEDGER_BUMP,
+    LEDGER_THRESHOLD,
+};
 
 #[contract]
 pub struct ContributorRegistryContract;
@@ -510,6 +513,73 @@ impl ContributorRegistryContract {
         Ok(())
     }
 
+    /// Apply a reputation penalty triggered by a resolved dispute.
+    ///
+    /// Requires multisig approval for `ProposalAction::ApplyPenalty`.
+    /// Deducts `points` from the contributor's reputation (floored at 0),
+    /// stores a `PenaltyRecord` for auditability, and emits
+    /// `ReputationPenaltyAppliedEvent`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn apply_reputation_penalty(
+        env: Env,
+        executor: Address,
+        proposal_id: u64,
+        contributor_address: Address,
+        dispute_id: u64,
+        severity: PenaltySeverity,
+        points: u64,
+        reason: String,
+    ) -> Result<(), ContributorError> {
+        consume_approval(&env, &executor, proposal_id, &ProposalAction::ApplyPenalty)?;
+
+        let mut contributor: ContributorData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contributor(contributor_address.clone()))
+            .ok_or(ContributorError::ContributorNotFound)?;
+        env.storage().persistent().extend_ttl(
+            &DataKey::Contributor(contributor_address.clone()),
+            LEDGER_THRESHOLD,
+            LEDGER_BUMP,
+        );
+
+        contributor.reputation_score = contributor.reputation_score.saturating_sub(points);
+        env.storage().persistent().set(
+            &DataKey::Contributor(contributor_address.clone()),
+            &contributor,
+        );
+        env.storage().persistent().extend_ttl(
+            &DataKey::Contributor(contributor_address.clone()),
+            LEDGER_THRESHOLD,
+            LEDGER_BUMP,
+        );
+
+        let record = PenaltyRecord {
+            dispute_id,
+            severity,
+            points_deducted: points,
+            reason: reason.clone(),
+            applied_at: env.ledger().timestamp(),
+        };
+        let penalty_key = DataKey::ReputationPenalty(contributor_address.clone());
+        env.storage().persistent().set(&penalty_key, &record);
+        env.storage()
+            .persistent()
+            .extend_ttl(&penalty_key, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+        ReputationPenaltyAppliedEvent {
+            contributor: contributor_address,
+            dispute_id,
+            severity,
+            points_deducted: points,
+            reason,
+            executor,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
     pub fn upgrade(
         env: Env,
         executor: Address,
@@ -581,6 +651,18 @@ impl ContributorRegistryContract {
                 .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
         }
         badges
+    }
+
+    /// Returns the most recent penalty record for a contributor, if any.
+    pub fn get_penalty_record(env: Env, contributor: Address) -> Option<PenaltyRecord> {
+        let key = DataKey::ReputationPenalty(contributor);
+        let record: Option<PenaltyRecord> = env.storage().persistent().get(&key);
+        if record.is_some() {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+        }
+        record
     }
 
     pub fn get_contributor(
@@ -1245,5 +1327,129 @@ mod test {
         client.revoke_badge(&s.alice, &id2, &contributor, &Badge::EarlyAdopter);
 
         assert_eq!(client.get_badges(&contributor).len(), 0);
+    }
+
+    // ── Reputation penalty hooks (issue #691) ─────────────────
+
+    #[test]
+    fn test_apply_penalty_deducts_reputation() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "penalty_dev");
+        client.register_contributor(&contributor, &handle);
+
+        // Give the contributor some reputation first.
+        let id = client.propose(&s.alice, &ProposalAction::UpdateReputation);
+        client.sign(&s.bob, &id);
+        client.update_reputation(&s.alice, &id, &contributor, &100i64);
+        assert_eq!(client.get_reputation(&contributor), 100);
+
+        // Apply a penalty via multisig.
+        let pid = client.propose(&s.alice, &ProposalAction::ApplyPenalty);
+        client.sign(&s.bob, &pid);
+        let reason = soroban_sdk::String::from_str(&s.env, "fraudulent milestone");
+        client.apply_reputation_penalty(
+            &s.alice,
+            &pid,
+            &contributor,
+            &1u64,
+            &PenaltySeverity::Moderate,
+            &30u64,
+            &reason,
+        );
+
+        assert_eq!(client.get_reputation(&contributor), 70);
+    }
+
+    #[test]
+    fn test_apply_penalty_floors_at_zero() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "floor_dev");
+        client.register_contributor(&contributor, &handle);
+
+        // Reputation is 0; penalty should not underflow.
+        let pid = client.propose(&s.alice, &ProposalAction::ApplyPenalty);
+        client.sign(&s.bob, &pid);
+        let reason = soroban_sdk::String::from_str(&s.env, "severe violation");
+        client.apply_reputation_penalty(
+            &s.alice,
+            &pid,
+            &contributor,
+            &2u64,
+            &PenaltySeverity::Severe,
+            &999u64,
+            &reason,
+        );
+
+        assert_eq!(client.get_reputation(&contributor), 0);
+    }
+
+    #[test]
+    fn test_apply_penalty_stores_record() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "record_dev");
+        client.register_contributor(&contributor, &handle);
+
+        let pid = client.propose(&s.alice, &ProposalAction::ApplyPenalty);
+        client.sign(&s.bob, &pid);
+        let reason = soroban_sdk::String::from_str(&s.env, "dispute resolved against");
+        client.apply_reputation_penalty(
+            &s.alice,
+            &pid,
+            &contributor,
+            &42u64,
+            &PenaltySeverity::Minor,
+            &10u64,
+            &reason,
+        );
+
+        let record = client.get_penalty_record(&contributor).unwrap();
+        assert_eq!(record.dispute_id, 42);
+        assert_eq!(record.severity, PenaltySeverity::Minor);
+        assert_eq!(record.points_deducted, 10);
+    }
+
+    #[test]
+    fn test_apply_penalty_requires_multisig() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "noauth_dev");
+        client.register_contributor(&contributor, &handle);
+
+        let reason = soroban_sdk::String::from_str(&s.env, "test");
+        let fake_id = 999u64;
+        assert!(client
+            .try_apply_reputation_penalty(
+                &s.alice,
+                &fake_id,
+                &contributor,
+                &1u64,
+                &PenaltySeverity::Minor,
+                &5u64,
+                &reason,
+            )
+            .is_err());
+    }
+
+    #[test]
+    fn test_get_penalty_record_returns_none_when_absent() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "no_penalty_dev");
+        client.register_contributor(&contributor, &handle);
+
+        assert!(client.get_penalty_record(&contributor).is_none());
     }
 }

--- a/apps/onchain/contracts/contributor_registry/src/multisig.rs
+++ b/apps/onchain/contracts/contributor_registry/src/multisig.rs
@@ -44,6 +44,7 @@ pub enum ProposalAction {
     UpdateReputation,
     GrantBadge,
     RevokeBadge,
+    ApplyPenalty,
 }
 
 #[contracttype]

--- a/apps/onchain/contracts/contributor_registry/src/storage.rs
+++ b/apps/onchain/contracts/contributor_registry/src/storage.rs
@@ -22,6 +22,10 @@ pub enum DataKey {
 
     // ── Badge keys ────────────────────────────────────────────
     Badges(Address),
+
+    // ── Penalty keys ──────────────────────────────────────────
+    /// Latest penalty record for a contributor (keyed by contributor address).
+    ReputationPenalty(Address),
 }
 
 #[contracttype]
@@ -51,4 +55,26 @@ pub enum Badge {
     BugHunter = 2,
     TopContributor = 3,
     SecurityAuditor = 4,
+}
+
+/// How severe the dispute outcome was.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum PenaltySeverity {
+    Minor = 1,
+    Moderate = 2,
+    Severe = 3,
+}
+
+/// Metadata stored on-chain for each applied penalty.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PenaltyRecord {
+    /// The dispute that triggered this penalty.
+    pub dispute_id: u64,
+    pub severity: PenaltySeverity,
+    pub points_deducted: u64,
+    pub reason: String,
+    pub applied_at: u64,
 }

--- a/apps/onchain/contracts/vesting-wallet/src/errors.rs
+++ b/apps/onchain/contracts/vesting-wallet/src/errors.rs
@@ -14,4 +14,5 @@ pub enum VestingError {
     NothingToClaim = 8,
     InsufficientBalance = 9,
     Reentrancy = 10,
+    DelegateNotAuthorized = 11,
 }

--- a/apps/onchain/contracts/vesting-wallet/src/events.rs
+++ b/apps/onchain/contracts/vesting-wallet/src/events.rs
@@ -35,3 +35,32 @@ pub struct AdminChangedEvent {
     pub old_admin: Address,
     pub new_admin: Address,
 }
+
+/// Emitted when a beneficiary approves a delegate for claim actions.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegateApprovedEvent {
+    #[topic]
+    pub beneficiary: Address,
+    pub delegate: Address,
+}
+
+/// Emitted when a beneficiary revokes a delegate.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegateRevokedEvent {
+    #[topic]
+    pub beneficiary: Address,
+    pub delegate: Address,
+}
+
+/// Emitted when a delegate executes a claim on behalf of a beneficiary.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DelegatedClaimEvent {
+    #[topic]
+    pub beneficiary: Address,
+    pub delegate: Address,
+    pub amount_claimed: i128,
+    pub remaining: i128,
+}

--- a/apps/onchain/contracts/vesting-wallet/src/lib.rs
+++ b/apps/onchain/contracts/vesting-wallet/src/lib.rs
@@ -9,7 +9,7 @@ mod vault_interface;
 use errors::VestingError;
 use events::{AdminChangedEvent, UpgradedEvent};
 use reentrancy_guard::{acquire as acquire_reentrancy, release as release_reentrancy};
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Vec};
 use storage::{
     DataKey, MilestoneLink, MilestoneRequirement, VestingData, LEDGER_BUMP, LEDGER_THRESHOLD,
 };
@@ -452,6 +452,196 @@ impl VestingWalletContract {
         }
         .publish(&env);
         Ok(())
+    }
+
+    // ── Delegate claim permissions ────────────────────────────
+
+    /// Approve `delegate` to execute claim actions on behalf of `beneficiary`.
+    ///
+    /// Requires authorization from `beneficiary`. Delegates can only call
+    /// `claim_for`; they cannot modify vesting schedules or admin settings.
+    pub fn approve_delegate(
+        env: Env,
+        beneficiary: Address,
+        delegate: Address,
+    ) -> Result<(), VestingError> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(VestingError::NotInitialized);
+        }
+        beneficiary.require_auth();
+
+        let key = DataKey::Delegates(beneficiary.clone());
+        let mut delegates: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(&env));
+
+        if !delegates.contains(&delegate) {
+            delegates.push_back(delegate.clone());
+            env.storage().persistent().set(&key, &delegates);
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+        }
+
+        events::DelegateApprovedEvent {
+            beneficiary,
+            delegate,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Revoke a previously approved delegate.
+    ///
+    /// Requires authorization from `beneficiary`.
+    pub fn revoke_delegate(
+        env: Env,
+        beneficiary: Address,
+        delegate: Address,
+    ) -> Result<(), VestingError> {
+        if !env.storage().instance().has(&DataKey::Admin) {
+            return Err(VestingError::NotInitialized);
+        }
+        beneficiary.require_auth();
+
+        let key = DataKey::Delegates(beneficiary.clone());
+        let mut delegates: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(&env));
+
+        if let Some(idx) = delegates.first_index_of(&delegate) {
+            delegates.remove(idx);
+            if delegates.is_empty() {
+                env.storage().persistent().remove(&key);
+            } else {
+                env.storage().persistent().set(&key, &delegates);
+                env.storage()
+                    .persistent()
+                    .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+            }
+        }
+
+        events::DelegateRevokedEvent {
+            beneficiary,
+            delegate,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Execute a claim on behalf of `beneficiary`.
+    ///
+    /// Requires authorization from `delegate`. The delegate must have been
+    /// previously approved by the beneficiary via `approve_delegate`.
+    /// Tokens are always transferred to the beneficiary, never to the delegate.
+    pub fn claim_for(
+        env: Env,
+        delegate: Address,
+        beneficiary: Address,
+    ) -> Result<i128, VestingError> {
+        Self::with_reentrancy_guard(&env, || {
+            if !env.storage().instance().has(&DataKey::Admin) {
+                return Err(VestingError::NotInitialized);
+            }
+            env.storage()
+                .instance()
+                .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
+
+            delegate.require_auth();
+
+            // Verify delegate is approved by beneficiary.
+            let delegates_key = DataKey::Delegates(beneficiary.clone());
+            let delegates: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&delegates_key)
+                .unwrap_or(Vec::new(&env));
+            if !delegates.contains(&delegate) {
+                return Err(VestingError::DelegateNotAuthorized);
+            }
+            env.storage()
+                .persistent()
+                .extend_ttl(&delegates_key, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+            let vesting_key = DataKey::Vesting(beneficiary.clone());
+            let mut vesting: VestingData = env
+                .storage()
+                .persistent()
+                .get(&vesting_key)
+                .ok_or(VestingError::VestingNotFound)?;
+            env.storage()
+                .persistent()
+                .extend_ttl(&vesting_key, LEDGER_THRESHOLD, LEDGER_BUMP);
+
+            let current_time = env.ledger().timestamp();
+            let available_amount = Self::calculate_claimable_amount(&env, current_time, &vesting);
+            if available_amount <= 0 {
+                return Err(VestingError::NothingToClaim);
+            }
+
+            let token: Address = env
+                .storage()
+                .instance()
+                .get(&DataKey::Token)
+                .ok_or(VestingError::NotInitialized)?;
+            env.storage()
+                .instance()
+                .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
+
+            vesting.claimed_amount += available_amount;
+            let remaining = vesting.total_amount - vesting.claimed_amount;
+
+            if remaining == 0 {
+                env.storage().persistent().remove(&vesting_key);
+            } else {
+                env.storage().persistent().set(&vesting_key, &vesting);
+                env.storage()
+                    .persistent()
+                    .extend_ttl(&vesting_key, LEDGER_THRESHOLD, LEDGER_BUMP);
+            }
+
+            let contract_address = env.current_contract_address();
+            // Tokens always go to the beneficiary, not the delegate.
+            transfer(
+                &env,
+                &token,
+                &contract_address,
+                &beneficiary,
+                &available_amount,
+            );
+
+            events::DelegatedClaimEvent {
+                beneficiary: vesting.beneficiary.clone(),
+                delegate,
+                amount_claimed: available_amount,
+                remaining,
+            }
+            .publish(&env);
+
+            Ok(available_amount)
+        })
+    }
+
+    /// Returns the list of approved delegates for a beneficiary.
+    pub fn get_delegates(env: Env, beneficiary: Address) -> Vec<Address> {
+        let key = DataKey::Delegates(beneficiary);
+        let delegates: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(Vec::new(&env));
+        if env.storage().persistent().has(&key) {
+            env.storage()
+                .persistent()
+                .extend_ttl(&key, LEDGER_THRESHOLD, LEDGER_BUMP);
+        }
+        delegates
     }
 }
 

--- a/apps/onchain/contracts/vesting-wallet/src/storage.rs
+++ b/apps/onchain/contracts/vesting-wallet/src/storage.rs
@@ -12,6 +12,8 @@ pub enum DataKey {
     Admin,            // -> Address
     Token,            // -> Address
     Vesting(Address), // beneficiary -> VestingData
+    /// Approved delegates for a beneficiary: beneficiary -> Vec<Address>
+    Delegates(Address),
 }
 
 #[contracttype]

--- a/apps/onchain/contracts/vesting-wallet/src/test.rs
+++ b/apps/onchain/contracts/vesting-wallet/src/test.rs
@@ -920,3 +920,135 @@ fn test_claim_cei_state_updated_before_balance_assertion() {
     assert_eq!(vesting.claimed_amount, amount / 2);
     assert_eq!(token_client.balance(&beneficiary), amount / 2);
 }
+
+// ---------------------------------------------------------------------------
+// Delegate claim permissions (issue #688)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_approve_and_get_delegates() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, beneficiary, token_client, _) = setup_test(&env);
+    client.initialize(&admin, &token_client.address);
+
+    let delegate = Address::generate(&env);
+
+    assert_eq!(client.get_delegates(&beneficiary).len(), 0);
+
+    client.approve_delegate(&beneficiary, &delegate);
+
+    let delegates = client.get_delegates(&beneficiary);
+    assert_eq!(delegates.len(), 1);
+    assert!(delegates.contains(&delegate));
+}
+
+#[test]
+fn test_revoke_delegate() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, beneficiary, token_client, _) = setup_test(&env);
+    client.initialize(&admin, &token_client.address);
+
+    let delegate = Address::generate(&env);
+    client.approve_delegate(&beneficiary, &delegate);
+    assert_eq!(client.get_delegates(&beneficiary).len(), 1);
+
+    client.revoke_delegate(&beneficiary, &delegate);
+    assert_eq!(client.get_delegates(&beneficiary).len(), 0);
+}
+
+#[test]
+fn test_claim_for_by_approved_delegate() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, beneficiary, token_client, _) = setup_test(&env);
+    client.initialize(&admin, &token_client.address);
+
+    let delegate = Address::generate(&env);
+    client.approve_delegate(&beneficiary, &delegate);
+
+    let current_time = env.ledger().timestamp();
+    let start_time = current_time + 100;
+    let duration = 10_000u64;
+    let amount: i128 = 1_000_000;
+    client.create_vesting(&admin, &beneficiary, &amount, &start_time, &duration);
+
+    // Fast-forward to halfway through vesting.
+    env.ledger().set_timestamp(start_time + duration / 2);
+
+    let claimed = client.claim_for(&delegate, &beneficiary);
+    assert_eq!(claimed, amount / 2);
+
+    // Tokens go to beneficiary, not delegate.
+    assert_eq!(token_client.balance(&beneficiary), amount / 2);
+    assert_eq!(token_client.balance(&delegate), 0);
+}
+
+#[test]
+fn test_claim_for_rejected_without_approval() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, beneficiary, token_client, _) = setup_test(&env);
+    client.initialize(&admin, &token_client.address);
+
+    let current_time = env.ledger().timestamp();
+    let start_time = current_time + 100;
+    let duration = 10_000u64;
+    let amount: i128 = 1_000_000;
+    client.create_vesting(&admin, &beneficiary, &amount, &start_time, &duration);
+
+    env.ledger().set_timestamp(start_time + duration / 2);
+
+    let unauthorized = Address::generate(&env);
+    let result = client.try_claim_for(&unauthorized, &beneficiary);
+    assert_eq!(result, Err(Ok(VestingError::DelegateNotAuthorized)));
+}
+
+#[test]
+fn test_claim_for_rejected_after_revocation() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, beneficiary, token_client, _) = setup_test(&env);
+    client.initialize(&admin, &token_client.address);
+
+    let delegate = Address::generate(&env);
+    client.approve_delegate(&beneficiary, &delegate);
+    client.revoke_delegate(&beneficiary, &delegate);
+
+    let current_time = env.ledger().timestamp();
+    let start_time = current_time + 100;
+    let duration = 10_000u64;
+    let amount: i128 = 1_000_000;
+    client.create_vesting(&admin, &beneficiary, &amount, &start_time, &duration);
+
+    env.ledger().set_timestamp(start_time + duration / 2);
+
+    let result = client.try_claim_for(&delegate, &beneficiary);
+    assert_eq!(result, Err(Ok(VestingError::DelegateNotAuthorized)));
+}
+
+#[test]
+fn test_multiple_delegates_for_one_beneficiary() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, beneficiary, token_client, _) = setup_test(&env);
+    client.initialize(&admin, &token_client.address);
+
+    let delegate1 = Address::generate(&env);
+    let delegate2 = Address::generate(&env);
+
+    client.approve_delegate(&beneficiary, &delegate1);
+    client.approve_delegate(&beneficiary, &delegate2);
+
+    let delegates = client.get_delegates(&beneficiary);
+    assert_eq!(delegates.len(), 2);
+    assert!(delegates.contains(&delegate1));
+    assert!(delegates.contains(&delegate2));
+}


### PR DESCRIPTION
## Summary

Resolves #691 and #688 — both Soroban smart contract issues assigned to @Xhristin3.

---

## Issue #691 — Slashing-ready Reputation Hooks for Fraudulent Milestone Behavior

**Contract:** `apps/onchain/contracts/contributor_registry`

### Changes
- **`storage.rs`**: Added `PenaltySeverity` enum (`Minor`/`Moderate`/`Severe`), `PenaltyRecord` struct (`dispute_id`, `severity`, `points_deducted`, `reason`, `applied_at`), and `ReputationPenalty(Address)` `DataKey` variant.
- **`multisig.rs`**: Added `ApplyPenalty` variant to `ProposalAction` — ensures penalty application is multisig-gated and cannot be replayed as any other action.
- **`events.rs`**: Added `ReputationPenaltyAppliedEvent` with full penalty metadata.
- **`lib.rs`**: Added `apply_reputation_penalty()` (multisig-gated, deducts points with saturation, stores `PenaltyRecord`) and `get_penalty_record()` query.

### Tests (5 new)
- Penalty deducts reputation correctly
- Reputation floors at zero (no underflow)
- `PenaltyRecord` is stored and readable
- Requires valid multisig approval
- Returns `None` when no penalty exists

---

## Issue #688 — Delegate Claim Permissions for Team and Project Treasury Operations

**Contract:** `apps/onchain/contracts/vesting-wallet`

### Changes
- **`storage.rs`**: Added `Delegates(Address)` `DataKey` variant (beneficiary → `Vec<Address>`).
- **`errors.rs`**: Added `DelegateNotAuthorized = 11`.
- **`events.rs`**: Added `DelegateApprovedEvent`, `DelegateRevokedEvent`, `DelegatedClaimEvent`.
- **`lib.rs`**: Added `approve_delegate()`, `revoke_delegate()`, `claim_for()`, `get_delegates()`. Tokens in `claim_for` always transfer to the beneficiary — delegates cannot redirect funds.

### Tests (6 new)
- Approve delegate and verify list
- Revoke delegate removes from list
- Approved delegate can execute claim; tokens go to beneficiary
- Unapproved delegate is rejected (`DelegateNotAuthorized`)
- Revoked delegate is rejected after revocation
- Multiple delegates can be approved for one beneficiary

---
closes #688 
closes #691 

## CI
All checks pass locally:
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo build --target wasm32-unknown-unknown --release` ✅
- `cargo test` ✅ (227 tests total, 0 failures)