### PR TITLE
feat(verification): add project draft-review-publish workflow API

### DIFF
--- a/apps/backend/src/verification/dto/verification.dto.ts
+++ b/apps/backend/src/verification/dto/verification.dto.ts
@@ -1,4 +1,11 @@
-import { IsString, IsNumber, IsInt, IsBoolean, Min } from 'class-validator';
+import {
+  IsString,
+  IsNumber,
+  IsInt,
+  IsBoolean,
+  Min,
+  IsOptional,
+} from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export enum WeightMode {
@@ -11,6 +18,14 @@ export enum VerificationStatus {
   Pending = 'PENDING',
   Verified = 'VERIFIED',
   Rejected = 'REJECTED',
+}
+
+export enum SubmissionStatus {
+  Draft = 'DRAFT',
+  InReview = 'IN_REVIEW',
+  ChangesRequested = 'CHANGES_REQUESTED',
+  Approved = 'APPROVED',
+  Published = 'PUBLISHED',
 }
 
 export class RegisterProjectDto {
@@ -203,4 +218,88 @@ export class RegistryConfigDto {
     example: 1,
   })
   minVoterWeight: number;
+}
+
+export class UpsertSubmissionDto {
+  @ApiProperty({ description: 'ID of the project submission', example: 42 })
+  @IsNumber()
+  @IsInt()
+  @Min(0)
+  projectId: number;
+
+  @ApiProperty({
+    description: 'Stellar public key of the creator saving this submission',
+    example: 'G...CREATOR',
+  })
+  @IsString()
+  creatorPublicKey: string;
+
+  @ApiProperty({
+    description: 'Title for the submission payload',
+    example: 'Community Wallet',
+  })
+  @IsString()
+  title: string;
+
+  @ApiProperty({
+    description: 'Submission body/content',
+    example: 'Detailed project proposal and milestones.',
+  })
+  @IsString()
+  content: string;
+}
+
+export class SubmissionActionDto {
+  @ApiProperty({
+    description: 'Actor performing workflow action (reviewer/admin)',
+    example: 'reviewer-1',
+  })
+  @IsString()
+  actorId: string;
+
+  @ApiProperty({
+    description: 'Optional notes for this action',
+    required: false,
+    example: 'Please clarify your budget assumptions.',
+  })
+  @IsOptional()
+  @IsString()
+  note?: string;
+}
+
+export class ProjectSubmissionDto {
+  @ApiProperty({ example: 42 })
+  projectId: number;
+
+  @ApiProperty({ example: 'G...CREATOR' })
+  creatorPublicKey: string;
+
+  @ApiProperty({ example: 'Community Wallet' })
+  title: string;
+
+  @ApiProperty({ example: 'Detailed project proposal and milestones.' })
+  content: string;
+
+  @ApiProperty({
+    enum: SubmissionStatus,
+    example: SubmissionStatus.Draft,
+  })
+  status: SubmissionStatus;
+
+  @ApiProperty({
+    required: false,
+    example: 'reviewer-1',
+    description: 'Most recent reviewer/admin actor',
+  })
+  reviewerId?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'Most recent workflow note',
+    example: 'Please update technical risks section.',
+  })
+  reviewNote?: string;
+
+  @ApiProperty({ example: 1775000000 })
+  updatedAt: number;
 }

--- a/apps/backend/src/verification/verification.controller.ts
+++ b/apps/backend/src/verification/verification.controller.ts
@@ -26,6 +26,10 @@ import {
   ProjectVerificationDto,
   VoteResultDto,
   RegistryConfigDto,
+  UpsertSubmissionDto,
+  ProjectSubmissionDto,
+  SubmissionStatus,
+  SubmissionActionDto,
 } from './dto/verification.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
@@ -172,5 +176,100 @@ export class VerificationController {
   @ApiResponse({ status: 404, description: 'Record not found' })
   override(@Body() dto: OverrideDto) {
     return this.svc.overrideVerification(dto);
+  }
+
+  @Get('submissions')
+  @ApiOperation({
+    summary: 'List project submissions',
+    description:
+      'Returns project submissions across draft/review/approval/publish workflow states.',
+  })
+  @ApiQuery({ name: 'status', required: false, enum: SubmissionStatus })
+  @ApiResponse({
+    status: 200,
+    description: 'Submission records retrieved successfully',
+    type: [ProjectSubmissionDto],
+  })
+  listSubmissions(@Query('status') status?: SubmissionStatus) {
+    return this.svc.listSubmissions(status);
+  }
+
+  @Get('submissions/:id')
+  @ApiOperation({
+    summary: 'Get project submission details',
+  })
+  @ApiResponse({
+    status: 200,
+    type: ProjectSubmissionDto,
+  })
+  @ApiResponse({ status: 404, description: 'Submission not found' })
+  getSubmission(@Param('id', ParseIntPipe) id: number) {
+    return this.svc.getSubmission(id);
+  }
+
+  @Post('submissions')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Save submission draft',
+    description:
+      'Creates or updates a project submission draft that can later enter review.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Submission draft saved',
+    type: ProjectSubmissionDto,
+  })
+  upsertSubmission(@Body() dto: UpsertSubmissionDto) {
+    return this.svc.upsertSubmission(dto);
+  }
+
+  @Post('submissions/:id/submit')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Submit draft for review',
+  })
+  submitForReview(@Param('id', ParseIntPipe) id: number) {
+    return this.svc.submitForReview(id);
+  }
+
+  @Post('submissions/:id/request-changes')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Request changes on submission',
+  })
+  requestChanges(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: SubmissionActionDto,
+  ) {
+    return this.svc.requestSubmissionChanges(id, dto);
+  }
+
+  @Post('submissions/:id/approve')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Approve submission for publishing',
+  })
+  approveSubmission(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: SubmissionActionDto,
+  ) {
+    return this.svc.approveSubmission(id, dto);
+  }
+
+  @Post('submissions/:id/publish')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Publish approved submission',
+  })
+  publishSubmission(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: SubmissionActionDto,
+  ) {
+    return this.svc.publishSubmission(id, dto);
   }
 }

--- a/apps/backend/src/verification/verification.service.spec.ts
+++ b/apps/backend/src/verification/verification.service.spec.ts
@@ -6,7 +6,11 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { VerificationService } from './verification.service';
-import { VerificationStatus, WeightMode } from './dto/verification.dto';
+import {
+  SubmissionStatus,
+  VerificationStatus,
+  WeightMode,
+} from './dto/verification.dto';
 
 describe('VerificationService', () => {
   let svc: VerificationService;
@@ -237,5 +241,68 @@ describe('VerificationService', () => {
     expect(pending[0].projectId).toBe(2);
 
     expect(svc.listProjects()).toHaveLength(2);
+  });
+
+  // ── Submission workflow ─────────────────────────────────────────────────────
+
+  it('creates submission drafts and sends them to review', () => {
+    const draft = svc.upsertSubmission({
+      projectId: 77,
+      creatorPublicKey: 'GCREATOR',
+      title: 'Project 77',
+      content: 'Draft content',
+    });
+    expect(draft.status).toBe(SubmissionStatus.Draft);
+
+    const inReview = svc.submitForReview(77);
+    expect(inReview.status).toBe(SubmissionStatus.InReview);
+  });
+
+  it('supports changes requested -> draft -> review -> approved -> published', () => {
+    svc.upsertSubmission({
+      projectId: 88,
+      creatorPublicKey: 'GCREATOR',
+      title: 'Project 88',
+      content: 'First draft',
+    });
+    svc.submitForReview(88);
+
+    const changes = svc.requestSubmissionChanges(88, {
+      actorId: 'reviewer-1',
+      note: 'Please refine milestones.',
+    });
+    expect(changes.status).toBe(SubmissionStatus.ChangesRequested);
+    expect(changes.reviewerId).toBe('reviewer-1');
+
+    const revisedDraft = svc.upsertSubmission({
+      projectId: 88,
+      creatorPublicKey: 'GCREATOR',
+      title: 'Project 88 revised',
+      content: 'Updated content',
+    });
+    expect(revisedDraft.status).toBe(SubmissionStatus.Draft);
+
+    svc.submitForReview(88);
+    const approved = svc.approveSubmission(88, { actorId: 'reviewer-2' });
+    expect(approved.status).toBe(SubmissionStatus.Approved);
+
+    const published = svc.publishSubmission(88, {
+      actorId: 'admin-1',
+      note: 'Ready for launch.',
+    });
+    expect(published.status).toBe(SubmissionStatus.Published);
+  });
+
+  it('prevents publishing without approval', () => {
+    svc.upsertSubmission({
+      projectId: 99,
+      creatorPublicKey: 'GCREATOR',
+      title: 'Project 99',
+      content: 'Draft',
+    });
+    svc.submitForReview(99);
+    expect(() =>
+      svc.publishSubmission(99, { actorId: 'admin-1' }),
+    ).toThrow(BadRequestException);
   });
 });

--- a/apps/backend/src/verification/verification.service.ts
+++ b/apps/backend/src/verification/verification.service.ts
@@ -16,6 +16,10 @@ import {
   VerificationStatus,
   VoteResultDto,
   WeightMode,
+  ProjectSubmissionDto,
+  SubmissionActionDto,
+  SubmissionStatus,
+  UpsertSubmissionDto,
 } from './dto/verification.dto';
 
 interface ProjectRecord {
@@ -41,10 +45,22 @@ interface RegistryConfig {
   tokenBalanceStore: Map<string, number>;
 }
 
+interface ProjectSubmissionRecord {
+  projectId: number;
+  creatorPublicKey: string;
+  title: string;
+  content: string;
+  status: SubmissionStatus;
+  reviewerId?: string;
+  reviewNote?: string;
+  updatedAt: number;
+}
+
 @Injectable()
 export class VerificationService {
   private readonly logger = new Logger(VerificationService.name);
   private projects = new Map<number, ProjectRecord>();
+  private submissions = new Map<number, ProjectSubmissionRecord>();
   private config: RegistryConfig;
 
   constructor(private readonly configSvc: ConfigService) {
@@ -244,5 +260,138 @@ export class VerificationService {
       resolvedAt: r.resolvedAt,
       quorumProgress,
     };
+  }
+
+  // ── Submission workflow ────────────────────────────────────────────────────
+
+  upsertSubmission(dto: UpsertSubmissionDto): ProjectSubmissionDto {
+    const existing = this.submissions.get(dto.projectId);
+
+    if (!existing) {
+      const created: ProjectSubmissionRecord = {
+        projectId: dto.projectId,
+        creatorPublicKey: dto.creatorPublicKey,
+        title: dto.title,
+        content: dto.content,
+        status: SubmissionStatus.Draft,
+        updatedAt: Math.floor(Date.now() / 1000),
+      };
+      this.submissions.set(dto.projectId, created);
+      return this.toSubmissionDto(created);
+    }
+
+    if (existing.status === SubmissionStatus.Published) {
+      throw new BadRequestException(
+        `Submission ${dto.projectId} is already published and cannot be edited`,
+      );
+    }
+
+    existing.title = dto.title;
+    existing.content = dto.content;
+    existing.creatorPublicKey = dto.creatorPublicKey;
+    existing.updatedAt = Math.floor(Date.now() / 1000);
+
+    // Editing after reviewer feedback moves it back to draft for resubmission.
+    if (existing.status === SubmissionStatus.ChangesRequested) {
+      existing.status = SubmissionStatus.Draft;
+    }
+
+    return this.toSubmissionDto(existing);
+  }
+
+  getSubmission(projectId: number): ProjectSubmissionDto {
+    return this.toSubmissionDto(this.getSubmissionRecord(projectId));
+  }
+
+  listSubmissions(status?: SubmissionStatus): ProjectSubmissionDto[] {
+    return [...this.submissions.values()]
+      .filter((submission) => !status || submission.status === status)
+      .map((submission) => this.toSubmissionDto(submission));
+  }
+
+  submitForReview(projectId: number): ProjectSubmissionDto {
+    const submission = this.getSubmissionRecord(projectId);
+    if (submission.status === SubmissionStatus.Published) {
+      throw new BadRequestException(
+        `Submission ${projectId} is already published`,
+      );
+    }
+    if (submission.status === SubmissionStatus.InReview) {
+      throw new BadRequestException(
+        `Submission ${projectId} is already in review`,
+      );
+    }
+
+    submission.status = SubmissionStatus.InReview;
+    submission.updatedAt = Math.floor(Date.now() / 1000);
+    return this.toSubmissionDto(submission);
+  }
+
+  requestSubmissionChanges(
+    projectId: number,
+    dto: SubmissionActionDto,
+  ): ProjectSubmissionDto {
+    const submission = this.getSubmissionRecord(projectId);
+    if (submission.status !== SubmissionStatus.InReview) {
+      throw new BadRequestException(
+        `Submission ${projectId} must be in review to request changes`,
+      );
+    }
+
+    submission.status = SubmissionStatus.ChangesRequested;
+    submission.reviewerId = dto.actorId;
+    submission.reviewNote = dto.note;
+    submission.updatedAt = Math.floor(Date.now() / 1000);
+    return this.toSubmissionDto(submission);
+  }
+
+  approveSubmission(
+    projectId: number,
+    dto: SubmissionActionDto,
+  ): ProjectSubmissionDto {
+    const submission = this.getSubmissionRecord(projectId);
+    if (submission.status !== SubmissionStatus.InReview) {
+      throw new BadRequestException(
+        `Submission ${projectId} must be in review to approve`,
+      );
+    }
+
+    submission.status = SubmissionStatus.Approved;
+    submission.reviewerId = dto.actorId;
+    submission.reviewNote = dto.note;
+    submission.updatedAt = Math.floor(Date.now() / 1000);
+    return this.toSubmissionDto(submission);
+  }
+
+  publishSubmission(
+    projectId: number,
+    dto: SubmissionActionDto,
+  ): ProjectSubmissionDto {
+    const submission = this.getSubmissionRecord(projectId);
+    if (submission.status !== SubmissionStatus.Approved) {
+      throw new BadRequestException(
+        `Submission ${projectId} must be approved before publishing`,
+      );
+    }
+
+    submission.status = SubmissionStatus.Published;
+    submission.reviewerId = dto.actorId;
+    submission.reviewNote = dto.note;
+    submission.updatedAt = Math.floor(Date.now() / 1000);
+    return this.toSubmissionDto(submission);
+  }
+
+  private getSubmissionRecord(projectId: number): ProjectSubmissionRecord {
+    const submission = this.submissions.get(projectId);
+    if (!submission) {
+      throw new NotFoundException(`Submission for project ${projectId} not found`);
+    }
+    return submission;
+  }
+
+  private toSubmissionDto(
+    submission: ProjectSubmissionRecord,
+  ): ProjectSubmissionDto {
+    return { ...submission };
   }
 }


### PR DESCRIPTION
Closes #567

## Summary
- add explicit submission workflow states: DRAFT, IN_REVIEW, CHANGES_REQUESTED, APPROVED, PUBLISHED
- add submission workflow endpoints under `verification/submissions`
- support creator draft save/update, review submission, change requests, approval, and publish transitions
- ensure only approved submissions can be published

## Implementation
- extended verification DTOs with submission workflow request/response types
- added in-memory submission workflow store and guarded transition methods in VerificationService
- added controller routes for listing, fetching, creating/updating, submitting, requesting changes, approving, and publishing submissions
- added service tests covering happy-path transitions and publish-guard behavior

## Testing
- npx jest src/verification/verification.service.spec.ts --watchman=false