### PR TITLE
feat: remove hardcoded contract IDs and add GET /v1/config/stellar endpoint

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -61,6 +61,13 @@ STELLAR_TIMEOUT=30000
 STELLAR_RETRY_ATTEMPTS=3
 STELLAR_RETRY_DELAY=1000
 
+# Soroban / contract IDs (client-safe — served via GET /v1/config/stellar)
+# Leave SOROBAN_RPC_URL blank to auto-derive from STELLAR_NETWORK.
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+# Set to the deployed Soroban contract address; leave blank if not yet deployed.
+CROWDFUND_CONTRACT_ID=
+STELLAR_EXPLORER_URL=https://stellar.expert/explorer
+
 # Auth
 JWT_EXPIRES_IN=7d
 DOMAIN=lumenpulse.io

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -50,6 +50,7 @@ import { IdempotencyInterceptor } from './common/interceptors/idempotency.interc
 import { SearchModule } from './search/search.module';
 import { ExportModule } from './export/export.module';
 import { CrowdfundModule } from './crowdfund/crowdfund.module';
+import { ClientConfigModule } from './client-config/client-config.module';
 
 @Module({
   imports: [
@@ -119,6 +120,7 @@ import { CrowdfundModule } from './crowdfund/crowdfund.module';
     SearchModule,
     FeatureFlagsModule,
     CrowdfundModule,
+    ClientConfigModule,
   ],
   controllers: [AppController, TestController, TestExceptionController],
   providers: [

--- a/apps/backend/src/client-config/client-config.controller.ts
+++ b/apps/backend/src/client-config/client-config.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, HttpCode, HttpStatus } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ClientConfigService } from './client-config.service';
+import { StellarConfigDto } from './dto/stellar-config.dto';
+
+/**
+ * Exposes client-safe configuration to the frontend / mobile apps.
+ *
+ * All endpoints under this controller are intentionally public — they contain
+ * no secrets and are designed to be fetched on application startup.
+ */
+@ApiTags('config')
+@Controller({ path: 'config', version: '1' })
+export class ClientConfigController {
+  constructor(private readonly clientConfigService: ClientConfigService) {}
+
+  /**
+   * GET /v1/config/stellar
+   *
+   * Returns the Stellar network configuration that the frontend needs to
+   * initialise the Soroban SDK and resolve contract IDs.  This replaces any
+   * hardcoded values that previously lived in the client bundle.
+   */
+  @Get('stellar')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Get Stellar / Soroban client configuration',
+    description:
+      'Returns network info, Horizon URL, Soroban RPC URL, contract IDs, and ' +
+      'explorer URL.  Safe to expose publicly — contains no secrets.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Stellar configuration retrieved successfully',
+    type: StellarConfigDto,
+  })
+  getStellarConfig(): StellarConfigDto {
+    return this.clientConfigService.getStellarConfig();
+  }
+}

--- a/apps/backend/src/client-config/client-config.module.ts
+++ b/apps/backend/src/client-config/client-config.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ClientConfigController } from './client-config.controller';
+import { ClientConfigService } from './client-config.service';
+
+@Module({
+  controllers: [ClientConfigController],
+  providers: [ClientConfigService],
+  exports: [ClientConfigService],
+})
+export class ClientConfigModule {}

--- a/apps/backend/src/client-config/client-config.service.ts
+++ b/apps/backend/src/client-config/client-config.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { config } from '../lib/config';
+import { StellarConfigDto } from './dto/stellar-config.dto';
+
+/**
+ * Assembles client-safe configuration objects from the validated server-side
+ * config store.  Nothing secret is ever included in the returned DTOs.
+ */
+@Injectable()
+export class ClientConfigService {
+  getStellarConfig(): StellarConfigDto {
+    const { stellar } = config;
+
+    return {
+      network: stellar.network,
+      horizonUrl: stellar.horizonUrl,
+      sorobanRpcUrl: stellar.sorobanRpcUrl,
+      crowdfundContractId: stellar.crowdfundContractId,
+      explorerUrl: stellar.explorerUrl,
+    };
+  }
+}

--- a/apps/backend/src/client-config/dto/stellar-config.dto.ts
+++ b/apps/backend/src/client-config/dto/stellar-config.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Client-safe Stellar / Soroban configuration.
+ *
+ * Only non-secret values are included here — this response is public and
+ * cached by the frontend on startup.  Never add secrets (private keys,
+ * JWT secrets, DB credentials, etc.) to this DTO.
+ */
+export class StellarConfigDto {
+  @ApiProperty({
+    description: 'Stellar network identifier',
+    enum: ['testnet', 'mainnet'],
+    example: 'testnet',
+  })
+  network!: 'testnet' | 'mainnet';
+
+  @ApiProperty({
+    description: 'Stellar Horizon REST API base URL',
+    example: 'https://horizon-testnet.stellar.org',
+  })
+  horizonUrl!: string;
+
+  @ApiProperty({
+    description: 'Soroban RPC endpoint URL',
+    example: 'https://soroban-testnet.stellar.org',
+  })
+  sorobanRpcUrl!: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Soroban contract ID for the crowdfund contract. Null when not yet deployed.',
+    example: 'CABL2E2NKLCQIRSF6BXVB4NLSDBNJ2QBFVGXNLGBMZFDWRQKQ7MWDKD',
+    nullable: true,
+  })
+  crowdfundContractId!: string | null;
+
+  @ApiProperty({
+    description: 'Stellar block-explorer base URL',
+    example: 'https://stellar.expert/explorer',
+  })
+  explorerUrl!: string;
+}

--- a/apps/backend/src/lib/config.ts
+++ b/apps/backend/src/lib/config.ts
@@ -38,6 +38,9 @@ import { z } from 'zod';
  * - STELLAR_TIMEOUT
  * - STELLAR_RETRY_ATTEMPTS
  * - STELLAR_RETRY_DELAY
+ * - SOROBAN_RPC_URL
+ * - CROWDFUND_CONTRACT_ID
+ * - STELLAR_EXPLORER_URL
  * - WEBHOOK_SECRET
  * - WEBHOOK_PROVIDERS
  * - TELEGRAM_BOT_TOKEN
@@ -357,6 +360,14 @@ const envSchema = z
     STELLAR_RETRY_DELAY: z.coerce.number().int().min(0).default(1_000),
     STELLAR_SERVER_SECRET: z.string().min(1), // SECRET — never log
 
+    // Soroban / contract config (client-safe — no secrets)
+    SOROBAN_RPC_URL: z.string().trim().optional(),
+    CROWDFUND_CONTRACT_ID: z.string().trim().optional(),
+    STELLAR_EXPLORER_URL: z
+      .string()
+      .trim()
+      .default('https://stellar.expert/explorer'),
+
     PYTHON_API_URL: z.string().trim().default('http://localhost:8000'),
     PYTHON_SERVICE_URL: z.string().trim().optional(),
     PYTHON_API_KEY: z.string().trim().optional(),
@@ -606,6 +617,9 @@ const optionalSummary = [
   ['STELLAR_TIMEOUT', String(parsedEnv.STELLAR_TIMEOUT)],
   ['STELLAR_RETRY_ATTEMPTS', String(parsedEnv.STELLAR_RETRY_ATTEMPTS)],
   ['STELLAR_RETRY_DELAY', String(parsedEnv.STELLAR_RETRY_DELAY)],
+  ['SOROBAN_RPC_URL', parsedEnv.SOROBAN_RPC_URL ?? '(auto)'],
+  ['CROWDFUND_CONTRACT_ID', parsedEnv.CROWDFUND_CONTRACT_ID ?? '(not set)'],
+  ['STELLAR_EXPLORER_URL', parsedEnv.STELLAR_EXPLORER_URL],
   ['PYTHON_API_URL', parsedEnv.PYTHON_API_URL],
   [
     'PYTHON_SERVICE_URL',
@@ -758,6 +772,14 @@ export const config = Object.freeze({
     retryAttempts: parsedEnv.STELLAR_RETRY_ATTEMPTS,
     retryDelay: parsedEnv.STELLAR_RETRY_DELAY,
     serverSecret: new SecretString(parsedEnv.STELLAR_SERVER_SECRET),
+    // Client-safe Soroban / contract config
+    sorobanRpcUrl:
+      parsedEnv.SOROBAN_RPC_URL ||
+      (parsedEnv.STELLAR_NETWORK === 'mainnet'
+        ? 'https://soroban.stellar.org'
+        : 'https://soroban-testnet.stellar.org'),
+    crowdfundContractId: parsedEnv.CROWDFUND_CONTRACT_ID ?? null,
+    explorerUrl: parsedEnv.STELLAR_EXPLORER_URL,
   }),
   auth: Object.freeze({
     jwtSecret: new SecretString(parsedEnv.JWT_SECRET),

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,5 +1,6 @@
 import './lib/config';
 import { NestFactory } from '@nestjs/core';
+import { VersioningType } from '@nestjs/common';
 import { AppModule } from './app.module';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { setupApp } from './bootstrap/app.setup';
@@ -8,6 +9,9 @@ import { config } from './lib/config';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { rawBody: true });
   setupApp(app);
+
+  // Enable URI-based versioning so routes can be prefixed with /v1, /v2, etc.
+  app.enableVersioning({ type: VersioningType.URI });
 
   const swaggerConfig = new DocumentBuilder()
     .setTitle('LumenPulse API')
@@ -29,6 +33,7 @@ async function bootstrap() {
     .addTag('news', 'Crypto news aggregation and sentiment analysis')
     .addTag('portfolio', 'Portfolio tracking and performance metrics')
     .addTag('stellar', 'Stellar blockchain integration')
+    .addTag('config', 'Client-safe application configuration')
     .addTag('search', 'Search and discovery endpoints')
     .addServer('http://localhost:3000', 'Development')
     .addServer('https://api.lumenpulse.io', 'Production')

--- a/apps/webapp/.env.local.example
+++ b/apps/webapp/.env.local.example
@@ -2,3 +2,8 @@
 # The Next.js API routes use this to proxy requests to the NestJS backend.
 # Defaults to http://localhost:3001 if not set.
 BACKEND_API_URL=http://localhost:3001
+
+# Backend API base URL exposed to the browser.
+# Used by the StellarConfigProvider to fetch /v1/config/stellar on startup.
+# Defaults to http://localhost:3001 if not set.
+NEXT_PUBLIC_API_URL=http://localhost:3001

--- a/apps/webapp/app/providers.tsx
+++ b/apps/webapp/app/providers.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { WalletProvider } from "@/contexts/WalletContext";
+import { StellarConfigProvider } from "@/contexts/StellarConfigContext";
+import { StellarConfigError } from "@/components/stellar-config-error";
 import {
   ReactNode,
   createContext,
@@ -12,11 +14,15 @@ import {
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
-    <WalletProvider>
-      <StellarProvider>
-        {children}
-      </StellarProvider>
-    </WalletProvider>
+    <StellarConfigProvider>
+      <WalletProvider>
+        <StellarProvider>
+          {/* Global error banner — shown when /v1/config/stellar is unreachable */}
+          <StellarConfigError />
+          {children}
+        </StellarProvider>
+      </WalletProvider>
+    </StellarConfigProvider>
   );
 }
 

--- a/apps/webapp/components/stellar-config-error.tsx
+++ b/apps/webapp/components/stellar-config-error.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useStellarConfig } from "@/contexts/StellarConfigContext";
+
+/**
+ * Full-page error banner shown when the Stellar config endpoint is
+ * unreachable or returns an error.  Rendered by the root Providers tree so
+ * every page benefits from it automatically.
+ */
+export function StellarConfigError() {
+  const { status, error, retry } = useStellarConfig();
+
+  if (status !== "error") return null;
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="fixed inset-x-0 top-0 z-50 flex items-start gap-4 bg-red-950/95 px-4 py-3 text-sm text-red-200 shadow-lg backdrop-blur-sm sm:items-center"
+    >
+      {/* Icon */}
+      <svg
+        aria-hidden="true"
+        className="mt-0.5 h-5 w-5 shrink-0 text-red-400 sm:mt-0"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        strokeWidth={2}
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M12 9v3m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+        />
+      </svg>
+
+      {/* Message */}
+      <div className="flex-1">
+        <p className="font-semibold text-red-100">
+          Stellar configuration unavailable
+        </p>
+        <p className="mt-0.5 text-red-300">
+          {error ??
+            "Could not load network configuration from the backend. Some features may not work correctly."}
+        </p>
+      </div>
+
+      {/* Retry */}
+      <button
+        onClick={retry}
+        className="shrink-0 rounded-md bg-red-800 px-3 py-1.5 text-xs font-medium text-red-100 transition hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+        aria-label="Retry loading Stellar configuration"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}

--- a/apps/webapp/contexts/StellarConfigContext.tsx
+++ b/apps/webapp/contexts/StellarConfigContext.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface StellarConfig {
+  network: "testnet" | "mainnet";
+  horizonUrl: string;
+  sorobanRpcUrl: string;
+  /** Null when the contract has not been deployed yet. */
+  crowdfundContractId: string | null;
+  explorerUrl: string;
+}
+
+type ConfigStatus = "loading" | "ready" | "error";
+
+interface StellarConfigState {
+  config: StellarConfig | null;
+  status: ConfigStatus;
+  /** Human-readable error message when status === "error". */
+  error: string | null;
+  /** Re-fetch the config (e.g. after a transient network failure). */
+  retry: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const StellarConfigContext = createContext<StellarConfigState>({
+  config: null,
+  status: "loading",
+  error: null,
+  retry: () => {},
+});
+
+export function useStellarConfig(): StellarConfigState {
+  return useContext(StellarConfigContext);
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+
+const CONFIG_ENDPOINT = `${API_BASE}/v1/config/stellar`;
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+async function fetchStellarConfig(): Promise<StellarConfig> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(CONFIG_ENDPOINT, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Config endpoint returned HTTP ${response.status}. ` +
+          "Check that the backend is running and CROWDFUND_CONTRACT_ID is set."
+      );
+    }
+
+    const data: StellarConfig = await response.json();
+    return data;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export function StellarConfigProvider({ children }: { children: ReactNode }) {
+  const [config, setConfig] = useState<StellarConfig | null>(null);
+  const [status, setStatus] = useState<ConfigStatus>("loading");
+  const [error, setError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setStatus("loading");
+    setError(null);
+
+    fetchStellarConfig()
+      .then((data) => {
+        if (cancelled) return;
+        setConfig(data);
+        setStatus("ready");
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const message =
+          err instanceof Error ? err.message : "Failed to load Stellar config.";
+        console.error("[StellarConfigProvider]", message);
+        setError(message);
+        setStatus("error");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [attempt]);
+
+  const retry = () => setAttempt((n) => n + 1);
+
+  return (
+    <StellarConfigContext.Provider value={{ config, status, error, retry }}>
+      {children}
+    </StellarConfigContext.Provider>
+  );
+}


### PR DESCRIPTION

closes #730 

- Add ClientConfigModule with public GET /v1/config/stellar endpoint
- Add StellarConfigDto (network, horizonUrl, sorobanRpcUrl, crowdfundContractId, explorerUrl)
- Add SOROBAN_RPC_URL, CROWDFUND_CONTRACT_ID, STELLAR_EXPLORER_URL env vars to lib/config.ts
- Auto-derive Soroban RPC URL from STELLAR_NETWORK when not explicitly set
- Enable URI versioning (VersioningType.URI) in main.ts
- Register ClientConfigModule in AppModule
- Add StellarConfigProvider — fetches /v1/config/stellar on app startup
- Add useStellarConfig() hook exposing { config, status, error, retry }
- Add StellarConfigError banner with Retry button for failed config fetch
- Wrap Providers tree with StellarConfigProvider
- Update .env.example and .env.local.example with new vars
