### PR TITLE
feat: add Stellar contract healthcheck

### DIFF
--- a/apps/backend/src/health/contract-health.service.spec.ts
+++ b/apps/backend/src/health/contract-health.service.spec.ts
@@ -1,0 +1,166 @@
+const mockServerSecret = 'mock-server-secret-for-redaction-test';
+
+const mockConfig = {
+  stellar: {
+    network: 'testnet' as const,
+    sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+    timeout: 3000,
+    serverSecret: {
+      reveal: jest.fn(() => mockServerSecret),
+    },
+    contracts: {
+      lumenToken: null as string | null,
+      crowdfundVault: null as string | null,
+      projectRegistry: null as string | null,
+      contributorRegistry: null as string | null,
+      matchingPool: null as string | null,
+      treasury: null as string | null,
+    },
+  },
+};
+
+jest.mock('../lib/config', () => ({
+  config: mockConfig,
+}));
+
+import { StrKey } from '@stellar/stellar-sdk';
+import { ContractHealthService } from './contract-health.service';
+
+const makeContractId = (seed: number): string =>
+  StrKey.encodeContract(Buffer.alloc(32, seed));
+
+const resetContracts = () => {
+  Object.assign(mockConfig.stellar.contracts, {
+    lumenToken: null,
+    crowdfundVault: null,
+    projectRegistry: null,
+    contributorRegistry: null,
+    matchingPool: null,
+    treasury: null,
+  });
+};
+
+describe('ContractHealthService', () => {
+  let service: ContractHealthService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetContracts();
+    service = new ContractHealthService();
+  });
+
+  it('reports missing contract IDs as misconfigured without loading RPC context', async () => {
+    const loadSpy = jest.spyOn(service as any, 'loadSimulationContext');
+
+    const report = await service.getContractHealthReport();
+
+    expect(report.status).toBe('error');
+    expect(report.summary).toEqual({
+      total: 6,
+      reachable: 0,
+      misconfigured: 6,
+      unreachable: 0,
+    });
+    expect(report.contracts.every((contract) => !contract.configured)).toBe(
+      true,
+    );
+    expect(loadSpy).not.toHaveBeenCalled();
+  });
+
+  it('runs configured read calls and marks a callable contract as reachable', async () => {
+    mockConfig.stellar.contracts.lumenToken = makeContractId(1);
+    jest
+      .spyOn(service as any, 'loadSimulationContext')
+      .mockResolvedValue({ context: 'mock' });
+    const simulateSpy = jest
+      .spyOn(service as any, 'simulateContractRead')
+      .mockImplementation((_context, _contractId: string, method: string) =>
+        Promise.resolve({
+          method,
+          status: 'ok',
+          returnType: 'scvU32',
+        }),
+      );
+
+    const report = await service.getContractHealthReport();
+    const lumenToken = report.contracts.find(
+      (contract) => contract.name === 'lumenToken',
+    );
+
+    expect(lumenToken).toEqual(
+      expect.objectContaining({
+        configured: true,
+        status: 'reachable',
+        envVar: 'STELLAR_CONTRACT_LUMEN_TOKEN',
+      }),
+    );
+    expect(lumenToken?.readMethods.map((check) => check.method)).toEqual([
+      'decimals',
+      'symbol',
+    ]);
+    expect(simulateSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports invalid contract IDs as misconfigured before simulation', async () => {
+    mockConfig.stellar.contracts.lumenToken = 'not-a-contract';
+    const loadSpy = jest.spyOn(service as any, 'loadSimulationContext');
+
+    const report = await service.getContractHealthReport();
+    const lumenToken = report.contracts.find(
+      (contract) => contract.name === 'lumenToken',
+    );
+
+    expect(lumenToken).toEqual(
+      expect.objectContaining({
+        configured: true,
+        status: 'misconfigured',
+        contractId: '[invalid-contract-id]',
+        message:
+          'STELLAR_CONTRACT_LUMEN_TOKEN is not a valid Stellar contract ID',
+      }),
+    );
+    expect(loadSpy).not.toHaveBeenCalled();
+  });
+
+  it('redacts configured IDs and secrets from failed read messages', async () => {
+    const treasuryId = makeContractId(2);
+    mockConfig.stellar.contracts.treasury = treasuryId;
+    jest
+      .spyOn(service as any, 'loadSimulationContext')
+      .mockResolvedValue({ context: 'mock' });
+    jest
+      .spyOn(service as any, 'simulateContractRead')
+      .mockImplementation((_context, _contractId: string, method: string) =>
+        Promise.resolve(
+          method === 'get_admin'
+            ? {
+                method,
+                status: 'ok',
+                returnType: 'scvAddress',
+              }
+            : {
+                method,
+                status: 'failed',
+                message: `Call failed for ${treasuryId} using ${mockServerSecret}`,
+              },
+        ),
+      );
+
+    const report = await service.getContractHealthReport();
+    const treasury = report.contracts.find(
+      (contract) => contract.name === 'treasury',
+    );
+    const serialized = JSON.stringify(report);
+
+    expect(treasury).toEqual(
+      expect.objectContaining({
+        configured: true,
+        status: 'unreachable',
+        contractId: `${treasuryId.slice(0, 6)}...${treasuryId.slice(-6)}`,
+      }),
+    );
+    expect(serialized).not.toContain(treasuryId);
+    expect(serialized).not.toContain(mockServerSecret);
+    expect(serialized).toContain('[REDACTED]');
+  });
+});

--- a/apps/backend/src/health/contract-health.service.ts
+++ b/apps/backend/src/health/contract-health.service.ts
@@ -1,0 +1,333 @@
+import { Injectable } from '@nestjs/common';
+import {
+  Account,
+  BASE_FEE,
+  Contract,
+  Keypair,
+  Networks,
+  StrKey,
+  TransactionBuilder,
+  rpc,
+  xdr,
+} from '@stellar/stellar-sdk';
+import { config } from '../lib/config';
+
+const NETWORK_PASSPHRASES = {
+  testnet: Networks.TESTNET,
+  mainnet: Networks.PUBLIC,
+} as const;
+
+const DEFAULT_SOROBAN_RPC_URLS = {
+  testnet: 'https://soroban-testnet.stellar.org',
+  mainnet: 'https://soroban.stellar.org',
+} as const;
+
+const CONTRACT_CHECKS = [
+  {
+    name: 'lumenToken',
+    envVar: 'STELLAR_CONTRACT_LUMEN_TOKEN',
+    readMethods: ['decimals', 'symbol'],
+  },
+  {
+    name: 'crowdfundVault',
+    envVar: 'STELLAR_CONTRACT_CROWDFUND_VAULT',
+    readMethods: ['get_admin', 'get_storage_version'],
+  },
+  {
+    name: 'projectRegistry',
+    envVar: 'STELLAR_CONTRACT_PROJECT_REGISTRY',
+    readMethods: ['get_admin', 'get_config'],
+  },
+  {
+    name: 'contributorRegistry',
+    envVar: 'STELLAR_CONTRACT_CONTRIBUTOR_REGISTRY',
+    readMethods: ['get_multisig_config'],
+  },
+  {
+    name: 'matchingPool',
+    envVar: 'STELLAR_CONTRACT_MATCHING_POOL',
+    readMethods: ['get_admin'],
+  },
+  {
+    name: 'treasury',
+    envVar: 'STELLAR_CONTRACT_TREASURY',
+    readMethods: ['get_admin', 'get_token'],
+  },
+] as const;
+
+type ContractCheckDefinition = (typeof CONTRACT_CHECKS)[number];
+type ContractName = ContractCheckDefinition['name'];
+type ContractStatus = 'reachable' | 'misconfigured' | 'unreachable';
+type ReadMethodStatus = 'ok' | 'failed' | 'restore_required';
+
+interface SimulationContext {
+  server: rpc.Server;
+  sourceAccountId: string;
+  sourceSequence: string;
+  networkPassphrase: string;
+}
+
+export interface ContractReadMethodHealth {
+  method: string;
+  status: ReadMethodStatus;
+  returnType?: string;
+  message?: string;
+}
+
+export interface ContractHealthResult {
+  name: ContractName;
+  envVar: string;
+  configured: boolean;
+  status: ContractStatus;
+  contractId?: string;
+  readMethods: ContractReadMethodHealth[];
+  message?: string;
+}
+
+export interface ContractHealthReport {
+  status: 'ok' | 'error';
+  summary: {
+    total: number;
+    reachable: number;
+    misconfigured: number;
+    unreachable: number;
+  };
+  network: 'testnet' | 'mainnet';
+  checkedAt: string;
+  contracts: ContractHealthResult[];
+}
+
+@Injectable()
+export class ContractHealthService {
+  async getContractHealthReport(): Promise<ContractHealthReport> {
+    const context = await this.loadSimulationContextIfNeeded();
+    const contracts = await Promise.all(
+      CONTRACT_CHECKS.map((definition) =>
+        this.checkContract(definition, context),
+      ),
+    );
+
+    const summary = contracts.reduce(
+      (acc, contract) => {
+        acc[contract.status] += 1;
+        return acc;
+      },
+      {
+        total: contracts.length,
+        reachable: 0,
+        misconfigured: 0,
+        unreachable: 0,
+      },
+    );
+
+    return {
+      status:
+        summary.misconfigured === 0 && summary.unreachable === 0
+          ? 'ok'
+          : 'error',
+      summary,
+      network: config.stellar.network,
+      checkedAt: new Date().toISOString(),
+      contracts,
+    };
+  }
+
+  private async checkContract(
+    definition: ContractCheckDefinition,
+    context: SimulationContext | null,
+  ): Promise<ContractHealthResult> {
+    const contractId = config.stellar.contracts[definition.name];
+
+    if (!contractId) {
+      return {
+        name: definition.name,
+        envVar: definition.envVar,
+        configured: false,
+        status: 'misconfigured',
+        readMethods: [],
+        message: `${definition.envVar} is not configured`,
+      };
+    }
+
+    const redactedContractId = this.redactContractId(contractId);
+
+    if (!StrKey.isValidContract(contractId)) {
+      return {
+        name: definition.name,
+        envVar: definition.envVar,
+        configured: true,
+        status: 'misconfigured',
+        contractId: '[invalid-contract-id]',
+        readMethods: [],
+        message: `${definition.envVar} is not a valid Stellar contract ID`,
+      };
+    }
+
+    if (!context) {
+      return {
+        name: definition.name,
+        envVar: definition.envVar,
+        configured: true,
+        status: 'unreachable',
+        contractId: redactedContractId,
+        readMethods: [],
+        message: 'Soroban RPC healthcheck source account is unavailable',
+      };
+    }
+
+    const readMethods = await Promise.all(
+      definition.readMethods.map((method: string) =>
+        this.simulateContractRead(context, contractId, method),
+      ),
+    );
+    const sanitizedReadMethods = readMethods.map((method) => ({
+      ...method,
+      message: method.message
+        ? this.sanitizeMessage(method.message, contractId)
+        : undefined,
+    }));
+    const failedRead = sanitizedReadMethods.find(
+      (method) => method.status !== 'ok',
+    );
+
+    return {
+      name: definition.name,
+      envVar: definition.envVar,
+      configured: true,
+      status: failedRead ? 'unreachable' : 'reachable',
+      contractId: redactedContractId,
+      readMethods: sanitizedReadMethods,
+      message: failedRead
+        ? `Read call ${failedRead.method} did not complete successfully`
+        : undefined,
+    };
+  }
+
+  private async loadSimulationContextIfNeeded(): Promise<SimulationContext | null> {
+    const hasConfiguredContract = CONTRACT_CHECKS.some((definition) => {
+      const contractId = config.stellar.contracts[definition.name];
+      return contractId && StrKey.isValidContract(contractId);
+    });
+
+    if (!hasConfiguredContract) {
+      return null;
+    }
+
+    try {
+      return await this.loadSimulationContext();
+    } catch {
+      return null;
+    }
+  }
+
+  private async loadSimulationContext(): Promise<SimulationContext> {
+    const server = new rpc.Server(this.getSorobanRpcUrl(), {
+      timeout: config.stellar.timeout,
+      allowHttp: config.stellar.sorobanRpcUrl?.startsWith('http://') ?? false,
+    });
+    const sourcePublicKey = Keypair.fromSecret(
+      config.stellar.serverSecret.reveal(),
+    ).publicKey();
+    const sourceAccount = await server.getAccount(sourcePublicKey);
+
+    return {
+      server,
+      sourceAccountId: sourceAccount.accountId(),
+      sourceSequence: sourceAccount.sequenceNumber(),
+      networkPassphrase: NETWORK_PASSPHRASES[config.stellar.network],
+    };
+  }
+
+  private async simulateContractRead(
+    context: SimulationContext,
+    contractId: string,
+    method: string,
+  ): Promise<ContractReadMethodHealth> {
+    try {
+      const tx = new TransactionBuilder(
+        new Account(context.sourceAccountId, context.sourceSequence),
+        {
+          fee: BASE_FEE,
+          networkPassphrase: context.networkPassphrase,
+        },
+      )
+        .addOperation(new Contract(contractId).call(method))
+        .setTimeout(30)
+        .build();
+      const simulation = await context.server.simulateTransaction(tx);
+
+      if (rpc.Api.isSimulationError(simulation)) {
+        return {
+          method,
+          status: 'failed',
+          message: simulation.error || 'Simulation failed',
+        };
+      }
+
+      if (rpc.Api.isSimulationRestore(simulation)) {
+        return {
+          method,
+          status: 'restore_required',
+          returnType: this.getReturnType(simulation.result.retval),
+          message:
+            'Contract data requires restoration before this read is live',
+        };
+      }
+
+      if (!simulation.result) {
+        return {
+          method,
+          status: 'failed',
+          message: 'Simulation completed without a return value',
+        };
+      }
+
+      return {
+        method,
+        status: 'ok',
+        returnType: this.getReturnType(simulation.result.retval),
+      };
+    } catch (error) {
+      return {
+        method,
+        status: 'failed',
+        message: this.getErrorMessage(error),
+      };
+    }
+  }
+
+  private getSorobanRpcUrl(): string {
+    return (
+      config.stellar.sorobanRpcUrl ??
+      DEFAULT_SOROBAN_RPC_URLS[config.stellar.network]
+    );
+  }
+
+  private getReturnType(value: xdr.ScVal): string {
+    return value.switch().name;
+  }
+
+  private redactContractId(contractId: string): string {
+    if (contractId.length <= 12) {
+      return '[invalid-contract-id]';
+    }
+
+    return `${contractId.slice(0, 6)}...${contractId.slice(-6)}`;
+  }
+
+  private sanitizeMessage(message: string, contractId: string): string {
+    const redacted = message
+      .replaceAll(contractId, this.redactContractId(contractId))
+      .replaceAll(config.stellar.serverSecret.reveal(), '[REDACTED]');
+
+    return redacted.length > 300 ? `${redacted.slice(0, 297)}...` : redacted;
+  }
+
+  private getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return 'Read call failed';
+  }
+}

--- a/apps/backend/src/health/health.controller.ts
+++ b/apps/backend/src/health/health.controller.ts
@@ -7,12 +7,16 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 import type { Response } from 'express';
+import { ContractHealthService } from './contract-health.service';
 import { HealthService } from './health.service';
 
 @ApiTags('health')
 @Controller()
 export class HealthController {
-  constructor(private readonly healthService: HealthService) {}
+  constructor(
+    private readonly healthService: HealthService,
+    private readonly contractHealthService: ContractHealthService,
+  ) {}
 
   @Get('health')
   @HealthCheck()
@@ -28,6 +32,27 @@ export class HealthController {
     const healthReport = await this.healthService.getHealthReport();
 
     response.status(healthReport.status === 'error' ? 503 : 200);
+
+    return healthReport;
+  }
+
+  @Get('health/contracts')
+  @ApiOperation({
+    summary: 'Reports configured Stellar contract reachability and readiness',
+  })
+  @ApiOkResponse({
+    description:
+      'Returns reachable contract status for all configured contract IDs.',
+  })
+  @ApiServiceUnavailableResponse({
+    description:
+      'Returns when one or more configured contract IDs are missing, invalid, or not callable.',
+  })
+  async getContractHealth(@Res({ passthrough: true }) response: Response) {
+    const healthReport =
+      await this.contractHealthService.getContractHealthReport();
+
+    response.status(healthReport.status === 'ok' ? 200 : 503);
 
     return healthReport;
   }

--- a/apps/backend/src/health/health.module.ts
+++ b/apps/backend/src/health/health.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { AppCacheModule } from '../cache/cache.module';
 import { StellarModule } from '../stellar/stellar.module';
+import { ContractHealthService } from './contract-health.service';
 import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
 
@@ -17,6 +18,6 @@ import { HealthService } from './health.service';
     StellarModule,
   ],
   controllers: [HealthController],
-  providers: [HealthService],
+  providers: [HealthService, ContractHealthService],
 })
 export class HealthModule {}


### PR DESCRIPTION
## What changed

Closes #708.

- Added `GET /health/contracts` for configured Stellar/Soroban contract readiness.
- Validates each configured contract ID for presence and valid Stellar contract format.
- Performs read-only Soroban simulation calls per configured contract:
  - `lumenToken`: `decimals`, `symbol`
  - `crowdfundVault`: `get_admin`, `get_storage_version`
  - `projectRegistry`: `get_admin`, `get_config`
  - `contributorRegistry`: `get_multisig_config`
  - `matchingPool`: `get_admin`
  - `treasury`: `get_admin`, `get_token`
- Reports each contract as `reachable`, `misconfigured`, or `unreachable`.
- Returns `503` when any configured contract is `misconfigured` or `unreachable`.
- Keeps output safe by redacting contract IDs and server secrets from error messages.

## Scope note

`restore_required` simulation results are treated as not healthy because the contract data is not currently callable without restoration. The endpoint reports this clearly instead of treating it as a successful ready state.

## Verification

- `npm test -- contract-health.service.spec.ts --runInBand`
- `npm test -- health.service.spec.ts contract-health.service.spec.ts --runInBand`
- `npm run build`
- `npx eslint src/health/contract-health.service.ts src/health/contract-health.service.spec.ts src/health/health.controller.ts src/health/health.module.ts`
- `git diff --check fb2fe28^ fb2fe28`

Note: initial local `npm install` hit a native `sharp` install-script issue, so local dependency setup used `npm install --ignore-scripts`. No package or lockfile changes are included.
