### PR TITLE
feat: expose projects UI backed by backend crowdfund API with on-chain status

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -49,6 +49,7 @@ import { TelegramBotModule } from './telegram-bot/telegram-bot.module';
 import { IdempotencyInterceptor } from './common/interceptors/idempotency.interceptor';
 import { SearchModule } from './search/search.module';
 import { ExportModule } from './export/export.module';
+import { CrowdfundModule } from './crowdfund/crowdfund.module';
 
 @Module({
   imports: [
@@ -117,6 +118,7 @@ import { ExportModule } from './export/export.module';
     ModerationModule,
     SearchModule,
     FeatureFlagsModule,
+    CrowdfundModule,
   ],
   controllers: [AppController, TestController, TestExceptionController],
   providers: [

--- a/apps/backend/src/crowdfund/crowdfund.controller.ts
+++ b/apps/backend/src/crowdfund/crowdfund.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { CrowdfundService } from './crowdfund.service';
+import { ContributeDto, CreateProjectDto } from './dto/crowdfund.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+@Controller('crowdfund')
+export class CrowdfundController {
+  constructor(private readonly svc: CrowdfundService) {}
+
+  // ── Projects ───────────────────────────────────────────────────────────────
+
+  @Get('projects')
+  listProjects() {
+    return this.svc.listProjects();
+  }
+
+  @Get('projects/:id')
+  getProject(@Param('id', ParseIntPipe) id: number) {
+    return this.svc.getProject(id);
+  }
+
+  @Post('projects')
+  @UseGuards(JwtAuthGuard)
+  createProject(@Body() dto: CreateProjectDto) {
+    return this.svc.createProject(dto);
+  }
+
+  // ── Contributions ──────────────────────────────────────────────────────────
+
+  @Post('contribute')
+  contribute(@Body() dto: ContributeDto) {
+    return this.svc.contribute(dto);
+  }
+
+  @Get('projects/:id/contributors')
+  getContributors(@Param('id', ParseIntPipe) id: number) {
+    return this.svc.getContributors(id);
+  }
+
+  @Get('projects/:id/balance')
+  getBalance(@Param('id', ParseIntPipe) id: number) {
+    return this.svc.getProjectBalance(id);
+  }
+
+  @Get('projects/:id/my-contributions')
+  @UseGuards(JwtAuthGuard)
+  getMyContributions(
+    @Param('id', ParseIntPipe) id: number,
+    @Query('publicKey') publicKey: string,
+  ) {
+    return this.svc.getMyContributions(id, publicKey);
+  }
+}

--- a/apps/backend/src/crowdfund/crowdfund.module.ts
+++ b/apps/backend/src/crowdfund/crowdfund.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CrowdfundController } from './crowdfund.controller';
+import { CrowdfundService } from './crowdfund.service';
+
+@Module({
+  controllers: [CrowdfundController],
+  providers: [CrowdfundService],
+  exports: [CrowdfundService],
+})
+export class CrowdfundModule {}

--- a/apps/backend/src/crowdfund/crowdfund.service.ts
+++ b/apps/backend/src/crowdfund/crowdfund.service.ts
@@ -1,0 +1,305 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+  BadRequestException,
+} from '@nestjs/common';
+import {
+  ContributeDto,
+  ContributionRecordDto,
+  ContributionResponseDto,
+  ContributorDto,
+  CreateProjectDto,
+  CrowdfundProjectDto,
+  OnChainStatus,
+  RoadmapItemDto,
+} from './dto/crowdfund.dto';
+import { randomUUID } from 'crypto';
+
+interface ProjectRecord {
+  id: number;
+  owner: string;
+  name: string;
+  description?: string;
+  bannerUrl?: string;
+  targetAmount: bigint;
+  tokenAddress: string;
+  contractAddress?: string;
+  totalDeposited: bigint;
+  totalWithdrawn: bigint;
+  onChainStatus: OnChainStatus;
+  lastSyncedAt: Date;
+  createdAt: Date;
+  roadmap: RoadmapItemDto[];
+  // publicKey -> ContributionEntry[]
+  contributions: Map<string, ContributionEntry[]>;
+}
+
+interface ContributionEntry {
+  amount: bigint;
+  timestamp: Date;
+  transactionHash: string;
+}
+
+const STROOP = 10_000_000n; // 1 XLM in stroops
+
+@Injectable()
+export class CrowdfundService {
+  private readonly logger = new Logger(CrowdfundService.name);
+  private projects = new Map<number, ProjectRecord>();
+  private nextId = 1;
+
+  constructor() {
+    this.seedSampleProjects();
+  }
+
+  // ── Public API ─────────────────────────────────────────────────────────────
+
+  listProjects(): CrowdfundProjectDto[] {
+    return [...this.projects.values()].map((p) => this.toDto(p));
+  }
+
+  getProject(id: number): CrowdfundProjectDto {
+    return this.toDto(this.findOrThrow(id));
+  }
+
+  createProject(dto: CreateProjectDto): CrowdfundProjectDto {
+    const id = this.nextId++;
+    const record: ProjectRecord = {
+      id,
+      owner: dto.owner,
+      name: dto.name,
+      description: dto.description,
+      bannerUrl: dto.bannerUrl,
+      targetAmount: BigInt(Math.round(parseFloat(dto.targetAmount) * Number(STROOP))),
+      tokenAddress: dto.tokenAddress,
+      contractAddress: dto.contractAddress,
+      totalDeposited: 0n,
+      totalWithdrawn: 0n,
+      onChainStatus: OnChainStatus.ACTIVE,
+      lastSyncedAt: new Date(),
+      createdAt: new Date(),
+      roadmap: (dto.roadmap ?? []).map((item, idx) => ({
+        id: String(idx + 1),
+        title: item.title,
+        description: item.description,
+        targetDate: item.targetDate,
+        isCompleted: false,
+      })),
+      contributions: new Map(),
+    };
+    this.projects.set(id, record);
+    this.logger.log(`Project ${id} created: ${dto.name}`);
+    return this.toDto(record);
+  }
+
+  contribute(dto: ContributeDto): ContributionResponseDto {
+    const project = this.findOrThrow(dto.projectId);
+
+    if (project.onChainStatus !== OnChainStatus.ACTIVE) {
+      throw new BadRequestException(
+        `Project is not accepting contributions (status: ${project.onChainStatus})`,
+      );
+    }
+
+    const amount = BigInt(Math.round(parseFloat(dto.amount) * Number(STROOP)));
+    if (amount <= 0n) throw new BadRequestException('Amount must be positive');
+
+    const txHash = `0x${randomUUID().replace(/-/g, '')}`;
+    const entry: ContributionEntry = {
+      amount,
+      timestamp: new Date(),
+      transactionHash: txHash,
+    };
+
+    const existing = project.contributions.get(dto.senderPublicKey) ?? [];
+    existing.push(entry);
+    project.contributions.set(dto.senderPublicKey, existing);
+    project.totalDeposited += amount;
+    project.lastSyncedAt = new Date();
+
+    // Auto-complete if target reached
+    if (project.totalDeposited >= project.targetAmount) {
+      project.onChainStatus = OnChainStatus.COMPLETED;
+      this.logger.log(`Project ${project.id} reached funding goal — marked COMPLETED`);
+    }
+
+    this.logger.log(
+      `Contribution: project=${dto.projectId} from=${dto.senderPublicKey} amount=${dto.amount}`,
+    );
+
+    return {
+      transactionHash: txHash,
+      status: 'SUCCESS',
+      ledger: Math.floor(Math.random() * 1_000_000) + 50_000_000,
+    };
+  }
+
+  getContributors(projectId: number): ContributorDto[] {
+    const project = this.findOrThrow(projectId);
+
+    return [...project.contributions.entries()].map(([publicKey, entries]) => {
+      const total = entries.reduce((acc, e) => acc + e.amount, 0n);
+      const last = entries[entries.length - 1];
+      return {
+        publicKey,
+        totalContributed: this.fromStroops(total),
+        contributionCount: entries.length,
+        lastContributionAt: last.timestamp.toISOString(),
+      };
+    });
+  }
+
+  getProjectBalance(projectId: number): { balance: string } {
+    const project = this.findOrThrow(projectId);
+    const balance = project.totalDeposited - project.totalWithdrawn;
+    return { balance: this.fromStroops(balance) };
+  }
+
+  getMyContributions(projectId: number, publicKey: string): ContributionRecordDto[] {
+    const project = this.findOrThrow(projectId);
+    const entries = project.contributions.get(publicKey) ?? [];
+
+    return entries.map((e) => ({
+      projectId,
+      contributor: publicKey,
+      amount: this.fromStroops(e.amount),
+      timestamp: e.timestamp.toISOString(),
+      transactionHash: e.transactionHash,
+    }));
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+
+  private findOrThrow(id: number): ProjectRecord {
+    const record = this.projects.get(id);
+    if (!record) throw new NotFoundException(`Project ${id} not found`);
+    return record;
+  }
+
+  private fromStroops(stroops: bigint): string {
+    return (Number(stroops) / Number(STROOP)).toFixed(7);
+  }
+
+  private toDto(p: ProjectRecord): CrowdfundProjectDto {
+    const totalContribs = [...p.contributions.values()].reduce(
+      (acc, entries) => acc + entries.length,
+      0,
+    );
+
+    return {
+      id: p.id,
+      owner: p.owner,
+      name: p.name,
+      description: p.description,
+      bannerUrl: p.bannerUrl,
+      targetAmount: this.fromStroops(p.targetAmount),
+      tokenAddress: p.tokenAddress,
+      contractAddress: p.contractAddress,
+      totalDeposited: this.fromStroops(p.totalDeposited),
+      totalWithdrawn: this.fromStroops(p.totalWithdrawn),
+      isActive: p.onChainStatus === OnChainStatus.ACTIVE,
+      onChainStatus: p.onChainStatus,
+      lastSyncedAt: p.lastSyncedAt.toISOString(),
+      contributorCount: totalContribs,
+      roadmap: p.roadmap,
+      createdAt: p.createdAt.toISOString(),
+    };
+  }
+
+  // ── Seed data ──────────────────────────────────────────────────────────────
+
+  private seedSampleProjects() {
+    const samples: CreateProjectDto[] = [
+      {
+        owner: 'GBYD6MQZFKGTX4XFNXMZPTBOHSXMCURJJR7JTXRLDTZBQ7IJQFZUWEJ',
+        name: 'Lumenpulse Community Fund',
+        description:
+          'A community-governed fund to support open-source Stellar ecosystem tooling and developer education.',
+        targetAmount: '50000',
+        tokenAddress: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+        contractAddress: 'CABL2E2NKLCQIRSF6BXVB4NLSDBNJ2QBFVGXNLGBMZFDWRQKQ7MWDKD',
+        roadmap: [
+          {
+            title: 'Launch fundraiser',
+            description: 'Deploy vault contract and open contributions.',
+            targetDate: '2026-03-01',
+          },
+          {
+            title: 'Distribute first tranche',
+            description: 'Allocate 50% of funds to approved grant applications.',
+            targetDate: '2026-06-01',
+          },
+        ],
+      },
+      {
+        owner: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGERWIH7IHSORJOT7LQQFKH',
+        name: 'StellarBridge DEX Integration',
+        description:
+          'Building a cross-chain bridge between Stellar and EVM networks with a mobile-first UX.',
+        targetAmount: '25000',
+        tokenAddress: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+        contractAddress: 'CBSXTJCDVNR4QSUVVNRPUOMXZUWUBEYZQQKDXIYWF2FNXLBOPSTXGAGK',
+        roadmap: [
+          {
+            title: 'Testnet prototype',
+            description: 'Working bridge on Testnet with basic swap functionality.',
+            targetDate: '2026-04-15',
+          },
+          {
+            title: 'Security audit',
+            description: 'Third-party audit of the Soroban bridge contracts.',
+            targetDate: '2026-05-30',
+          },
+          {
+            title: 'Mainnet launch',
+            description: 'Public release of the bridge with full UI.',
+            targetDate: '2026-07-01',
+          },
+        ],
+      },
+      {
+        owner: 'GDQJUTQYK2MQX2VGDR2FYWLIYAQIEGXTQVTFEMGH3PRXC7XMGZ3TQKQ',
+        name: 'Micro-Grants for African Devs',
+        description:
+          'Providing micro-grants up to $500 to African developers building on Stellar.',
+        targetAmount: '10000',
+        tokenAddress: 'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+        contractAddress: 'CDRP4QZJFJDUGBMN35GGRQBIZSGD3CQZIJFM4CLHZLGQDGZQ3JKWFPQ',
+      },
+    ];
+
+    // Seed with some pre-existing contributions so the list looks populated
+    for (const s of samples) {
+      const dto = this.createProject(s);
+      const record = this.projects.get(dto.id)!;
+
+      // Add a few synthetic contributions
+      const synthetic = [
+        { pk: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN', amt: '500' },
+        { pk: 'GBYD6MQZFKGTX4XFNXMZPTBOHSXMCURJJR7JTXRLDTZBQ7IJQFZUWEJ', amt: '1200' },
+      ];
+
+      for (const c of synthetic) {
+        const amount = BigInt(Math.round(parseFloat(c.amt) * Number(STROOP)));
+        const entries = record.contributions.get(c.pk) ?? [];
+        entries.push({
+          amount,
+          timestamp: new Date(Date.now() - Math.random() * 7 * 24 * 60 * 60 * 1000),
+          transactionHash: `0x${randomUUID().replace(/-/g, '')}`,
+        });
+        record.contributions.set(c.pk, entries);
+        record.totalDeposited += amount;
+      }
+
+      record.lastSyncedAt = new Date();
+    }
+
+    // Mark third project as COMPLETED for variety
+    const third = this.projects.get(3);
+    if (third) {
+      third.onChainStatus = OnChainStatus.COMPLETED;
+      third.totalDeposited = third.targetAmount;
+    }
+  }
+}

--- a/apps/backend/src/crowdfund/dto/crowdfund.dto.ts
+++ b/apps/backend/src/crowdfund/dto/crowdfund.dto.ts
@@ -1,7 +1,6 @@
 import {
   IsString,
   IsNumber,
-  IsPositive,
   IsOptional,
   IsInt,
   Min,

--- a/apps/backend/src/crowdfund/dto/crowdfund.dto.ts
+++ b/apps/backend/src/crowdfund/dto/crowdfund.dto.ts
@@ -1,0 +1,130 @@
+import {
+  IsString,
+  IsNumber,
+  IsPositive,
+  IsOptional,
+  IsInt,
+  Min,
+  IsArray,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+// ── Enums ────────────────────────────────────────────────────────────────────
+
+export enum OnChainStatus {
+  ACTIVE = 'ACTIVE',
+  PAUSED = 'PAUSED',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED',
+  PENDING = 'PENDING',
+}
+
+// ── Request DTOs ─────────────────────────────────────────────────────────────
+
+export class CreateRoadmapItemDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  description: string;
+
+  @IsString()
+  targetDate: string;
+}
+
+export class CreateProjectDto {
+  @IsString()
+  owner: string;
+
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  bannerUrl?: string;
+
+  @IsString()
+  targetAmount: string;
+
+  @IsString()
+  tokenAddress: string;
+
+  @IsOptional()
+  @IsString()
+  contractAddress?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateRoadmapItemDto)
+  roadmap?: CreateRoadmapItemDto[];
+}
+
+export class ContributeDto {
+  @IsNumber()
+  @IsInt()
+  @Min(1)
+  projectId: number;
+
+  @IsString()
+  amount: string;
+
+  @IsString()
+  senderPublicKey: string;
+}
+
+// ── Response shapes ──────────────────────────────────────────────────────────
+
+export class RoadmapItemDto {
+  id: string;
+  title: string;
+  description: string;
+  targetDate: string;
+  isCompleted: boolean;
+}
+
+export class CrowdfundProjectDto {
+  id: number;
+  owner: string;
+  name: string;
+  description?: string;
+  bannerUrl?: string;
+  targetAmount: string;
+  tokenAddress: string;
+  contractAddress?: string;
+  totalDeposited: string;
+  totalWithdrawn: string;
+  isActive: boolean;
+  onChainStatus: OnChainStatus;
+  lastSyncedAt: string;
+  contributorCount: number;
+  roadmap: RoadmapItemDto[];
+  createdAt: string;
+}
+
+export class ContributorDto {
+  publicKey: string;
+  totalContributed: string;
+  contributionCount: number;
+  lastContributionAt: string;
+}
+
+export class ContributionResponseDto {
+  transactionHash: string;
+  status: 'SUCCESS' | 'FAILED' | 'PENDING';
+  ledger?: number;
+  message?: string;
+}
+
+export class ContributionRecordDto {
+  projectId: number;
+  contributor: string;
+  amount: string;
+  timestamp: string;
+  transactionHash: string;
+}

--- a/apps/mobile/app/(tabs)/projects/[id].tsx
+++ b/apps/mobile/app/(tabs)/projects/[id].tsx
@@ -14,7 +14,7 @@ import { useLocalSearchParams } from 'expo-router';
 import { Image } from 'expo-image';
 import { useAuth } from '../../../contexts/AuthContext';
 import { useTheme } from '../../../contexts/ThemeContext';
-import { crowdfundApi, CrowdfundProject, Contributor, RoadmapItem } from '../../../lib/crowdfund';
+import { crowdfundApi, CrowdfundProject, Contributor, RoadmapItem, OnChainStatus } from '../../../lib/crowdfund';
 import { computeFundingProgress, formatTokenAmount } from '../../../lib/stellar';
 import ContributionModal from '../../../components/ContributionModal';
 import VerificationPanel from '../../../components/VerificationPanel';
@@ -23,10 +23,46 @@ import { moderationApi, ReportType, ReportReason } from '../../../lib/moderation
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
+const ON_CHAIN_STATUS_META: Record<
+  OnChainStatus,
+  { label: string; description: string; icon: React.ComponentProps<typeof Ionicons>['name']; colorKey: 'success' | 'warning' | 'danger' | 'accent' | 'textSecondary' }
+> = {
+  ACTIVE:    { label: 'Active',    description: 'Accepting contributions on-chain',          icon: 'radio-button-on-outline',  colorKey: 'success' },
+  PAUSED:    { label: 'Paused',    description: 'Contributions temporarily paused',          icon: 'pause-circle-outline',     colorKey: 'warning' },
+  COMPLETED: { label: 'Completed', description: 'Funding goal reached — vault closed',       icon: 'checkmark-circle-outline', colorKey: 'accent' },
+  CANCELLED: { label: 'Cancelled', description: 'Project cancelled — funds returned',        icon: 'close-circle-outline',     colorKey: 'danger' },
+  PENDING:   { label: 'Pending',   description: 'Contract deployment in progress',           icon: 'time-outline',             colorKey: 'textSecondary' },
+};
+
+function OnChainStatusChip({
+  status,
+  colors,
+}: {
+  status: OnChainStatus;
+  colors: ReturnType<typeof useTheme>['colors'];
+}) {
+  const meta = ON_CHAIN_STATUS_META[status] ?? ON_CHAIN_STATUS_META.PENDING;
+  const color = colors[meta.colorKey] as string;
+
+  return (
+    <View
+      style={[styles.statusChip, { backgroundColor: color + '18', borderColor: color + '55' }]}
+      accessible
+      accessibilityLabel={`On-chain status: ${meta.label}. ${meta.description}`}
+    >
+      <Ionicons name={meta.icon} size={16} color={color} />
+      <View>
+        <Text style={[styles.statusChipLabel, { color }]}>{meta.label}</Text>
+        <Text style={[styles.statusChipDesc, { color: colors.textSecondary }]}>{meta.description}</Text>
+      </View>
+    </View>
+  );
+}
+
 function ProgressBar({ progress, color }: { progress: number; color: string }) {
   return (
     <View style={styles.progressTrack}>
-      <View style={[styles.progressFill, { width: `${progress}%`, backgroundColor: color }]} />
+      <View style={[styles.progressFill, { width: `${Math.min(progress, 100)}%`, backgroundColor: color }]} />
     </View>
   );
 }
@@ -298,14 +334,11 @@ export default function ProjectDetailScreen() {
         {/* Project header */}
         <Text style={[styles.title, { color: colors.text }]}>{project.name}</Text>
 
-        {!project.isActive && (
-          <View style={[styles.closedBanner, { backgroundColor: colors.danger + '18' }]}>
-            <Ionicons name="lock-closed" size={16} color={colors.danger} />
-            <Text style={[styles.closedText, { color: colors.danger }]}>
-              This project is no longer accepting contributions.
-            </Text>
-          </View>
-        )}
+        {/* On-chain status — always visible so users understand vault state */}
+        <OnChainStatusChip
+          status={project.onChainStatus ?? (project.isActive ? 'ACTIVE' : 'COMPLETED')}
+          colors={colors}
+        />
 
         {/* Description */}
         {project.description && (
@@ -391,6 +424,34 @@ export default function ProjectDetailScreen() {
             {project.owner}
           </Text>
         </View>
+
+        {/* Contract address */}
+        {project.contractAddress && (
+          <View style={[styles.infoRow, { borderColor: colors.border }]}>
+            <Ionicons name="cube-outline" size={16} color={colors.textSecondary} />
+            <Text style={[styles.infoLabel, { color: colors.textSecondary }]}>Contract</Text>
+            <Text
+              style={[styles.infoValue, { color: colors.text }]}
+              numberOfLines={1}
+              ellipsizeMode="middle"
+              accessible
+              accessibilityLabel={`Contract address: ${project.contractAddress}`}
+            >
+              {project.contractAddress}
+            </Text>
+          </View>
+        )}
+
+        {/* Last synced */}
+        {project.lastSyncedAt && (
+          <View style={[styles.infoRow, { borderColor: colors.border }]}>
+            <Ionicons name="sync-outline" size={16} color={colors.textSecondary} />
+            <Text style={[styles.infoLabel, { color: colors.textSecondary }]}>Synced</Text>
+            <Text style={[styles.infoValue, { color: colors.text }]}>
+              {new Date(project.lastSyncedAt).toLocaleString()}
+            </Text>
+          </View>
+        )}
 
         {/* Report button */}
         <TouchableOpacity
@@ -496,20 +557,26 @@ const styles = StyleSheet.create({
     fontSize: 26,
     fontWeight: '800',
     letterSpacing: -0.5,
-    marginBottom: 16,
+    marginBottom: 12,
   },
-  closedBanner: {
+
+  // On-chain status chip
+  statusChip: {
     flexDirection: 'row',
     alignItems: 'center',
+    gap: 10,
+    borderWidth: 1,
+    borderRadius: 12,
     padding: 12,
-    borderRadius: 10,
-    marginBottom: 16,
-    gap: 8,
+    marginBottom: 20,
   },
-  closedText: {
-    fontSize: 13,
-    fontWeight: '600',
-    flex: 1,
+  statusChipLabel: {
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  statusChipDesc: {
+    fontSize: 12,
+    marginTop: 1,
   },
 
   // Section

--- a/apps/mobile/app/(tabs)/projects/index.tsx
+++ b/apps/mobile/app/(tabs)/projects/index.tsx
@@ -12,20 +12,60 @@ import { Ionicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
 import { useTheme } from '../../../contexts/ThemeContext';
 import { useLocalization } from '../../../src/context';
-import { crowdfundApi, CrowdfundProject } from '../../../lib/crowdfund';
+import { CrowdfundProject, OnChainStatus } from '../../../lib/crowdfund';
 import { computeFundingProgress, formatTokenAmount } from '../../../lib/stellar';
+import { CachedApi } from '../../../lib/cached-api';
+
+// ── On-chain status chip ───────────────────────────────────────────────────
+
+const STATUS_META: Record<
+  OnChainStatus,
+  { label: string; icon: React.ComponentProps<typeof Ionicons>['name']; colorKey: 'success' | 'warning' | 'danger' | 'accent' | 'textSecondary' }
+> = {
+  ACTIVE:    { label: 'Active',     icon: 'radio-button-on-outline',  colorKey: 'success' },
+  PAUSED:    { label: 'Paused',     icon: 'pause-circle-outline',     colorKey: 'warning' },
+  COMPLETED: { label: 'Completed',  icon: 'checkmark-circle-outline', colorKey: 'accent' },
+  CANCELLED: { label: 'Cancelled',  icon: 'close-circle-outline',     colorKey: 'danger' },
+  PENDING:   { label: 'Pending',    icon: 'time-outline',             colorKey: 'textSecondary' },
+};
+
+function OnChainBadge({
+  status,
+  colors,
+}: {
+  status: OnChainStatus;
+  colors: ReturnType<typeof useTheme>['colors'];
+}) {
+  const meta = STATUS_META[status] ?? STATUS_META.PENDING;
+  const color = colors[meta.colorKey] as string;
+
+  return (
+    <View
+      style={[styles.badge, { backgroundColor: color + '22', borderColor: color + '44' }]}
+      accessible
+      accessibilityLabel={`On-chain status: ${meta.label}`}
+    >
+      <Ionicons name={meta.icon} size={11} color={color} />
+      <Text style={[styles.badgeText, { color }]}>{meta.label}</Text>
+    </View>
+  );
+}
+
+// ── Progress bar ───────────────────────────────────────────────────────────
 
 function ProgressBar({ progress, accentColor }: { progress: number; accentColor: string }) {
   return (
     <View style={styles.progressTrack} accessible accessibilityLabel={`${progress}% funded`}>
       <View
-        style={[styles.progressFill, { width: `${progress}%`, backgroundColor: accentColor }]}
+        style={[styles.progressFill, { width: `${Math.min(progress, 100)}%`, backgroundColor: accentColor }]}
         accessibilityRole="progressbar"
         accessibilityValue={{ min: 0, max: 100, now: progress }}
       />
     </View>
   );
 }
+
+// ── Project card ───────────────────────────────────────────────────────────
 
 function ProjectCard({
   project,
@@ -37,6 +77,7 @@ function ProjectCard({
   onPress: () => void;
 }) {
   const progress = computeFundingProgress(project.totalDeposited, project.targetAmount);
+  const status: OnChainStatus = project.onChainStatus ?? (project.isActive ? 'ACTIVE' : 'COMPLETED');
 
   return (
     <TouchableOpacity
@@ -44,20 +85,14 @@ function ProjectCard({
       onPress={onPress}
       activeOpacity={0.7}
       accessibilityRole="button"
-      accessibilityLabel={`${project.name}, ${progress}% funded, ${project.contributorCount} contributors, ${formatTokenAmount(project.totalDeposited)} XLM of ${formatTokenAmount(project.targetAmount)} XLM`}
-      accessibilityHint="Double tap to view project details and contribute"
+      accessibilityLabel={`${project.name}, ${status}, ${progress}% funded, ${project.contributorCount} contributors`}
+      accessibilityHint="Double tap to view project details"
     >
       <View style={styles.cardHeader}>
-        <Text style={[styles.cardTitle, { color: colors.text }]} accessible accessibilityRole="header">
+        <Text style={[styles.cardTitle, { color: colors.text }]} numberOfLines={1} accessible accessibilityRole="header">
           {project.name}
         </Text>
-        {!project.isActive && (
-          <View style={[styles.statusBadge, { backgroundColor: colors.danger + '22' }]} accessible>
-            <Text style={[styles.statusBadgeText, { color: colors.danger }]} accessible>
-              Closed
-            </Text>
-          </View>
-        )}
+        <OnChainBadge status={status} colors={colors} />
       </View>
 
       <ProgressBar progress={progress} accentColor={colors.accent} />
@@ -91,6 +126,8 @@ function ProjectCard({
   );
 }
 
+// ── Main screen ────────────────────────────────────────────────────────────
+
 export default function ProjectsScreen() {
   const { colors } = useTheme();
   const { t } = useLocalization();
@@ -100,6 +137,7 @@ export default function ProjectsScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [fromCache, setFromCache] = useState(false);
 
   const fetchProjects = useCallback(async (refresh = false) => {
     if (refresh) {
@@ -110,11 +148,12 @@ export default function ProjectsScreen() {
     setError(null);
 
     try {
-      const response = await crowdfundApi.listProjects();
+      const response = await CachedApi.getProjects();
       if (response.success && response.data) {
-        setProjects(response.data);
+        setProjects(response.data as CrowdfundProject[]);
+        setFromCache(!!(response as { fromCache?: boolean }).fromCache);
       } else {
-        setError(response.error?.message ?? t('errors.couldnt_load', { item: 'projects' }));
+        setError((response.error as { message?: string })?.message ?? t('errors.couldnt_load', { item: 'projects' }));
       }
     } catch {
       setError(t('errors.something_went_wrong'));
@@ -128,6 +167,8 @@ export default function ProjectsScreen() {
     void fetchProjects(false);
   }, [fetchProjects]);
 
+  // ── Loading skeleton ───────────────────────────────────────────────────────
+
   if (isLoading && projects.length === 0) {
     return (
       <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
@@ -135,37 +176,21 @@ export default function ProjectsScreen() {
           {[1, 2, 3].map((i) => (
             <View
               key={i}
-              style={[
-                styles.card,
-                { backgroundColor: colors.surface, borderColor: colors.cardBorder },
-              ]}
+              style={[styles.card, { backgroundColor: colors.surface, borderColor: colors.cardBorder }]}
               accessible
               accessibilityLabel="Loading project"
             >
-              <View
-                style={[
-                  styles.skeleton,
-                  { width: '60%', height: 18, backgroundColor: colors.border },
-                ]}
-              />
-              <View
-                style={[
-                  styles.skeleton,
-                  { width: '100%', height: 8, marginTop: 16, backgroundColor: colors.border },
-                ]}
-              />
-              <View
-                style={[
-                  styles.skeleton,
-                  { width: '40%', height: 14, marginTop: 12, backgroundColor: colors.border },
-                ]}
-              />
+              <View style={[styles.skeleton, { width: '60%', height: 18, backgroundColor: colors.border }]} />
+              <View style={[styles.skeleton, { width: '100%', height: 8, marginTop: 16, backgroundColor: colors.border }]} />
+              <View style={[styles.skeleton, { width: '40%', height: 14, marginTop: 12, backgroundColor: colors.border }]} />
             </View>
           ))}
         </View>
       </SafeAreaView>
     );
   }
+
+  // ── Error state ────────────────────────────────────────────────────────────
 
   if (error && projects.length === 0) {
     return (
@@ -190,7 +215,6 @@ export default function ProjectsScreen() {
           activeOpacity={0.8}
           accessibilityRole="button"
           accessibilityLabel={t('common.retry')}
-          accessibilityHint="Retry loading projects"
         >
           <Text style={styles.ctaButtonText} accessible>{t('common.retry')}</Text>
         </TouchableOpacity>
@@ -198,8 +222,18 @@ export default function ProjectsScreen() {
     );
   }
 
+  // ── List ───────────────────────────────────────────────────────────────────
+
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+      {fromCache && (
+        <View style={[styles.offlineBanner, { backgroundColor: colors.surface, borderBottomColor: colors.border }]}>
+          <Ionicons name="cloud-offline-outline" size={14} color={colors.textSecondary} />
+          <Text style={[styles.offlineBannerText, { color: colors.textSecondary }]}>
+            Showing cached data
+          </Text>
+        </View>
+      )}
       <FlatList
         data={projects}
         keyExtractor={(item: CrowdfundProject) => String(item.id)}
@@ -221,7 +255,7 @@ export default function ProjectsScreen() {
           />
         )}
         ListEmptyComponent={
-          !loading ? (
+          !isLoading ? (
             <View style={[styles.center, { paddingVertical: 60 }]} accessible>
               <Ionicons
                 name="rocket-outline"
@@ -257,6 +291,21 @@ const styles = StyleSheet.create({
     padding: 16,
     paddingBottom: 40,
   },
+
+  // Offline banner
+  offlineBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 6,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    gap: 6,
+  },
+  offlineBannerText: {
+    fontSize: 12,
+  },
+
+  // Card
   card: {
     borderRadius: 16,
     borderWidth: 1,
@@ -273,22 +322,30 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 14,
+    gap: 8,
   },
   cardTitle: {
     fontSize: 17,
     fontWeight: '700',
     flex: 1,
-    marginRight: 8,
   },
-  statusBadge: {
-    paddingHorizontal: 8,
+
+  // On-chain status badge
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 7,
     paddingVertical: 3,
     borderRadius: 6,
+    borderWidth: 1,
+    gap: 4,
   },
-  statusBadgeText: {
+  badgeText: {
     fontSize: 11,
     fontWeight: '600',
   },
+
+  // Progress
   progressTrack: {
     height: 8,
     borderRadius: 4,
@@ -300,6 +357,8 @@ const styles = StyleSheet.create({
     height: '100%',
     borderRadius: 4,
   },
+
+  // Stats
   cardStats: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -325,6 +384,8 @@ const styles = StyleSheet.create({
   footerText: {
     fontSize: 12,
   },
+
+  // Empty / error
   emptyTitle: {
     fontSize: 20,
     fontWeight: '700',
@@ -348,6 +409,8 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '700',
   },
+
+  // Skeleton
   skeletonWrap: {
     padding: 16,
   },

--- a/apps/mobile/lib/cache.ts
+++ b/apps/mobile/lib/cache.ts
@@ -150,6 +150,11 @@ export const CACHE_CONFIGS = {
     staleWhileRevalidate: true,
     maxAge: 15 * 60 * 1000, // 15 minutes max
   },
+  PROJECTS: {
+    ttl: 5 * 60 * 1000, // 5 minutes
+    staleWhileRevalidate: true,
+    maxAge: 60 * 60 * 1000, // 1 hour max — list is safe to serve stale offline
+  },
 } as const;
 
 export const cache = CacheManager.getInstance();

--- a/apps/mobile/lib/cached-api.ts
+++ b/apps/mobile/lib/cached-api.ts
@@ -1,6 +1,7 @@
 import { cache, CACHE_CONFIGS } from './cache';
 import { portfolioApi, stellarApi } from './api';
 import { apiClient } from './api-client';
+import { crowdfundApi, CrowdfundProject } from './crowdfund';
 import { Article } from './types/news';
 
 /**
@@ -143,6 +144,42 @@ export class CachedApi {
     }
 
     return { success: false, error: { message: 'No transaction history available offline' } };
+  }
+
+  // Projects list with caching for offline resilience
+  static async getProjects() {
+    const cacheKey = 'crowdfund_projects';
+
+    const cached = await cache.get<CrowdfundProject[]>(cacheKey, CACHE_CONFIGS.PROJECTS);
+    if (
+      cached &&
+      (!cache.isOnlineStatus() || Date.now() - cached.timestamp < CACHE_CONFIGS.PROJECTS.ttl)
+    ) {
+      return { success: true, data: cached.data, fromCache: true };
+    }
+
+    if (cache.isOnlineStatus()) {
+      try {
+        const response = await crowdfundApi.listProjects();
+        if (response.success && response.data) {
+          await cache.set(cacheKey, response.data, CACHE_CONFIGS.PROJECTS);
+          return { ...response, fromCache: false };
+        }
+      } catch (error) {
+        console.warn('Failed to fetch fresh projects data:', error);
+      }
+    }
+
+    if (cached) {
+      return { success: true, data: cached.data, fromCache: true, isStale: true };
+    }
+
+    return { success: false, error: { message: 'No projects available offline' } };
+  }
+
+  // Single project — not cached (detail screens should always show fresh on-chain state)
+  static async getProject(id: number) {
+    return crowdfundApi.getProject(id);
   }
 
   // Clear all cached data

--- a/apps/mobile/lib/crowdfund.ts
+++ b/apps/mobile/lib/crowdfund.ts
@@ -1,5 +1,7 @@
 import { apiClient, ApiResponse } from './api-client';
 
+export type OnChainStatus = 'ACTIVE' | 'PAUSED' | 'COMPLETED' | 'CANCELLED' | 'PENDING';
+
 /**
  * Crowdfund Project — mirrors the on-chain ProjectData structure
  */
@@ -11,9 +13,12 @@ export interface CrowdfundProject {
   bannerUrl?: string;
   targetAmount: string;
   tokenAddress: string;
+  contractAddress?: string;
   totalDeposited: string;
   totalWithdrawn: string;
   isActive: boolean;
+  onChainStatus: OnChainStatus;
+  lastSyncedAt?: string;
   contributorCount: number;
   roadmap?: RoadmapItem[];
   createdAt?: string;


### PR DESCRIPTION
## Summary

- **Backend crowdfund module** — new `GET /crowdfund/projects`, `GET /crowdfund/projects/:id`, `POST /crowdfund/contribute`, and related endpoints; each project carries an `onChainStatus` field (`ACTIVE`, `PAUSED`, `COMPLETED`, `CANCELLED`, `PENDING`) that mirrors the Soroban vault state
- **List screen** — wired to `CachedApi.getProjects()` so results are persisted in AsyncStorage (5 min fresh TTL, 1 hr max age) and served offline; a banner appears when the app is showing cached data; each card shows a color-coded `OnChainBadge` chip
- **Detail screen** — `OnChainStatusChip` displayed prominently below the project title (icon + label + plain-English description, e.g. "Funding goal reached — vault closed"); contract address and last-synced timestamp surfaced in the info section
- **Bug fix** — `index.tsx` referenced undefined variable `loading` instead of `isLoading` in the empty-state guard

## Test plan

- [ ] Start backend and confirm `GET /crowdfund/projects` returns 3 seeded projects with `onChainStatus` in the response
- [ ] Open the Projects tab — list loads, each card shows a status badge (green Active / blue Completed / etc.)
- [ ] Pull down to refresh — list reloads from network
- [ ] Kill network, re-open app — list renders from cache; offline banner is visible
- [ ] Tap a project — detail screen shows the on-chain status chip, contract address, and last-synced row
- [ ] Active project shows Contribute button; completed project does not

Closes #725