### PR TITLE
feat(logging): structured request logs + correlation IDs

### DIFF
--- a/apps/backend/src/common/middleware/logger.middleware.spec.ts
+++ b/apps/backend/src/common/middleware/logger.middleware.spec.ts
@@ -1,0 +1,42 @@
+import { Logger } from '@nestjs/common';
+import { LoggerMiddleware } from './logger.middleware';
+
+describe('LoggerMiddleware', () => {
+  const middleware = new LoggerMiddleware();
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('logs structured JSON with request correlation id', () => {
+    const logSpy = jest.spyOn(Logger, 'log').mockImplementation();
+    const req = {
+      method: 'GET',
+      url: '/v1/config/stellar',
+      originalUrl: '/v1/config/stellar',
+      requestId: 'req-123',
+    } as any;
+    const res = {
+      statusCode: 200,
+      end: jest.fn(),
+    } as any;
+
+    middleware.use(req, res, () => undefined);
+    res.end();
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const [payload, context] = logSpy.mock.calls[0];
+    expect(context).toBe('HTTP');
+    expect(typeof payload).toBe('string');
+
+    const parsed = JSON.parse(payload as string);
+    expect(parsed).toMatchObject({
+      event: 'http_request_completed',
+      requestId: 'req-123',
+      method: 'GET',
+      url: '/v1/config/stellar',
+      statusCode: 200,
+    });
+    expect(typeof parsed.durationMs).toBe('number');
+  });
+});

--- a/apps/backend/src/common/middleware/logger.middleware.ts
+++ b/apps/backend/src/common/middleware/logger.middleware.ts
@@ -29,7 +29,15 @@ export class LoggerMiddleware implements NestMiddleware {
       const duration = Date.now() - startTime;
       const requestId =
         typeof request.requestId === 'string' ? request.requestId : 'unknown';
-      const message = `[Request:${requestId}] ${req.method} ${req.url} - ${res.statusCode} - ${duration}ms`;
+      const message = JSON.stringify({
+        event: 'http_request_completed',
+        requestId,
+        method: req.method,
+        url: req.originalUrl ?? req.url,
+        statusCode: res.statusCode,
+        durationMs: duration,
+        timestamp: new Date().toISOString(),
+      });
 
       // Log based on status code
       if (res.statusCode >= 500) {

--- a/apps/backend/src/common/middleware/request-id.middleware.spec.ts
+++ b/apps/backend/src/common/middleware/request-id.middleware.spec.ts
@@ -1,0 +1,37 @@
+import { RequestIdMiddleware } from './request-id.middleware';
+import { REQUEST_ID_HEADER } from '../constants/request.constants';
+
+describe('RequestIdMiddleware', () => {
+  const middleware = new RequestIdMiddleware();
+
+  it('reuses incoming x-request-id and echoes it back in response header', () => {
+    const req = {
+      header: jest.fn().mockReturnValue('abc-123'),
+    } as any;
+    const res = {
+      setHeader: jest.fn(),
+    } as any;
+    const next = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(req.requestId).toBe('abc-123');
+    expect(res.setHeader).toHaveBeenCalledWith(REQUEST_ID_HEADER, 'abc-123');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a request id when one is not provided', () => {
+    const req = {
+      header: jest.fn().mockReturnValue(undefined),
+    } as any;
+    const res = {
+      setHeader: jest.fn(),
+    } as any;
+
+    middleware.use(req, res, () => undefined);
+
+    expect(typeof req.requestId).toBe('string');
+    expect(req.requestId).not.toHaveLength(0);
+    expect(res.setHeader).toHaveBeenCalledWith(REQUEST_ID_HEADER, req.requestId);
+  });
+});

--- a/apps/backend/src/filters/global-exception.filter.ts
+++ b/apps/backend/src/filters/global-exception.filter.ts
@@ -32,12 +32,30 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     if (status >= 500) {
       const stack = exception instanceof Error ? (exception.stack ?? '') : '';
       this.logger.error(
-        `[${requestId}] ${request.method} ${request.url} -> ${status}`,
+        JSON.stringify({
+          event: 'http_request_failed',
+          requestId,
+          method: request.method,
+          url: request.originalUrl ?? request.url,
+          statusCode: status,
+          errorCode: errorResponse.code,
+          message: errorResponse.message,
+          timestamp: new Date().toISOString(),
+        }),
         stack,
       );
     } else {
       this.logger.warn(
-        `[${requestId}] ${request.method} ${request.url} -> ${status} ${errorResponse.code}`,
+        JSON.stringify({
+          event: 'http_request_failed',
+          requestId,
+          method: request.method,
+          url: request.originalUrl ?? request.url,
+          statusCode: status,
+          errorCode: errorResponse.code,
+          message: errorResponse.message,
+          timestamp: new Date().toISOString(),
+        }),
       );
     }
 


### PR DESCRIPTION
Closes #562

## Summary
- emit structured JSON logs for completed HTTP requests with requestId, method, URL, status code, duration, and timestamp
- keep request correlation IDs request-scoped and visible in log entries
- add structured error/warn logging payloads in the global exception filter so failed requests carry consistent metadata
- add middleware tests for request-id propagation and structured logger output

## Implementation Notes
- request IDs continue to come from `x-request-id` when supplied, otherwise a UUID is generated
- response header propagation remains unchanged, preserving API compatibility
- only logging format/shape was changed to improve machine-readability across request flows

## Testing
- npx jest src/common/middleware/request-id.middleware.spec.ts src/common/middleware/logger.middleware.spec.ts --watchman=false