### PR TITLE
feat(crowdfund): add metrics endpoint and implement KPI computation f…

### DIFF
--- a/apps/data-processing/src/analytics/crowdfund_metrics.py
+++ b/apps/data-processing/src/analytics/crowdfund_metrics.py
@@ -1,0 +1,148 @@
+from typing import List, Dict, Tuple, Any
+from datetime import datetime
+import json
+import os
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "data")
+OUTPUT_FILE = os.path.join(DATA_DIR, "crowdfund_metrics.jsonl")
+
+
+def _parse_iso(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def compute_kpis_from_events(events: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """
+    Compute TVL and cumulative deposit volume time-series from crowdfund vault events.
+
+    Event format (expected):
+      {
+        "id": "unique-event-id",
+        "type": "deposit" | "withdraw",
+        "project_id": 123,
+        "amount": 100.0,
+        "timestamp": "2024-01-01T12:00:00Z",
+        // optional correction fields:
+        "correction_of": "original-event-id"  # indicates this event replaces original
+      }
+
+    Rules:
+      - Idempotent: duplicate event `id` are ignored.
+      - Corrections: if `correction_of` present, the original event is reversed (if seen)
+        and the corrected event applied in its place.
+
+    Returns a list sorted by timestamp of dicts:
+      {"timestamp": iso, "tvl": float, "cumulative_deposits": float}
+    """
+
+    # Keep track of seen events and project balances
+    seen = {}
+    project_balances: Dict[int, float] = {}
+    cumulative_deposits = 0.0
+
+    # sort events by timestamp ascending
+    events_sorted = sorted(events, key=lambda e: _parse_iso(e.get("timestamp")))
+
+    series: List[Dict[str, Any]] = []
+
+    for ev in events_sorted:
+        ev_id = ev.get("id")
+        if not ev_id:
+            # ignore malformed
+            continue
+
+        # Handle corrections that replace a prior event
+        correction_of = ev.get("correction_of")
+        if correction_of:
+            orig = seen.get(correction_of)
+            if orig:
+                # reverse original
+                _reverse_event_effect(orig, project_balances)
+                # remove original's contribution to cumulative_deposits if it was a deposit
+                if orig.get("type") == "deposit":
+                    cumulative_deposits -= float(orig.get("amount", 0))
+                # mark original as replaced
+                seen.pop(correction_of, None)
+
+        # Idempotency: skip if we've already applied this event
+        if ev_id in seen:
+            continue
+
+        # Apply event
+        _apply_event_effect(ev, project_balances)
+
+        if ev.get("type") == "deposit":
+            cumulative_deposits += float(ev.get("amount", 0))
+
+        # record seen
+        seen[ev_id] = ev
+
+        # compute current TVL
+        tvl = sum(project_balances.values())
+
+        series.append(
+            {
+                "timestamp": ev.get("timestamp"),
+                "tvl": tvl,
+                "cumulative_deposits": cumulative_deposits,
+            }
+        )
+
+    return series
+
+
+def _apply_event_effect(ev: Dict[str, Any], project_balances: Dict[int, float]):
+    p = int(ev.get("project_id", 0))
+    amt = float(ev.get("amount", 0))
+    t = ev.get("type")
+
+    if p not in project_balances:
+        project_balances[p] = 0.0
+
+    if t == "deposit":
+        project_balances[p] += amt
+    elif t == "withdraw":
+        project_balances[p] -= amt
+        # floor at zero to avoid negative TVL due to out-of-order events
+        if project_balances[p] < 0:
+            project_balances[p] = 0.0
+
+
+def _reverse_event_effect(ev: Dict[str, Any], project_balances: Dict[int, float]):
+    # reverse the effect of a single event
+    p = int(ev.get("project_id", 0))
+    amt = float(ev.get("amount", 0))
+    t = ev.get("type")
+
+    if p not in project_balances:
+        project_balances[p] = 0.0
+
+    if t == "deposit":
+        project_balances[p] -= amt
+        if project_balances[p] < 0:
+            project_balances[p] = 0.0
+    elif t == "withdraw":
+        project_balances[p] += amt
+
+
+def persist_series(series: List[Dict[str, Any]], output_file: str = OUTPUT_FILE):
+    os.makedirs(os.path.dirname(output_file), exist_ok=True)
+    # Write JSON Lines for easy incremental reads
+    with open(output_file, "w", encoding="utf-8") as fh:
+        for item in series:
+            fh.write(json.dumps(item) + "\n")
+
+
+def load_persisted_series(output_file: str = OUTPUT_FILE) -> List[Dict[str, Any]]:
+    if not os.path.exists(output_file):
+        return []
+    res = []
+    with open(output_file, "r", encoding="utf-8") as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            try:
+                res.append(json.loads(line))
+            except Exception:
+                continue
+    return res

--- a/apps/data-processing/src/api/server.py
+++ b/apps/data-processing/src/api/server.py
@@ -18,6 +18,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from sentiment import SentimentAnalyzer
 from src.utils.logger import setup_logger, correlation_id_ctx, generate_correlation_id
 from src.utils.metrics import API_FAILURES_TOTAL, generate_latest, CONTENT_TYPE_LATEST
+from src.analytics.crowdfund_metrics import load_persisted_series
 
 # Initialize structured logger
 logger = setup_logger(__name__)
@@ -103,6 +104,16 @@ async def health_check() -> HealthResponse:
         timestamp=datetime.now().isoformat(),
         service="sentiment-analysis",
     )
+
+
+@app.get("/crowdfund/metrics")
+async def crowdfund_metrics():
+    """Return persisted crowdfund KPI series (TVL and cumulative deposits)."""
+    try:
+        data = load_persisted_series()
+        return {"count": len(data), "series": data}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 
 @app.post("/analyze", response_model=AnalyzeResponse)

--- a/apps/data-processing/tests/unit/test_crowdfund_metrics.py
+++ b/apps/data-processing/tests/unit/test_crowdfund_metrics.py
@@ -1,0 +1,45 @@
+from src.analytics.crowdfund_metrics import compute_kpis_from_events
+
+def test_simple_deposit_withdraw_and_correction():
+    events = [
+        {
+            "id": "e1",
+            "type": "deposit",
+            "project_id": 1,
+            "amount": 100.0,
+            "timestamp": "2024-01-01T00:00:00Z",
+        },
+        {
+            "id": "e2",
+            "type": "withdraw",
+            "project_id": 1,
+            "amount": 30.0,
+            "timestamp": "2024-01-01T01:00:00Z",
+        },
+        # correction: e3 replaces e1 with amount 120
+        {
+            "id": "e3",
+            "type": "deposit",
+            "project_id": 1,
+            "amount": 120.0,
+            "timestamp": "2024-01-01T02:00:00Z",
+            "correction_of": "e1",
+        },
+    ]
+
+    series = compute_kpis_from_events(events)
+
+    # After e1: tvl=100, cumulative=100
+    assert series[0]["tvl"] == 100.0
+    assert series[0]["cumulative_deposits"] == 100.0
+
+    # After e2: tvl=70, cumulative still 100
+    assert series[1]["tvl"] == 70.0
+    assert series[1]["cumulative_deposits"] == 100.0
+
+    # After e3 correction: original deposit 100 reversed and replaced by 120
+    # balances: start 0 -> e1 +100 -> e2 -30 => 70
+    # reverse e1: 70 -100 => floored at 0 -> then apply e3 +120 => 120
+    # cumulative deposits: 100 -> (100 -100) +120 = 120
+    assert series[2]["tvl"] == 120.0
+    assert series[2]["cumulative_deposits"] == 120.0


### PR DESCRIPTION
#closes #734 

This PR introduces a lightweight, idempotent processor for computing protocol-level KPIs (TVL and cumulative deposit volume) from Crowdfund Vault events. It includes JSONL persistence for the computed time-series and an HTTP API for backend consumption.

What changed
------------
- Added KPI computation module: [apps/data-processing/src/analytics/crowdfund_metrics.py](apps/data-processing/src/analytics/crowdfund_metrics.py)
- Exposed persisted KPIs via API: [apps/data-processing/src/api/server.py](apps/data-processing/src/api/server.py) (new route `GET /crowdfund/metrics`)
- Unit tests: [apps/data-processing/tests/unit/test_crowdfund_metrics.py](apps/data-processing/tests/unit/test_crowdfund_metrics.py)

Files of interest
-----------------
- [apps/data-processing/src/analytics/crowdfund_metrics.py](apps/data-processing/src/analytics/crowdfund_metrics.py)
- [apps/data-processing/src/api/server.py](apps/data-processing/src/api/server.py#L1-L300)
- [apps/data-processing/tests/unit/test_crowdfund_metrics.py](apps/data-processing/tests/unit/test_crowdfund_metrics.py)

Behavior & assumptions
----------------------
- Input event schema expected: `id`, `type` (`deposit`|`withdraw`), `project_id`, `amount`, `timestamp` (ISO), optional `correction_of`.
- Idempotency: duplicate event `id` values are ignored.
- Corrections: events with `correction_of` reverse the original event (if seen) and apply the corrected event.
- TVL is computed as the sum of per-project balances; negative balances are floored to zero to tolerate out-of-order messages.
- Persistence location: `apps/data-processing/data/crowdfund_metrics.jsonl` (JSON Lines)

How to test locally
--------------------
1) Setup Python venv and install deps:
```powershell
cd apps/data-processing
python -m venv .venv
.venv\Scripts\Activate.ps1
pip install -r requirements.txt
```

2) Run the unit test for KPI logic:
```powershell
pytest tests/unit/test_crowdfund_metrics.py -q
```

3) Run a quick manual ingestion script (example):
```python
from src.analytics.crowdfund_metrics import compute_kpis_from_events, persist_series

events = [
  {"id":"e1","type":"deposit","project_id":1,"amount":100.0,"timestamp":"2024-01-01T00:00:00Z"},
  {"id":"e2","type":"withdraw","project_id":1,"amount":30.0,"timestamp":"2024-01-01T01:00:00Z"},
  {"id":"e3","type":"deposit","project_id":1,"amount":120.0,"timestamp":"2024-01-01T02:00:00Z","correction_of":"e1"},
]

series = compute_kpis_from_events(events)
persist_series(series)
print(series)
```

4) Start API and fetch persisted series:
```powershell
uvicorn src.api.server:app --host 0.0.0.0 --port 8000 --reload
curl http://localhost:8000/crowdfund/metrics
```

Reviewer checklist
------------------
- [ ] Confirm event schema and correction semantics match indexer output.
- [ ] Validate idempotency logic for duplicate events.
- [ ] Review persistence strategy (JSONL file vs DB) for production suitability.
- [ ] Ensure API route and CORS/security boundaries are acceptable.

Notes / Next steps
-----------------
- Production: replace file-based persistence with a durable store (Postgres / S3) and add retention/rotation.
- Add an ingestion adapter to map Soroban/Horizon events to the expected event schema and run `compute_kpis_from_events` in the indexer pipeline.
- Add Prometheus metrics and observability for the KPI job.

If you want I can open a PR branch & push these commits, or implement the ingestion adapter that wires Horizon/Soroban events into `compute_kpis_from_events`.
#closes