### PR TITLE
feat(search): link extracted mentions to known ecosystem entities

### DIFF
--- a/apps/backend/src/search/dto/entity-linking.dto.ts
+++ b/apps/backend/src/search/dto/entity-linking.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class EntityLinkingQueryDto {
+  @ApiProperty({
+    description: 'Input text to resolve into known projects/assets/ecosystem entities',
+    example: 'LumenPulse project tracks XLM and USDC in the Stellar ecosystem.',
+  })
+  @IsString()
+  text: string;
+
+  @ApiProperty({
+    required: false,
+    minimum: 1,
+    maximum: 20,
+    default: 5,
+    description: 'Maximum number of matches returned for each entity type',
+    example: 5,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(20)
+  limitPerType?: number;
+}
+
+export class LinkedProjectDto {
+  @ApiProperty({ example: 42 })
+  projectId: number;
+  @ApiProperty({ example: 'LumenPulse Wallet' })
+  name: string;
+  @ApiProperty({ example: 'lumenpulse' })
+  matchedMention: string;
+}
+
+export class LinkedAssetDto {
+  @ApiProperty({ example: 'USDC' })
+  assetCode: string;
+  @ApiProperty({ example: 'GD....' })
+  assetIssuer: string;
+  @ApiProperty({ example: 'usdc' })
+  matchedMention: string;
+}
+
+export class LinkedEcosystemEntityDto {
+  @ApiProperty({ enum: ['tag', 'category'], example: 'tag' })
+  kind: 'tag' | 'category';
+  @ApiProperty({ example: 'stellar' })
+  value: string;
+  @ApiProperty({ example: 'stellar' })
+  matchedMention: string;
+}
+
+export class EntityLinkingResponseDto {
+  @ApiProperty({ type: [LinkedProjectDto] })
+  projects: LinkedProjectDto[];
+  @ApiProperty({ type: [LinkedAssetDto] })
+  assets: LinkedAssetDto[];
+  @ApiProperty({ type: [LinkedEcosystemEntityDto] })
+  ecosystem: LinkedEcosystemEntityDto[];
+}

--- a/apps/backend/src/search/dto/entity-linking.dto.ts
+++ b/apps/backend/src/search/dto/entity-linking.dto.ts
@@ -3,7 +3,8 @@ import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 
 export class EntityLinkingQueryDto {
   @ApiProperty({
-    description: 'Input text to resolve into known projects/assets/ecosystem entities',
+    description:
+      'Input text to resolve into known projects/assets/ecosystem entities',
     example: 'LumenPulse project tracks XLM and USDC in the Stellar ecosystem.',
   })
   @IsString()

--- a/apps/backend/src/search/search.controller.ts
+++ b/apps/backend/src/search/search.controller.ts
@@ -11,6 +11,10 @@ import {
   EcosystemSearchQueryDto,
   EcosystemSearchResponseDto,
 } from './dto/ecosystem-search.dto';
+import {
+  EntityLinkingQueryDto,
+  EntityLinkingResponseDto,
+} from './dto/entity-linking.dto';
 
 @ApiTags('search')
 @Controller('search')
@@ -69,5 +73,23 @@ export class SearchController {
     @Query() query: EcosystemSearchQueryDto,
   ): Promise<EcosystemSearchResponseDto> {
     return this.searchService.searchEcosystemEntities(query);
+  }
+
+  @Get('entity-links')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Link extracted mentions to known entities',
+    description:
+      'Links mentions in free text to known projects, Stellar assets, and ecosystem entries.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Linked entities resolved from the input text',
+    type: EntityLinkingResponseDto,
+  })
+  async linkEntities(
+    @Query() query: EntityLinkingQueryDto,
+  ): Promise<EntityLinkingResponseDto> {
+    return this.searchService.linkEntities(query);
   }
 }

--- a/apps/backend/src/search/search.service.spec.ts
+++ b/apps/backend/src/search/search.service.spec.ts
@@ -206,4 +206,55 @@ describe('SearchService', () => {
       expect(res.items[0]).toEqual({ kind: 'category', value: 'defi' });
     });
   });
+
+  describe('linkEntities', () => {
+    it('links text mentions to known projects/assets/ecosystem entries', async () => {
+      verificationService.listProjects.mockReturnValue([
+        {
+          projectId: 1,
+          name: 'LumenPulse Wallet',
+          ownerPublicKey: 'G1',
+          status: VerificationStatus.Pending,
+          votesFor: 0,
+          votesAgainst: 0,
+          registeredAt: 1,
+          resolvedAt: 0,
+          quorumProgress: 0,
+        },
+      ]);
+
+      stellarService.discoverAssets.mockResolvedValue({
+        assets: [
+          {
+            assetCode: 'XLM',
+            assetIssuer: 'native',
+            assetType: 'native',
+            numAccounts: 1000,
+          },
+        ],
+        hasMore: false,
+      });
+
+      (newsRepo.query as jest.Mock).mockResolvedValue([
+        { kind: 'tag', value: 'stellar' },
+      ]);
+
+      const res = await service.linkEntities({
+        text: 'LumenPulse Wallet tracks XLM in the Stellar ecosystem',
+      });
+
+      expect(res.projects[0]).toMatchObject({
+        projectId: 1,
+        matchedMention: 'lumenpulse',
+      });
+      expect(res.assets[0]).toMatchObject({
+        assetCode: 'XLM',
+        matchedMention: 'xlm',
+      });
+      expect(res.ecosystem[0]).toMatchObject({
+        kind: 'tag',
+        value: 'stellar',
+      });
+    });
+  });
 });

--- a/apps/backend/src/search/search.service.ts
+++ b/apps/backend/src/search/search.service.ts
@@ -17,6 +17,10 @@ import {
   EcosystemSearchQueryDto,
   EcosystemSearchResponseDto,
 } from './dto/ecosystem-search.dto';
+import {
+  EntityLinkingQueryDto,
+  EntityLinkingResponseDto,
+} from './dto/entity-linking.dto';
 
 type TagRow = { value: string; count: number };
 type CategoryRow = { value: string; count: number };
@@ -160,6 +164,69 @@ export class SearchService {
     };
   }
 
+  async linkEntities(
+    query: EntityLinkingQueryDto,
+  ): Promise<EntityLinkingResponseDto> {
+    const limitPerType = Math.min(query.limitPerType ?? 5, 20);
+    const normalizedText = query.text.trim().toLowerCase();
+    const mentions = this.extractMentions(normalizedText);
+
+    const projectMatches = this.verificationService
+      .listProjects()
+      .filter((project) =>
+        mentions.some((mention) => project.name.toLowerCase().includes(mention)),
+      )
+      .slice(0, limitPerType)
+      .map((project) => {
+        const matchedMention =
+          mentions.find((mention) => project.name.toLowerCase().includes(mention)) ??
+          project.name.toLowerCase();
+        return {
+          projectId: project.projectId,
+          name: project.name,
+          matchedMention,
+        };
+      });
+
+    const assetMatches: Array<{
+      assetCode: string;
+      assetIssuer: string;
+      matchedMention: string;
+    }> = [];
+    const seenAssetKeys = new Set<string>();
+
+    for (const mention of mentions.slice(0, 8)) {
+      if (assetMatches.length >= limitPerType) break;
+      const res = await this.stellarService.discoverAssets({
+        q: mention,
+        limit: 5,
+      });
+      for (const asset of res.assets) {
+        const key = `${asset.assetCode}:${asset.assetIssuer}`;
+        if (seenAssetKeys.has(key)) continue;
+        if (asset.assetCode.toLowerCase() !== mention) continue;
+        seenAssetKeys.add(key);
+        assetMatches.push({
+          assetCode: asset.assetCode,
+          assetIssuer: asset.assetIssuer,
+          matchedMention: mention,
+        });
+        if (assetMatches.length >= limitPerType) break;
+      }
+    }
+
+    const ecosystemRows = await this.fetchEcosystemByMentions(
+      mentions,
+      limitPerType,
+    );
+
+    return {
+      projects: projectMatches,
+      assets: assetMatches,
+      ecosystem: ecosystemRows,
+    };
+  }
+
   private projectToScoredItem(
     p: ProjectVerificationDto,
     qLower: string,
@@ -247,5 +314,62 @@ export class SearchService {
     `;
 
     return await this.newsRepository.query(sql, params);
+  }
+
+  private extractMentions(text: string): string[] {
+    const tokens = text
+      .split(/[^a-z0-9_]+/)
+      .map((t) => t.trim())
+      .filter((t) => t.length >= 2);
+    return [...new Set(tokens)];
+  }
+
+  private async fetchEcosystemByMentions(
+    mentions: string[],
+    limit: number,
+  ): Promise<Array<{ kind: 'tag' | 'category'; value: string; matchedMention: string }>> {
+    if (mentions.length === 0) return [];
+
+    const params = [...mentions, limit];
+    const mentionPlaceholders = mentions
+      .map((_, idx) => `$${idx + 1}`)
+      .join(', ');
+    const limitParam = `$${mentions.length + 1}`;
+
+    const sql = `
+      WITH matched_tags AS (
+        SELECT 'tag'::text AS kind, tag AS value
+        FROM (
+          SELECT LOWER(UNNEST(tags)) AS tag
+          FROM articles
+          WHERE tags IS NOT NULL AND array_length(tags, 1) > 0
+        ) t
+        WHERE tag IN (${mentionPlaceholders})
+      ),
+      matched_categories AS (
+        SELECT 'category'::text AS kind, LOWER(category) AS value
+        FROM articles
+        WHERE category IS NOT NULL
+          AND LOWER(category) IN (${mentionPlaceholders})
+      )
+      SELECT DISTINCT kind, value
+      FROM (
+        SELECT * FROM matched_tags
+        UNION ALL
+        SELECT * FROM matched_categories
+      ) all_matches
+      LIMIT ${limitParam};
+    `;
+
+    const rows = (await this.newsRepository.query(sql, params)) as Array<{
+      kind: 'tag' | 'category';
+      value: string;
+    }>;
+
+    return rows.map((row) => ({
+      kind: row.kind,
+      value: row.value,
+      matchedMention: row.value,
+    }));
   }
 }

--- a/apps/backend/src/search/search.service.ts
+++ b/apps/backend/src/search/search.service.ts
@@ -174,13 +174,16 @@ export class SearchService {
     const projectMatches = this.verificationService
       .listProjects()
       .filter((project) =>
-        mentions.some((mention) => project.name.toLowerCase().includes(mention)),
+        mentions.some((mention) =>
+          project.name.toLowerCase().includes(mention),
+        ),
       )
       .slice(0, limitPerType)
       .map((project) => {
         const matchedMention =
-          mentions.find((mention) => project.name.toLowerCase().includes(mention)) ??
-          project.name.toLowerCase();
+          mentions.find((mention) =>
+            project.name.toLowerCase().includes(mention),
+          ) ?? project.name.toLowerCase();
         return {
           projectId: project.projectId,
           name: project.name,
@@ -327,7 +330,9 @@ export class SearchService {
   private async fetchEcosystemByMentions(
     mentions: string[],
     limit: number,
-  ): Promise<Array<{ kind: 'tag' | 'category'; value: string; matchedMention: string }>> {
+  ): Promise<
+    Array<{ kind: 'tag' | 'category'; value: string; matchedMention: string }>
+  > {
     if (mentions.length === 0) return [];
 
     const params = [...mentions, limit];
@@ -361,15 +366,40 @@ export class SearchService {
       LIMIT ${limitParam};
     `;
 
-    const rows = (await this.newsRepository.query(sql, params)) as Array<{
-      kind: 'tag' | 'category';
-      value: string;
-    }>;
+    const rawRows: unknown = await this.newsRepository.query(sql, params);
+    const rows = this.asEcosystemRows(rawRows);
 
     return rows.map((row) => ({
       kind: row.kind,
       value: row.value,
       matchedMention: row.value,
     }));
+  }
+
+  private asEcosystemRows(
+    value: unknown,
+  ): Array<{ kind: 'tag' | 'category'; value: string }> {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value.flatMap((row) => {
+      if (!row || typeof row !== 'object') {
+        return [];
+      }
+
+      const record = row as Record<string, unknown>;
+      const kind = record.kind;
+      const rowValue = record.value;
+
+      if (
+        (kind === 'tag' || kind === 'category') &&
+        typeof rowValue === 'string'
+      ) {
+        return [{ kind, value: rowValue }];
+      }
+
+      return [];
+    });
   }
 }


### PR DESCRIPTION
Closes #537

## Summary
- add a new endpoint `GET /search/entity-links` to resolve free-text mentions into known entities
- link mentions to known Lumenpulse projects, Stellar assets, and ecosystem entries
- return grouped results by entity type so clients can consume linked references directly

## Implementation
- added new DTOs for request/response typing in `search/dto/entity-linking.dto.ts`
- added `SearchService.linkEntities()` with mention extraction and linking logic:
  - matches project mentions against known verification projects
  - resolves asset mentions through Stellar asset discovery
  - links ecosystem mentions against known tags/categories from stored articles
- added controller route wiring for `/search/entity-links`
- added unit tests for end-to-end linking behavior in `search.service.spec.ts`

## Testing
- npx jest src/search/search.service.spec.ts --watchman=false