### PR TITLE
Add testnet on-chain query indexes

### DIFF
--- a/apps/backend/PERFORMANCE_TESTNET_ONCHAIN_QUERY_AUDIT.md
+++ b/apps/backend/PERFORMANCE_TESTNET_ONCHAIN_QUERY_AUDIT.md
@@ -1,0 +1,62 @@
+# Testnet On-Chain Query Plan Audit
+
+Issue: Pulsefy/Lumenpulse#813
+
+## Top Slow Query Families
+
+The backend paths most likely to dominate p95 latency as testnet event volume grows are:
+
+| Rank | Query family | Code path | Existing risk | Added index |
+| --- | --- | --- | --- | --- |
+| 1 | Latest raw portfolio snapshot fallback by user | `PortfolioService.getPortfolioSummary`, `MaterializedSnapshotService.refreshForUser` | Sorts each user's historical snapshots when the materialized row is missing or stale | `IDX_portfolio_snapshots_user_created_at_desc` |
+| 2 | Recent Soroban events by contract/type for dashboards | `soroban_events` API/ops views and indexer diagnostics | Contract dashboards need recent slices and otherwise scan/filter event history | `IDX_soroban_events_contract_type_created_at` |
+| 3 | Pending/failed Soroban event queue views | `SorobanEventsProcessor` and admin/ops review paths | Status-only index still leaves a recency sort as event volume grows | `IDX_soroban_events_status_created_at` |
+| 4 | Processed Soroban event timeline | testnet event processing diagnostics | Processed history needs efficient newest-first reads | `IDX_soroban_events_processed_at` |
+| 5 | Materialized portfolio dashboard freshness and source joins | dashboard fast paths, backfill/reconciliation checks | Freshness scans and source snapshot audits need stable ordered access | `IDX_materialized_snapshots_updated_at`, `IDX_materialized_snapshots_source_snapshot` |
+
+## Before/After Timing Capture
+
+Use the repeatable audit script against staging or a local restored testnet dump:
+
+```bash
+cd apps/backend
+psql "$DATABASE_URL" \
+  -v user_id="<uuid-user-id>" \
+  -v contract_id="<contract-id>" \
+  -v event_type="transfer" \
+  -f src/database/testnet-onchain-query-plan-audit.sql
+```
+
+The top-statements section reads from `pg_stat_statements`; enable that extension
+in the target environment before using the ranking query.
+
+Capture the `EXPLAIN (ANALYZE, BUFFERS)` output before and after running:
+
+```bash
+npm run migration:run
+```
+
+The expected plan changes are:
+
+| Query | Before migration | After migration |
+| --- | --- | --- |
+| Latest snapshot fallback | Bitmap/index scan plus explicit sort on `createdAt DESC`, or sequential scan on large local datasets | Backward read from `IDX_portfolio_snapshots_user_created_at_desc`; no separate sort |
+| Contract event dashboard slice | Filter by `contractId`/`eventType` then sort recent rows | Index scan on `IDX_soroban_events_contract_type_created_at` in newest-first order |
+| Pending/failed operations queue | Status filter plus sort by `createdAt DESC` | Index scan on `IDX_soroban_events_status_created_at` |
+| Processed event timeline | Filter non-null `processedAt` plus sort | Partial index scan on `IDX_soroban_events_processed_at` |
+| Materialized snapshot freshness | Full scan or heap lookups for dashboard freshness/source checks | Covering ordered index for freshness reads and direct source snapshot lookup |
+
+## Index Rationale
+
+- All indexes support read paths already present in the backend; no new runtime dependency or data model is introduced.
+- The Soroban indexes are ordered by recency because testnet dashboards and failure triage generally read the newest events first.
+- The latest-snapshot index keeps the fallback path fast when a materialized portfolio row has not been created yet.
+- The materialized freshness index uses `INCLUDE` columns so dashboard summaries can avoid extra heap reads when PostgreSQL can serve the query from the index.
+- The migration is reversible with `DROP INDEX CONCURRENTLY IF EXISTS` in `down()`.
+
+## Safety
+
+- The migration only creates secondary indexes. It does not rewrite table data or alter existing columns.
+- `CREATE INDEX CONCURRENTLY IF NOT EXISTS` makes rollout idempotent while avoiding long write locks on growing tables.
+- `migrationsTransactionMode: 'each'` allows this migration's `transaction = false` setting to keep concurrent index operations outside a transaction while preserving per-migration transactions elsewhere.
+- Rollback uses `DROP INDEX CONCURRENTLY IF EXISTS` and drops only the named indexes added for this audit.

--- a/apps/backend/src/database/data-source.ts
+++ b/apps/backend/src/database/data-source.ts
@@ -13,6 +13,7 @@ export default new DataSource({
   entities: ['dist/**/*.entity.js', 'src/**/*.entity.ts'],
 
   migrations: ['dist/database/migrations/*.js', 'src/database/migrations/*.ts'],
+  migrationsTransactionMode: 'each',
 
   logging: true,
 });

--- a/apps/backend/src/database/migrations/1780148000000-AddTestnetOnchainQueryIndexes.ts
+++ b/apps/backend/src/database/migrations/1780148000000-AddTestnetOnchainQueryIndexes.ts
@@ -1,0 +1,70 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTestnetOnchainQueryIndexes1780148000000
+  implements MigrationInterface
+{
+  name = 'AddTestnetOnchainQueryIndexes1780148000000';
+  transaction = false;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_soroban_events_contract_type_created_at"
+        ON "soroban_events" ("contractId", "eventType", "createdAt" DESC)
+        WHERE "contractId" IS NOT NULL
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_soroban_events_status_created_at"
+        ON "soroban_events" ("status", "createdAt" DESC)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_soroban_events_processed_at"
+        ON "soroban_events" ("processedAt" DESC)
+        WHERE "processedAt" IS NOT NULL
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_portfolio_snapshots_user_created_at_desc"
+        ON "portfolio_snapshots" ("userId", "createdAt" DESC)
+        INCLUDE ("totalValueUsd")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_materialized_snapshots_updated_at"
+        ON "portfolio_materialized_snapshots" ("updatedAt" DESC)
+        INCLUDE ("userId", "totalValueUsd", "hasLinkedAccount")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_materialized_snapshots_source_snapshot"
+        ON "portfolio_materialized_snapshots" ("source_snapshot_id")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS "public"."IDX_materialized_snapshots_source_snapshot"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS "public"."IDX_materialized_snapshots_updated_at"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS "public"."IDX_portfolio_snapshots_user_created_at_desc"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS "public"."IDX_soroban_events_processed_at"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS "public"."IDX_soroban_events_status_created_at"
+    `);
+
+    await queryRunner.query(`
+      DROP INDEX CONCURRENTLY IF EXISTS "public"."IDX_soroban_events_contract_type_created_at"
+    `);
+  }
+}

--- a/apps/backend/src/database/testnet-onchain-query-plan-audit.sql
+++ b/apps/backend/src/database/testnet-onchain-query-plan-audit.sql
@@ -1,0 +1,73 @@
+-- Testnet on-chain/materialized-view query plan audit.
+--
+-- Run before and after the index migration to capture the top query families:
+--   psql "$DATABASE_URL" \
+--     -v user_id="<uuid-user-id>" \
+--     -v contract_id="<contract-id>" \
+--     -v event_type="transfer" \
+--     -f src/database/testnet-onchain-query-plan-audit.sql
+--
+-- The top statements section requires pg_stat_statements to be enabled.
+
+\echo 'Top statements touching on-chain derived/materialized tables'
+SELECT
+  calls,
+  ROUND(mean_exec_time::numeric, 2) AS mean_ms,
+  ROUND(total_exec_time::numeric, 2) AS total_ms,
+  rows,
+  LEFT(regexp_replace(query, '\s+', ' ', 'g'), 220) AS query
+FROM pg_stat_statements
+WHERE query ILIKE ANY (ARRAY[
+  '%soroban_events%',
+  '%portfolio_materialized_snapshots%',
+  '%portfolio_snapshots%',
+  '%stellar_processed_events%',
+  '%stellar_sync_checkpoints%'
+])
+ORDER BY mean_exec_time DESC
+LIMIT 10;
+
+\echo 'Q1: latest portfolio snapshot fallback'
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT "id", "userId", "createdAt", "assetBalances", "totalValueUsd"
+FROM "portfolio_snapshots"
+WHERE "userId" = :'user_id'
+ORDER BY "createdAt" DESC
+LIMIT 1;
+
+\echo 'Q2: dashboard fast path materialized snapshot'
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT "userId", "totalValueUsd", "assetBalances", "assetAllocation",
+       "hasLinkedAccount", "updatedAt"
+FROM "portfolio_materialized_snapshots"
+WHERE "userId" = :'user_id'
+LIMIT 1;
+
+\echo 'Q3: stale materialized snapshot refresh candidates'
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT ps."userId"
+FROM "portfolio_snapshots" ps
+LEFT JOIN "portfolio_materialized_snapshots" pms
+  ON pms."userId" = ps."userId"
+WHERE pms."userId" IS NULL
+GROUP BY ps."userId"
+LIMIT 100;
+
+\echo 'Q4: recent contract event dashboard slice'
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT "id", "txHash", "eventIndex", "contractId", "eventType",
+       "status", "createdAt", "processedAt"
+FROM "soroban_events"
+WHERE "contractId" = :'contract_id'
+  AND (:'event_type' IS NULL OR "eventType" = :'event_type')
+ORDER BY "createdAt" DESC
+LIMIT 100;
+
+\echo 'Q5: failed/pending event operations queue'
+EXPLAIN (ANALYZE, BUFFERS)
+SELECT "id", "txHash", "eventIndex", "contractId", "eventType",
+       "status", "createdAt", "errorMessage"
+FROM "soroban_events"
+WHERE "status" IN ('pending', 'failed')
+ORDER BY "createdAt" DESC
+LIMIT 100;

--- a/apps/backend/src/portfolio/entities/portfolio-materialized-snapshot.entity.ts
+++ b/apps/backend/src/portfolio/entities/portfolio-materialized-snapshot.entity.ts
@@ -21,6 +21,8 @@ import { User } from '../../users/entities/user.entity';
  */
 @Entity('portfolio_materialized_snapshots')
 @Index('UQ_materialized_user', ['userId'], { unique: true })
+@Index('IDX_materialized_snapshots_updated_at', ['updatedAt'])
+@Index('IDX_materialized_snapshots_source_snapshot', ['sourceSnapshotId'])
 export class PortfolioMaterializedSnapshot {
   @PrimaryGeneratedColumn('uuid')
   id: string;

--- a/apps/backend/src/portfolio/entities/portfolio-snapshot.entity.ts
+++ b/apps/backend/src/portfolio/entities/portfolio-snapshot.entity.ts
@@ -10,7 +10,7 @@ import {
 import { User } from '../../users/entities/user.entity';
 
 @Entity('portfolio_snapshots')
-@Index(['userId', 'createdAt'])
+@Index('IDX_portfolio_snapshots_user_created_at_desc', ['userId', 'createdAt'])
 @Index(['createdAt'])
 export class PortfolioSnapshot {
   @PrimaryGeneratedColumn('uuid')

--- a/apps/backend/src/soroban-events/entities/soroban-event.entity.ts
+++ b/apps/backend/src/soroban-events/entities/soroban-event.entity.ts
@@ -15,6 +15,13 @@ export enum SorobanEventStatus {
 @Entity('soroban_events')
 @Index(['txHash', 'eventIndex'], { unique: true })
 @Index(['status'])
+@Index('IDX_soroban_events_contract_type_created_at', [
+  'contractId',
+  'eventType',
+  'createdAt',
+])
+@Index('IDX_soroban_events_status_created_at', ['status', 'createdAt'])
+@Index('IDX_soroban_events_processed_at', ['processedAt'])
 export class SorobanEvent {
   @PrimaryGeneratedColumn('uuid')
   id: string;


### PR DESCRIPTION
## Summary
- add reversible concurrent indexes for Soroban event dashboard slices, event queue scans, portfolio snapshot fallback reads, and materialized snapshot freshness/source lookups
- add a repeatable pg_stat_statements/EXPLAIN query plan audit script for the top slow on-chain/materialized query families
- document before/after timing capture, expected plan changes, index rationale, and rollback safety

Closes #813

## Verification
- git diff --check
- git diff --cached --check
- npm ci --cache /Users/jakehatchett/Documents/Codex/2026-05-29/goal-look-for-the-best-drips/work/npm-cache
- npm run build
- npm test -- --runInBand (38 suites, 323 tests)