### PR TITLE
feat(soroban-events): add ingestion entrypoint and background processor

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -55,6 +55,7 @@ import { AppConfigModule } from './config/config.module';
 import { CrowdfundModule } from './crowdfund/crowdfund.module';
 import { AuditModule } from './audit/audit.module';
 import { AuditLogInterceptor } from './audit/interceptors/audit-log.interceptor';
+import { SorobanEventsModule } from './soroban-events/soroban-events.module';
 
 @Module({
   imports: [
@@ -127,6 +128,7 @@ import { AuditLogInterceptor } from './audit/interceptors/audit-log.interceptor'
     CrowdfundModule,
     AppConfigModule,
     AuditModule,
+    SorobanEventsModule,
   ],
   controllers: [AppController, TestController, TestExceptionController],
   providers: [

--- a/apps/backend/src/database/migrations/1774000000000-CreateSorobanEvents.ts
+++ b/apps/backend/src/database/migrations/1774000000000-CreateSorobanEvents.ts
@@ -1,0 +1,32 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateSorobanEvents1774000000000 implements MigrationInterface {
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TYPE soroban_event_status AS ENUM ('pending', 'processed', 'failed');
+
+      CREATE TABLE soroban_events (
+        id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        tx_hash         VARCHAR(128) NOT NULL,
+        event_index     INTEGER NOT NULL,
+        contract_id     VARCHAR(128),
+        event_type      VARCHAR(128),
+        raw_payload     JSONB NOT NULL,
+        status          soroban_event_status NOT NULL DEFAULT 'pending',
+        error_message   TEXT,
+        created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+        processed_at    TIMESTAMPTZ,
+        CONSTRAINT uq_soroban_events_tx_index UNIQUE (tx_hash, event_index)
+      );
+
+      CREATE INDEX idx_soroban_events_status ON soroban_events (status);
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP TABLE IF EXISTS soroban_events;
+      DROP TYPE IF EXISTS soroban_event_status;
+    `);
+  }
+}

--- a/apps/backend/src/soroban-events/dto/ingest-soroban-event.dto.ts
+++ b/apps/backend/src/soroban-events/dto/ingest-soroban-event.dto.ts
@@ -1,0 +1,29 @@
+import {
+  IsInt,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+
+export class IngestSorobanEventDto {
+  @IsString()
+  @IsNotEmpty()
+  txHash: string;
+
+  @IsInt()
+  @Min(0)
+  eventIndex: number;
+
+  @IsString()
+  @IsOptional()
+  contractId?: string;
+
+  @IsString()
+  @IsOptional()
+  eventType?: string;
+
+  @IsObject()
+  rawPayload: Record<string, unknown>;
+}

--- a/apps/backend/src/soroban-events/entities/soroban-event.entity.ts
+++ b/apps/backend/src/soroban-events/entities/soroban-event.entity.ts
@@ -1,0 +1,57 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+export enum SorobanEventStatus {
+  PENDING = 'pending',
+  PROCESSED = 'processed',
+  FAILED = 'failed',
+}
+
+@Entity('soroban_events')
+@Index(['txHash', 'eventIndex'], { unique: true })
+@Index(['status'])
+export class SorobanEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Idempotency key: transaction hash */
+  @Column({ type: 'varchar', length: 128 })
+  txHash: string;
+
+  /** Idempotency key: position of the event within the transaction */
+  @Column({ type: 'integer' })
+  eventIndex: number;
+
+  /** Soroban contract address that emitted the event */
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  contractId: string | null;
+
+  /** Event type / topic, e.g. "transfer", "mint" */
+  @Column({ type: 'varchar', length: 128, nullable: true })
+  eventType: string | null;
+
+  /** Full raw payload stored for audit/debug */
+  @Column({ type: 'jsonb' })
+  rawPayload: Record<string, unknown>;
+
+  @Column({
+    type: 'enum',
+    enum: SorobanEventStatus,
+    default: SorobanEventStatus.PENDING,
+  })
+  status: SorobanEventStatus;
+
+  @Column({ type: 'text', nullable: true })
+  errorMessage: string | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  processedAt: Date | null;
+}

--- a/apps/backend/src/soroban-events/soroban-events.controller.ts
+++ b/apps/backend/src/soroban-events/soroban-events.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UnauthorizedException,
+  Headers,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { IngestSorobanEventDto } from './dto/ingest-soroban-event.dto';
+import { SorobanEventsService } from './soroban-events.service';
+
+@ApiTags('soroban-events')
+@Controller('soroban-events')
+export class SorobanEventsController {
+  private readonly ingestSecret: string;
+
+  constructor(
+    private readonly service: SorobanEventsService,
+    private readonly config: ConfigService,
+  ) {
+    this.ingestSecret = this.config.get<string>('SOROBAN_INGEST_SECRET', '');
+  }
+
+  @Post('ingest')
+  @HttpCode(HttpStatus.ACCEPTED)
+  @ApiOperation({ summary: 'Ingest a Soroban event from the indexer/cron' })
+  @ApiResponse({ status: 202, description: 'Event accepted for processing' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid ingest secret' })
+  async ingest(
+    @Headers('x-ingest-secret') secret: string,
+    @Body() dto: IngestSorobanEventDto,
+  ) {
+    if (!this.ingestSecret || secret !== this.ingestSecret) {
+      throw new UnauthorizedException('Invalid ingest secret');
+    }
+
+    return this.service.ingest(dto);
+  }
+}

--- a/apps/backend/src/soroban-events/soroban-events.module.ts
+++ b/apps/backend/src/soroban-events/soroban-events.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bullmq';
+import { SorobanEvent } from './entities/soroban-event.entity';
+import {
+  SorobanEventsService,
+  SOROBAN_EVENTS_QUEUE,
+} from './soroban-events.service';
+import { SorobanEventsProcessor } from './soroban-events.processor';
+import { SorobanEventsController } from './soroban-events.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([SorobanEvent]),
+    BullModule.registerQueue({ name: SOROBAN_EVENTS_QUEUE }),
+  ],
+  controllers: [SorobanEventsController],
+  providers: [SorobanEventsService, SorobanEventsProcessor],
+})
+export class SorobanEventsModule {}

--- a/apps/backend/src/soroban-events/soroban-events.processor.ts
+++ b/apps/backend/src/soroban-events/soroban-events.processor.ts
@@ -1,0 +1,78 @@
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Job } from 'bullmq';
+import {
+  SorobanEvent,
+  SorobanEventStatus,
+} from './entities/soroban-event.entity';
+import { IngestSorobanEventDto } from './dto/ingest-soroban-event.dto';
+import {
+  SOROBAN_EVENTS_QUEUE,
+  PROCESS_EVENT_JOB,
+} from './soroban-events.service';
+
+@Processor(SOROBAN_EVENTS_QUEUE)
+@Injectable()
+export class SorobanEventsProcessor extends WorkerHost {
+  private readonly logger = new Logger(SorobanEventsProcessor.name);
+
+  constructor(
+    @InjectRepository(SorobanEvent)
+    private readonly eventRepo: Repository<SorobanEvent>,
+  ) {
+    super();
+  }
+
+  async process(job: Job<IngestSorobanEventDto>): Promise<void> {
+    if (job.name !== PROCESS_EVENT_JOB) {
+      this.logger.warn(`Unknown job name: ${job.name}`);
+      return;
+    }
+
+    const { txHash, eventIndex, contractId, eventType, rawPayload } = job.data;
+
+    // Idempotency: skip if already stored (unique index on txHash + eventIndex)
+    const existing = await this.eventRepo.findOne({
+      where: { txHash, eventIndex },
+      select: ['id', 'status'],
+    });
+
+    if (existing) {
+      this.logger.debug(
+        `Soroban event ${txHash}:${eventIndex} already processed (${existing.status}), skipping`,
+      );
+      return;
+    }
+
+    const event = this.eventRepo.create({
+      txHash,
+      eventIndex,
+      contractId: contractId ?? null,
+      eventType: eventType ?? null,
+      rawPayload,
+      status: SorobanEventStatus.PENDING,
+      processedAt: null,
+      errorMessage: null,
+    });
+
+    await this.eventRepo.save(event);
+
+    try {
+      // placeholder for downstream processing (e.g. trigger notifications, update state)
+      event.status = SorobanEventStatus.PROCESSED;
+      event.processedAt = new Date();
+    } catch (err) {
+      event.status = SorobanEventStatus.FAILED;
+      event.errorMessage = err instanceof Error ? err.message : String(err);
+      await this.eventRepo.save(event);
+      throw err; // let BullMQ retry
+    }
+
+    await this.eventRepo.save(event);
+    this.logger.log(
+      `Processed soroban event ${txHash}:${eventIndex} (${eventType})`,
+    );
+  }
+}

--- a/apps/backend/src/soroban-events/soroban-events.service.ts
+++ b/apps/backend/src/soroban-events/soroban-events.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Queue } from 'bullmq';
+import { IngestSorobanEventDto } from './dto/ingest-soroban-event.dto';
+
+export const SOROBAN_EVENTS_QUEUE = 'soroban-events';
+export const PROCESS_EVENT_JOB = 'process-event';
+
+@Injectable()
+export class SorobanEventsService {
+  private readonly logger = new Logger(SorobanEventsService.name);
+
+  constructor(
+    @InjectQueue(SOROBAN_EVENTS_QUEUE) private readonly queue: Queue,
+  ) {}
+
+  async ingest(dto: IngestSorobanEventDto): Promise<{ queued: boolean }> {
+    const jobId = `${dto.txHash}:${dto.eventIndex}`;
+
+    // BullMQ deduplicates by jobId — duplicate submissions are silently dropped
+    await this.queue.add(PROCESS_EVENT_JOB, dto, {
+      jobId,
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 1000 },
+      removeOnComplete: { count: 500 },
+      removeOnFail: { count: 200 },
+    });
+
+    this.logger.debug(`Queued soroban event ${jobId}`);
+    return { queued: true };
+  }
+}


### PR DESCRIPTION
- POST /soroban-events/ingest accepts payloads from indexer/cron
- Returns 202 immediately; processing happens in BullMQ worker
- Idempotent via jobId (txHash:eventIndex) at queue level + DB unique constraint
- Processor stores raw payload for audit/debug, tracks PENDING->PROCESSED->FAILED lifecycle
- contractId and eventType are optional to match nullable entity columns
- Migration 1774000000000-CreateSorobanEvents adds table, enum, and unique index
- Protected by x-ingest-secret header

## Summary

Describe what changed and why.

## Linked Issue

Closes #

## Type of Change

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Validation

- [ ] Lint passed for affected area(s)
- [ ] Tests passed for affected area(s)
- [ ] Manual verification completed (if applicable)

## Documentation

- [ ] Documentation updated (or N/A with explanation)
- [ ] Screenshots/videos attached for UI changes

## Checklist

- [ ] Branch name uses `feat/`, `fix/`, or `docs/`
- [ ] Commit messages follow Conventional Commits
- [ ] PR scope matches linked issue acceptance criteria

closes #717
