### PR TITLE
feat: issue #729

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ For module-specific docs: [FRONTEND.md](FRONTEND.md), [BACKEND.md](BACKEND.md), 
    Tests require testnet; mocks for external APIs.
 
 ### Deployment
-- **Frontend**: Vercel—connect repo, add env vars.
+- **Frontend**: Vercel—connect repo, set `NEXT_PUBLIC_API_URL` and `BACKEND_API_URL` to the deployed backend, and ensure the backend is configured to return testnet Stellar config.
 - **Backend/Data**: Railway or AWS; containerize Python scripts.
 - **Soroban Contracts**: Deploy via CI/CD (GitHub Actions); verify on Stellar explorer.
 - Production: Set `STELLAR_NETWORK=mainnet`; audit contracts.

--- a/apps/webapp/.env.local.example
+++ b/apps/webapp/.env.local.example
@@ -2,3 +2,7 @@
 # The Next.js API routes use this to proxy requests to the NestJS backend.
 # Defaults to http://localhost:3001 if not set.
 BACKEND_API_URL=http://localhost:3001
+
+# Public API base URL for client-side requests.
+# On Vercel, set this to the backend deployment URL for pages that call the API directly.
+NEXT_PUBLIC_API_URL=http://localhost:3001


### PR DESCRIPTION
closes #729

Changes made
Updated [.env.local.example](https://congenial-guide-w444vjg49jvfg46p.github.dev/)

Added [NEXT_PUBLIC_API_URL](https://congenial-guide-w444vjg49jvfg46p.github.dev/) alongside [BACKEND_API_URL](https://congenial-guide-w444vjg49jvfg46p.github.dev/)

Documented that [NEXT_PUBLIC_API_URL](https://congenial-guide-w444vjg49jvfg46p.github.dev/) is the public client-side API base URL for Vercel

Updated [README.md](https://congenial-guide-w444vjg49jvfg46p.github.dev/)

Clarified Vercel frontend deployment instructions
Specified that [NEXT_PUBLIC_API_URL](https://congenial-guide-w444vjg49jvfg46p.github.dev/) and [BACKEND_API_URL](https://congenial-guide-w444vjg49jvfg46p.github.dev/) must be set to the deployed backend

Noted the backend must return testnet Stellar config for the app to display testnet mode