### PR TITLE
test(config): lock stellar bootstrap response contract

### DIFF
--- a/apps/backend/src/config/config.controller.spec.ts
+++ b/apps/backend/src/config/config.controller.spec.ts
@@ -1,0 +1,28 @@
+import { ConfigController } from './config.controller';
+import { ConfigService } from './config.service';
+
+describe('ConfigController', () => {
+  it('delegates stellar config retrieval to ConfigService', () => {
+    const getStellarConfig = jest.fn().mockReturnValue({
+      network: 'testnet',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      contracts: {
+        lumenToken: null,
+        crowdfundVault: null,
+        projectRegistry: null,
+        contributorRegistry: null,
+        matchingPool: null,
+        treasury: null,
+      },
+    });
+    const service = { getStellarConfig } as unknown as ConfigService;
+    const controller = new ConfigController(service);
+
+    const result = controller.getStellarConfig();
+
+    expect(getStellarConfig).toHaveBeenCalledTimes(1);
+    expect(result.network).toBe('testnet');
+  });
+});

--- a/apps/backend/src/config/config.service.spec.ts
+++ b/apps/backend/src/config/config.service.spec.ts
@@ -1,0 +1,63 @@
+import type { ConfigType } from '@nestjs/config';
+import stellarConfig from '../stellar/config/stellar.config';
+import { config } from '../lib/config';
+import { ConfigService } from './config.service';
+
+jest.mock('../lib/config', () => ({
+  config: {
+    stellar: {
+      sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+      contracts: {
+        lumenToken: 'CLUMEN',
+        crowdfundVault: 'CCROWDFUND',
+        projectRegistry: 'CPROJECT',
+        contributorRegistry: 'CCONTRIB',
+        matchingPool: 'CMATCH',
+        treasury: 'CTREASURY',
+      },
+    },
+  },
+}));
+
+describe('ConfigService', () => {
+  it('returns a client-safe stellar config payload', () => {
+    const service = new ConfigService({
+      network: 'testnet',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      timeout: 30_000,
+      retryAttempts: 3,
+      retryDelay: 1_000,
+    } as ConfigType<typeof stellarConfig>);
+
+    expect(service.getStellarConfig()).toEqual({
+      network: 'testnet',
+      horizonUrl: 'https://horizon-testnet.stellar.org',
+      sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+      contracts: {
+        lumenToken: 'CLUMEN',
+        crowdfundVault: 'CCROWDFUND',
+        projectRegistry: 'CPROJECT',
+        contributorRegistry: 'CCONTRIB',
+        matchingPool: 'CMATCH',
+        treasury: 'CTREASURY',
+      },
+    });
+  });
+
+  it('falls back to canonical network RPC URL when env RPC URL is absent', () => {
+    (config.stellar.sorobanRpcUrl as string | null | undefined) = undefined;
+
+    const service = new ConfigService({
+      network: 'mainnet',
+      horizonUrl: 'https://horizon.stellar.org',
+      timeout: 30_000,
+      retryAttempts: 3,
+      retryDelay: 1_000,
+    } as ConfigType<typeof stellarConfig>);
+
+    expect(service.getStellarConfig().sorobanRpcUrl).toBe(
+      'https://soroban.stellar.org',
+    );
+  });
+});


### PR DESCRIPTION
Closes #706

## Summary
- add focused unit tests for ConfigService.getStellarConfig to lock response shape used by clients at /v1/config/stellar
- verify network + URL payload and environment-driven contract IDs are returned as expected
- verify canonical Soroban RPC fallback is used when no env RPC URL is provided
- add controller delegation test for ConfigController.getStellarConfig

## Implementation Notes
- no runtime behavior changed; this PR strengthens confidence and response stability for client bootstrap
- tests assert the contract fields required by the issue: network, Horizon URL, Soroban RPC URL, and contract IDs

## Testing
- npx jest config --watchman=false