### PR TITLE
feat(backend): Crowdfund Vault Sync Worker — contributions, milestones, refund windows (#711)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -104,6 +104,9 @@ COINDESK_API_KEY=coindesk-api-key-here
 SOROBAN_INGEST_SECRET=soroban-ingest-secret-here
 SOROBAN_TIMESTAMP_TOLERANCE_MS=300000
 
+# Crowdfund vault sync worker polls Soroban getEvents when STELLAR_CONTRACT_CROWDFUND_VAULT is set
+# Events are ingested via the soroban-events queue for idempotent materialization
+
 # Webhooks and bot
 WEBHOOK_SECRET=webhook-secret-here
 WEBHOOK_PROVIDERS='[{"name":"data-processing","algorithm":"hmac-sha256","secret":"webhook-secret-here","enabled":true}]'

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -56,6 +56,7 @@ import { CrowdfundModule } from './crowdfund/crowdfund.module';
 import { AuditModule } from './audit/audit.module';
 import { AuditLogInterceptor } from './audit/interceptors/audit-log.interceptor';
 import { SorobanEventsModule } from './soroban-events/soroban-events.module';
+import { CrowdfundVaultSyncModule } from './crowdfund-vault-sync/crowdfund-vault-sync.module';
 import { TreasuryModule } from './treasury/treasury.module';
 import { VestingWalletModule } from './vesting-wallet/vesting-wallet.module';
 
@@ -124,6 +125,7 @@ import { VestingWalletModule } from './vesting-wallet/vesting-wallet.module';
     AppConfigModule,
     AuditModule,
     SorobanEventsModule,
+    CrowdfundVaultSyncModule,
     TreasuryModule,
     VestingWalletModule,
   ],

--- a/apps/backend/src/crowdfund-vault-sync/crowdfund-vault-sync.module.ts
+++ b/apps/backend/src/crowdfund-vault-sync/crowdfund-vault-sync.module.ts
@@ -1,0 +1,30 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CrowdfundVaultSyncService } from './crowdfund-vault-sync.service';
+import { CrowdfundVaultSyncScheduler } from './crowdfund-vault-sync.scheduler';
+import { CrowdfundVaultEventEntity } from './entities/crowdfund-vault-event.entity';
+import { CrowdfundVaultProjectEntity } from './entities/crowdfund-vault-project.entity';
+import { CrowdfundVaultContributorEntity } from './entities/crowdfund-vault-contributor.entity';
+import { CrowdfundVaultMilestoneEntity } from './entities/crowdfund-vault-milestone.entity';
+import { CrowdfundVaultSyncCheckpointEntity } from './entities/crowdfund-vault-sync-checkpoint.entity';
+import { StellarModule } from '../stellar/stellar.module';
+import { SchedulerModule } from '../scheduler/scheduler.module';
+import { SorobanEventsModule } from '../soroban-events/soroban-events.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      CrowdfundVaultEventEntity,
+      CrowdfundVaultProjectEntity,
+      CrowdfundVaultContributorEntity,
+      CrowdfundVaultMilestoneEntity,
+      CrowdfundVaultSyncCheckpointEntity,
+    ]),
+    StellarModule,
+    SchedulerModule,
+    forwardRef(() => SorobanEventsModule),
+  ],
+  providers: [CrowdfundVaultSyncService, CrowdfundVaultSyncScheduler],
+  exports: [CrowdfundVaultSyncService],
+})
+export class CrowdfundVaultSyncModule {}

--- a/apps/backend/src/crowdfund-vault-sync/crowdfund-vault-sync.scheduler.ts
+++ b/apps/backend/src/crowdfund-vault-sync/crowdfund-vault-sync.scheduler.ts
@@ -1,0 +1,104 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { JobLockService } from '../scheduler/job-lock.service';
+import { SorobanRpcClientService } from '../stellar/services/soroban-rpc-client.service';
+import { CrowdfundVaultSyncService } from './crowdfund-vault-sync.service';
+import { SorobanEventsService } from '../soroban-events/soroban-events.service';
+
+const JOB_NAME = 'crowdfund-vault-sync-poll';
+const LEDGER_BATCH = 50;
+
+interface SorobanRpcEvent {
+  ledger?: number;
+  txHash?: string;
+  event?: {
+    contractId?: string;
+    type?: string;
+    body?: { v0?: { data?: unknown } };
+  };
+  id?: string;
+  topic?: unknown[];
+}
+
+@Injectable()
+export class CrowdfundVaultSyncScheduler {
+  private readonly logger = new Logger(CrowdfundVaultSyncScheduler.name);
+
+  constructor(
+    private readonly vaultSync: CrowdfundVaultSyncService,
+    private readonly sorobanEvents: SorobanEventsService,
+    private readonly sorobanRpc: SorobanRpcClientService,
+    private readonly jobLock: JobLockService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async pollVaultEvents(): Promise<void> {
+    const contractId = this.vaultSync.getVaultContractId();
+    if (!contractId) {
+      return;
+    }
+
+    await this.jobLock.withLock(JOB_NAME, async () => {
+      const lastLedger = await this.vaultSync.getCheckpoint(contractId);
+      const startLedger = lastLedger > 0 ? lastLedger + 1 : 1;
+
+      try {
+        const response = await this.sorobanRpc.rawServer.getEvents({
+          startLedger,
+          filters: [{ type: 'contract', contractIds: [contractId] }],
+          limit: LEDGER_BATCH,
+        });
+
+        const events = (response.events ?? []) as SorobanRpcEvent[];
+        let maxLedger = lastLedger;
+
+        for (let i = 0; i < events.length; i++) {
+          const ev = events[i];
+          const ledger = Number(ev.ledger ?? 0);
+          if (ledger > maxLedger) {
+            maxLedger = ledger;
+          }
+
+          const txHash = ev.txHash ?? ev.id ?? `unknown-${ledger}-${i}`;
+          const eventType =
+            typeof ev.event?.type === 'string' ? ev.event.type : 'unknown';
+          const rawPayload = this.eventToPayload(ev, ledger);
+
+          await this.sorobanEvents.ingest({
+            txHash,
+            eventIndex: i,
+            contractId,
+            eventType,
+            rawPayload,
+          });
+        }
+
+        if (maxLedger > lastLedger) {
+          await this.vaultSync.setCheckpoint(contractId, maxLedger);
+        }
+
+        if (events.length > 0) {
+          this.logger.log(
+            `Queued ${events.length} crowdfund vault events from ledger ${String(startLedger ?? 'latest')}`,
+          );
+        }
+      } catch (err) {
+        this.logger.warn(
+          `Vault event poll failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    });
+  }
+
+  private eventToPayload(
+    ev: SorobanRpcEvent,
+    ledger: number,
+  ): Record<string, unknown> {
+    return {
+      ledgerSeq: ledger,
+      contractId: ev.event?.contractId,
+      eventType: ev.event?.type,
+      raw: ev,
+    };
+  }
+}

--- a/apps/backend/src/crowdfund-vault-sync/crowdfund-vault-sync.service.spec.ts
+++ b/apps/backend/src/crowdfund-vault-sync/crowdfund-vault-sync.service.spec.ts
@@ -1,0 +1,339 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CrowdfundVaultSyncService } from './crowdfund-vault-sync.service';
+import { CrowdfundVaultEventEntity } from './entities/crowdfund-vault-event.entity';
+import { CrowdfundVaultProjectEntity } from './entities/crowdfund-vault-project.entity';
+import { CrowdfundVaultContributorEntity } from './entities/crowdfund-vault-contributor.entity';
+import { CrowdfundVaultMilestoneEntity } from './entities/crowdfund-vault-milestone.entity';
+import { CrowdfundVaultSyncCheckpointEntity } from './entities/crowdfund-vault-sync-checkpoint.entity';
+
+const VAULT_CONTRACT = 'CVAULT123456789';
+
+jest.mock('../lib/config', () => ({
+  config: {
+    stellar: {
+      contracts: {
+        crowdfundVault: 'CVAULT123456789',
+      },
+    },
+  },
+}));
+
+describe('CrowdfundVaultSyncService', () => {
+  let service: CrowdfundVaultSyncService;
+  let eventRepo: jest.Mocked<Repository<CrowdfundVaultEventEntity>>;
+  let projectRepo: jest.Mocked<Repository<CrowdfundVaultProjectEntity>>;
+  let contributorRepo: jest.Mocked<Repository<CrowdfundVaultContributorEntity>>;
+  let milestoneRepo: jest.Mocked<Repository<CrowdfundVaultMilestoneEntity>>;
+  let checkpointRepo: jest.Mocked<Repository<CrowdfundVaultSyncCheckpointEntity>>;
+
+  const projects = new Map<string, CrowdfundVaultProjectEntity>();
+  const contributors = new Map<string, CrowdfundVaultContributorEntity>();
+  const events = new Map<string, CrowdfundVaultEventEntity>();
+
+  beforeEach(async () => {
+    projects.clear();
+    contributors.clear();
+    events.clear();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CrowdfundVaultSyncService,
+        {
+          provide: getRepositoryToken(CrowdfundVaultEventEntity),
+          useValue: createEventRepoMock(),
+        },
+        {
+          provide: getRepositoryToken(CrowdfundVaultProjectEntity),
+          useValue: createProjectRepoMock(),
+        },
+        {
+          provide: getRepositoryToken(CrowdfundVaultContributorEntity),
+          useValue: createContributorRepoMock(),
+        },
+        {
+          provide: getRepositoryToken(CrowdfundVaultMilestoneEntity),
+          useValue: createMilestoneRepoMock(),
+        },
+        {
+          provide: getRepositoryToken(CrowdfundVaultSyncCheckpointEntity),
+          useValue: createCheckpointRepoMock(),
+        },
+      ],
+    }).compile();
+
+    service = module.get(CrowdfundVaultSyncService);
+    eventRepo = module.get(getRepositoryToken(CrowdfundVaultEventEntity));
+    projectRepo = module.get(getRepositoryToken(CrowdfundVaultProjectEntity));
+    contributorRepo = module.get(
+      getRepositoryToken(CrowdfundVaultContributorEntity),
+    );
+    milestoneRepo = module.get(getRepositoryToken(CrowdfundVaultMilestoneEntity));
+    checkpointRepo = module.get(
+      getRepositoryToken(CrowdfundVaultSyncCheckpointEntity),
+    );
+  });
+
+  function createEventRepoMock() {
+    return {
+      findOne: jest.fn(async ({ where }: { where: { txHash: string; eventIndex: number } }) => {
+        return events.get(`${where.txHash}:${where.eventIndex}`) ?? null;
+      }),
+      create: jest.fn((data: CrowdfundVaultEventEntity) => ({ id: 'ev-1', ...data })),
+      save: jest.fn(async (entity: CrowdfundVaultEventEntity) => {
+        events.set(`${entity.txHash}:${entity.eventIndex}`, entity);
+        return entity;
+      }),
+    };
+  }
+
+  function createProjectRepoMock() {
+    return {
+      findOne: jest.fn(async ({ where }: { where: { projectId: string } }) => {
+        return projects.get(where.projectId) ?? null;
+      }),
+      create: jest.fn((data: Partial<CrowdfundVaultProjectEntity>) => ({
+        id: 'proj-1',
+        uniqueContributors: 0,
+        totalContributions: '0',
+        totalWithdrawn: '0',
+        status: 'active',
+        ...data,
+      })),
+      save: jest.fn(async (entity: CrowdfundVaultProjectEntity) => {
+        projects.set(entity.projectId, entity);
+        return entity;
+      }),
+      upsert: jest.fn(
+        async (data: Partial<CrowdfundVaultProjectEntity>, _keys: string[]) => {
+          const existing = projects.get(String(data.projectId));
+          const merged = {
+            ...(existing ?? {
+              id: 'proj-1',
+              uniqueContributors: 0,
+              totalContributions: '0',
+              totalWithdrawn: '0',
+            }),
+            ...data,
+          } as CrowdfundVaultProjectEntity;
+          projects.set(String(data.projectId), merged);
+        },
+      ),
+      update: jest.fn(
+        async (
+          criteria: { projectId: string },
+          data: Partial<CrowdfundVaultProjectEntity>,
+        ) => {
+          const existing = projects.get(criteria.projectId);
+          if (existing) {
+            Object.assign(existing, data);
+          }
+        },
+      ),
+    };
+  }
+
+  function createContributorRepoMock() {
+    return {
+      findOne: jest.fn(
+        async ({
+          where,
+        }: {
+          where: { projectId: string; contributor: string };
+        }) => {
+          return (
+            contributors.get(`${where.projectId}:${where.contributor}`) ?? null
+          );
+        },
+      ),
+      create: jest.fn((data: Partial<CrowdfundVaultContributorEntity>) => ({
+        id: 'contrib-1',
+        totalContributed: '0',
+        ...data,
+      })),
+      save: jest.fn(async (entity: CrowdfundVaultContributorEntity) => {
+        contributors.set(`${entity.projectId}:${entity.contributor}`, entity);
+        return entity;
+      }),
+    };
+  }
+
+  function createMilestoneRepoMock() {
+    return {
+      findOne: jest.fn(),
+      upsert: jest.fn(),
+    };
+  }
+
+  function createCheckpointRepoMock() {
+    let lastLedger = '0';
+    return {
+      findOne: jest.fn(async () =>
+        lastLedger === '0'
+          ? null
+          : ({ contractId: VAULT_CONTRACT, lastLedger }),
+      ),
+      upsert: jest.fn(async (data: { contractId: string; lastLedger: string }) => {
+        lastLedger = data.lastLedger;
+      }),
+    };
+  }
+
+  it('identifies the configured vault contract', () => {
+    expect(service.isVaultContract(VAULT_CONTRACT)).toBe(true);
+    expect(service.isVaultContract('OTHER')).toBe(false);
+  });
+
+  it('materializes deposit events and updates contributor totals', async () => {
+    await service.syncVaultEvent({
+      txHash: 'tx-deposit-1',
+      eventIndex: 0,
+      contractId: VAULT_CONTRACT,
+      eventType: 'DepositEvent',
+      ledgerSeq: 100,
+      rawPayload: {
+        projectId: 1,
+        user: 'GUSER111',
+        amount: '5000000',
+      },
+    });
+
+    const project = projects.get('1');
+    expect(project?.totalContributions).toBe('5000000');
+    expect(project?.lastLedgerSeq).toBe('100');
+
+    const contributor = contributors.get('1:GUSER111');
+    expect(contributor?.totalContributed).toBe('5000000');
+
+    expect(eventRepo.save).toHaveBeenCalledTimes(1);
+    expect(checkpointRepo.upsert).toHaveBeenCalled();
+  });
+
+  it('skips replay of the same tx/event index (idempotent)', async () => {
+    const input = {
+      txHash: 'tx-replay',
+      eventIndex: 0,
+      contractId: VAULT_CONTRACT,
+      eventType: 'DepositEvent',
+      ledgerSeq: 200,
+      rawPayload: { projectId: 2, user: 'GUSER222', amount: '100' },
+    };
+
+    await service.syncVaultEvent(input);
+    await service.syncVaultEvent(input);
+
+    expect(eventRepo.save).toHaveBeenCalledTimes(1);
+    expect(projects.get('2')?.totalContributions).toBe('100');
+  });
+
+  it('ignores stale ledger sequences for project updates', async () => {
+    projects.set('3', {
+      id: 'proj-3',
+      projectId: '3',
+      contractId: VAULT_CONTRACT,
+      owner: 'GOWNER',
+      tokenAddress: null,
+      totalContributions: '1000',
+      totalWithdrawn: '0',
+      uniqueContributors: 1,
+      status: 'active',
+      refundWindowDeadline: null,
+      lastLedgerSeq: '500',
+      lastTxHash: 'tx-newer',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await service.syncVaultEvent({
+      txHash: 'tx-stale',
+      eventIndex: 0,
+      contractId: VAULT_CONTRACT,
+      eventType: 'DepositEvent',
+      ledgerSeq: 400,
+      rawPayload: { projectId: 3, user: 'GUSER333', amount: '999' },
+    });
+
+    expect(projects.get('3')?.totalContributions).toBe('1000');
+  });
+
+  it('records milestone approvals', async () => {
+    await service.syncVaultEvent({
+      txHash: 'tx-milestone',
+      eventIndex: 0,
+      contractId: VAULT_CONTRACT,
+      eventType: 'MilestoneApprovedEvent',
+      ledgerSeq: 600,
+      rawPayload: { projectId: 4, milestoneId: 1 },
+    });
+
+    expect(milestoneRepo.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: '4',
+        milestoneId: 1,
+        status: 'approved',
+      }),
+      ['projectId', 'milestoneId'],
+    );
+  });
+
+  it('applies refund window expiry and contribution reversals', async () => {
+    projects.set('5', {
+      id: 'proj-5',
+      projectId: '5',
+      contractId: VAULT_CONTRACT,
+      owner: 'GOWNER',
+      tokenAddress: null,
+      totalContributions: '2000',
+      totalWithdrawn: '0',
+      uniqueContributors: 1,
+      status: 'active',
+      refundWindowDeadline: null,
+      lastLedgerSeq: '700',
+      lastTxHash: 'tx-base',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    contributors.set('5:GUSER555', {
+      id: 'c-5',
+      projectId: '5',
+      contributor: 'GUSER555',
+      totalContributed: '2000',
+      firstContributionLedger: '700',
+      lastContributionLedger: '700',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    await service.syncVaultEvent({
+      txHash: 'tx-expired',
+      eventIndex: 0,
+      contractId: VAULT_CONTRACT,
+      eventType: 'ProjectExpiredEvent',
+      ledgerSeq: 710,
+      rawPayload: {
+        projectId: 5,
+        refundWindowDeadline: 999999,
+      },
+    });
+
+    expect(projects.get('5')?.status).toBe('expired');
+    expect(projects.get('5')?.refundWindowDeadline).toBe('999999');
+
+    await service.syncVaultEvent({
+      txHash: 'tx-refund',
+      eventIndex: 1,
+      contractId: VAULT_CONTRACT,
+      eventType: 'ContributionRefundedEvent',
+      ledgerSeq: 720,
+      rawPayload: {
+        projectId: 5,
+        contributor: 'GUSER555',
+        amount: '500',
+      },
+    });
+
+    expect(projects.get('5')?.totalContributions).toBe('1500');
+    expect(contributors.get('5:GUSER555')?.totalContributed).toBe('1500');
+  });
+});

--- a/apps/backend/src/crowdfund-vault-sync/crowdfund-vault-sync.service.ts
+++ b/apps/backend/src/crowdfund-vault-sync/crowdfund-vault-sync.service.ts
@@ -1,0 +1,544 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { config } from '../lib/config';
+import { CrowdfundVaultEventEntity } from './entities/crowdfund-vault-event.entity';
+import { CrowdfundVaultProjectEntity } from './entities/crowdfund-vault-project.entity';
+import { CrowdfundVaultContributorEntity } from './entities/crowdfund-vault-contributor.entity';
+import { CrowdfundVaultMilestoneEntity } from './entities/crowdfund-vault-milestone.entity';
+import { CrowdfundVaultSyncCheckpointEntity } from './entities/crowdfund-vault-sync-checkpoint.entity';
+import {
+  VaultSyncEventInput,
+  VAULT_EVENT_TYPES,
+} from './dto/vault-sync-event.dto';
+
+@Injectable()
+export class CrowdfundVaultSyncService {
+  private readonly logger = new Logger(CrowdfundVaultSyncService.name);
+
+  constructor(
+    @InjectRepository(CrowdfundVaultEventEntity)
+    private readonly eventRepo: Repository<CrowdfundVaultEventEntity>,
+    @InjectRepository(CrowdfundVaultProjectEntity)
+    private readonly projectRepo: Repository<CrowdfundVaultProjectEntity>,
+    @InjectRepository(CrowdfundVaultContributorEntity)
+    private readonly contributorRepo: Repository<CrowdfundVaultContributorEntity>,
+    @InjectRepository(CrowdfundVaultMilestoneEntity)
+    private readonly milestoneRepo: Repository<CrowdfundVaultMilestoneEntity>,
+    @InjectRepository(CrowdfundVaultSyncCheckpointEntity)
+    private readonly checkpointRepo: Repository<CrowdfundVaultSyncCheckpointEntity>,
+  ) {}
+
+  getVaultContractId(): string | null {
+    return config.stellar.contracts.crowdfundVault ?? null;
+  }
+
+  isVaultContract(contractId: string | undefined | null): boolean {
+    const vaultId = this.getVaultContractId();
+    return Boolean(vaultId && contractId && contractId === vaultId);
+  }
+
+  /**
+   * Idempotent vault event sync: stores raw event once, then materializes state.
+   * Skips stale ledger sequences to tolerate reorg-like reordering.
+   */
+  async syncVaultEvent(input: VaultSyncEventInput): Promise<void> {
+    const ledgerSeq = this.resolveLedgerSeq(input);
+    const normalizedType = this.normalizeEventType(input.eventType);
+
+    const existingEvent = await this.eventRepo.findOne({
+      where: { txHash: input.txHash, eventIndex: input.eventIndex },
+    });
+    if (existingEvent) {
+      this.logger.debug(
+        { txHash: input.txHash, eventIndex: input.eventIndex },
+        'Vault event already ingested, skipping replay',
+      );
+      return;
+    }
+
+    const parsed = this.parsePayload(input.rawPayload, normalizedType);
+
+    const rawEvent = this.eventRepo.create({
+      contractId: input.contractId,
+      txHash: input.txHash,
+      eventIndex: input.eventIndex,
+      eventType: normalizedType,
+      ledgerSeq: String(ledgerSeq),
+      projectId: parsed.projectId,
+      contributor: parsed.contributor,
+      amount: parsed.amount,
+      milestoneId: parsed.milestoneId,
+      rawPayload: input.rawPayload,
+    });
+    await this.eventRepo.save(rawEvent);
+
+    await this.materializeEvent({
+      contractId: input.contractId,
+      txHash: input.txHash,
+      ledgerSeq,
+      eventType: normalizedType,
+      parsed,
+    });
+
+    await this.updateCheckpoint(input.contractId, ledgerSeq);
+  }
+
+  async getCheckpoint(contractId: string): Promise<number> {
+    const row = await this.checkpointRepo.findOne({ where: { contractId } });
+    return row ? Number(row.lastLedger) : 0;
+  }
+
+  async setCheckpoint(contractId: string, lastLedger: number): Promise<void> {
+    await this.checkpointRepo.upsert(
+      { contractId, lastLedger: String(lastLedger) },
+      ['contractId'],
+    );
+  }
+
+  private async materializeEvent(ctx: {
+    contractId: string;
+    txHash: string;
+    ledgerSeq: number;
+    eventType: string;
+    parsed: ParsedVaultPayload;
+  }): Promise<void> {
+    const { eventType, parsed, ledgerSeq, txHash, contractId } = ctx;
+    if (parsed.projectId === null) {
+      return;
+    }
+
+    const projectId = parsed.projectId;
+
+    switch (eventType) {
+      case VAULT_EVENT_TYPES.PROJECT_CREATED:
+        await this.applyProjectCreated(
+          projectId,
+          contractId,
+          parsed,
+          ledgerSeq,
+          txHash,
+        );
+        break;
+      case VAULT_EVENT_TYPES.DEPOSIT:
+        await this.applyDeposit(projectId, contractId, parsed, ledgerSeq, txHash);
+        break;
+      case VAULT_EVENT_TYPES.WITHDRAW:
+        await this.applyWithdraw(projectId, parsed, ledgerSeq, txHash);
+        break;
+      case VAULT_EVENT_TYPES.MILESTONE_APPROVED:
+      case VAULT_EVENT_TYPES.MILESTONE_APPROVED_BY_VOTE:
+        await this.applyMilestoneApproved(
+          projectId,
+          parsed,
+          ledgerSeq,
+          txHash,
+        );
+        break;
+      case VAULT_EVENT_TYPES.PROJECT_CANCELED:
+        await this.applyProjectStatus(projectId, 'canceled', ledgerSeq, txHash);
+        break;
+      case VAULT_EVENT_TYPES.PROJECT_EXPIRED:
+        await this.applyProjectExpired(projectId, parsed, ledgerSeq, txHash);
+        break;
+      case VAULT_EVENT_TYPES.CONTRIBUTION_REFUNDED:
+      case VAULT_EVENT_TYPES.CONTRIBUTION_CLAWED_BACK:
+        await this.applyContributionReversal(
+          projectId,
+          parsed,
+          ledgerSeq,
+          txHash,
+        );
+        break;
+      default:
+        this.logger.debug({ eventType }, 'No materializer for vault event type');
+    }
+  }
+
+  private async applyProjectCreated(
+    projectId: string,
+    contractId: string,
+    parsed: ParsedVaultPayload,
+    ledgerSeq: number,
+    txHash: string,
+  ): Promise<void> {
+    if (await this.isStaleProject(projectId, ledgerSeq)) {
+      return;
+    }
+
+    await this.projectRepo.upsert(
+      {
+        projectId,
+        contractId,
+        owner: parsed.owner ?? '',
+        tokenAddress: parsed.tokenAddress,
+        status: 'active',
+        lastLedgerSeq: String(ledgerSeq),
+        lastTxHash: txHash,
+      },
+      ['projectId'],
+    );
+  }
+
+  private async applyDeposit(
+    projectId: string,
+    contractId: string,
+    parsed: ParsedVaultPayload,
+    ledgerSeq: number,
+    txHash: string,
+  ): Promise<void> {
+    if (!parsed.contributor || !parsed.amount) {
+      return;
+    }
+    if (await this.isStaleProject(projectId, ledgerSeq)) {
+      return;
+    }
+
+    const amount = parsed.amount;
+    const project = await this.projectRepo.findOne({ where: { projectId } });
+
+    if (!project) {
+      await this.projectRepo.save(
+        this.projectRepo.create({
+          projectId,
+          contractId,
+          owner: parsed.owner ?? parsed.contributor,
+          tokenAddress: parsed.tokenAddress,
+          totalContributions: amount,
+          uniqueContributors: 1,
+          status: 'active',
+          lastLedgerSeq: String(ledgerSeq),
+          lastTxHash: txHash,
+        }),
+      );
+    } else {
+      project.totalContributions = this.addAmount(
+        project.totalContributions,
+        amount,
+      );
+      project.lastLedgerSeq = String(ledgerSeq);
+      project.lastTxHash = txHash;
+      await this.projectRepo.save(project);
+    }
+
+    const contributorRow = await this.contributorRepo.findOne({
+      where: { projectId, contributor: parsed.contributor },
+    });
+
+    if (!contributorRow) {
+      await this.contributorRepo.save(
+        this.contributorRepo.create({
+          projectId,
+          contributor: parsed.contributor,
+          totalContributed: amount,
+          firstContributionLedger: String(ledgerSeq),
+          lastContributionLedger: String(ledgerSeq),
+        }),
+      );
+      const proj = await this.projectRepo.findOne({ where: { projectId } });
+      if (proj) {
+        proj.uniqueContributors += 1;
+        await this.projectRepo.save(proj);
+      }
+    } else {
+      contributorRow.totalContributed = this.addAmount(
+        contributorRow.totalContributed,
+        amount,
+      );
+      contributorRow.lastContributionLedger = String(ledgerSeq);
+      contributorRow.firstContributionLedger ??= String(ledgerSeq);
+      await this.contributorRepo.save(contributorRow);
+    }
+  }
+
+  private async applyWithdraw(
+    projectId: string,
+    parsed: ParsedVaultPayload,
+    ledgerSeq: number,
+    txHash: string,
+  ): Promise<void> {
+    if (!parsed.amount || (await this.isStaleProject(projectId, ledgerSeq))) {
+      return;
+    }
+
+    const project = await this.projectRepo.findOne({ where: { projectId } });
+    if (!project) {
+      return;
+    }
+
+    project.totalWithdrawn = this.addAmount(project.totalWithdrawn, parsed.amount);
+    project.lastLedgerSeq = String(ledgerSeq);
+    project.lastTxHash = txHash;
+    await this.projectRepo.save(project);
+  }
+
+  private async applyMilestoneApproved(
+    projectId: string,
+    parsed: ParsedVaultPayload,
+    ledgerSeq: number,
+    txHash: string,
+  ): Promise<void> {
+    if (parsed.milestoneId === null) {
+      return;
+    }
+
+    const existing = await this.milestoneRepo.findOne({
+      where: { projectId, milestoneId: parsed.milestoneId },
+    });
+
+    if (
+      existing?.lastLedgerSeq &&
+      Number(existing.lastLedgerSeq) > ledgerSeq
+    ) {
+      return;
+    }
+
+    await this.milestoneRepo.upsert(
+      {
+        projectId,
+        milestoneId: parsed.milestoneId,
+        status: 'approved',
+        approvedAt: new Date(),
+        lastLedgerSeq: String(ledgerSeq),
+      },
+      ['projectId', 'milestoneId'],
+    );
+
+    if (!(await this.isStaleProject(projectId, ledgerSeq))) {
+      await this.projectRepo.update(
+        { projectId },
+        { lastLedgerSeq: String(ledgerSeq), lastTxHash: txHash },
+      );
+    }
+  }
+
+  private async applyProjectStatus(
+    projectId: string,
+    status: string,
+    ledgerSeq: number,
+    txHash: string,
+  ): Promise<void> {
+    if (await this.isStaleProject(projectId, ledgerSeq)) {
+      return;
+    }
+
+    await this.projectRepo.update(
+      { projectId },
+      { status, lastLedgerSeq: String(ledgerSeq), lastTxHash: txHash },
+    );
+  }
+
+  private async applyProjectExpired(
+    projectId: string,
+    parsed: ParsedVaultPayload,
+    ledgerSeq: number,
+    txHash: string,
+  ): Promise<void> {
+    if (await this.isStaleProject(projectId, ledgerSeq)) {
+      return;
+    }
+
+    await this.projectRepo.update(
+      { projectId },
+      {
+        status: 'expired',
+        refundWindowDeadline: parsed.refundWindowDeadline
+          ? String(parsed.refundWindowDeadline)
+          : null,
+        lastLedgerSeq: String(ledgerSeq),
+        lastTxHash: txHash,
+      },
+    );
+  }
+
+  private async applyContributionReversal(
+    projectId: string,
+    parsed: ParsedVaultPayload,
+    ledgerSeq: number,
+    txHash: string,
+  ): Promise<void> {
+    if (!parsed.contributor || !parsed.amount) {
+      return;
+    }
+    if (await this.isStaleProject(projectId, ledgerSeq)) {
+      return;
+    }
+
+    const project = await this.projectRepo.findOne({ where: { projectId } });
+    if (project) {
+      project.totalContributions = this.subtractAmount(
+        project.totalContributions,
+        parsed.amount,
+      );
+      project.lastLedgerSeq = String(ledgerSeq);
+      project.lastTxHash = txHash;
+      await this.projectRepo.save(project);
+    }
+
+    const contributorRow = await this.contributorRepo.findOne({
+      where: { projectId, contributor: parsed.contributor },
+    });
+    if (contributorRow) {
+      contributorRow.totalContributed = this.subtractAmount(
+        contributorRow.totalContributed,
+        parsed.amount,
+      );
+      contributorRow.lastContributionLedger = String(ledgerSeq);
+      await this.contributorRepo.save(contributorRow);
+    }
+  }
+
+  private async isStaleProject(
+    projectId: string,
+    ledgerSeq: number,
+  ): Promise<boolean> {
+    const project = await this.projectRepo.findOne({
+      where: { projectId },
+      select: ['lastLedgerSeq'],
+    });
+    if (!project) {
+      return false;
+    }
+    return Number(project.lastLedgerSeq) > ledgerSeq;
+  }
+
+  private async updateCheckpoint(
+    contractId: string,
+    ledgerSeq: number,
+  ): Promise<void> {
+    const current = await this.getCheckpoint(contractId);
+    if (ledgerSeq > current) {
+      await this.setCheckpoint(contractId, ledgerSeq);
+    }
+  }
+
+  private resolveLedgerSeq(input: VaultSyncEventInput): number {
+    if (input.ledgerSeq !== undefined && input.ledgerSeq > 0) {
+      return input.ledgerSeq;
+    }
+    const fromPayload = input.rawPayload?.ledgerSeq ?? input.rawPayload?.ledger;
+    const n = Number(fromPayload);
+    return Number.isFinite(n) && n > 0 ? n : 0;
+  }
+
+  private normalizeEventType(eventType: string): string {
+    return eventType.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
+  }
+
+  private parsePayload(
+    raw: Record<string, unknown>,
+    normalizedType: string,
+  ): ParsedVaultPayload {
+    const projectId = this.pickBigInt(raw, [
+      'projectId',
+      'project_id',
+      'projectID',
+    ]);
+    const contributor = this.pickString(raw, [
+      'user',
+      'contributor',
+      'owner',
+      'recipient',
+    ]);
+    const amount = this.pickAmount(raw);
+    const milestoneId = this.pickInt(raw, ['milestoneId', 'milestone_id']);
+    const owner = this.pickString(raw, ['owner']);
+    const tokenAddress = this.pickString(raw, [
+      'tokenAddress',
+      'token_address',
+    ]);
+    const refundWindowDeadline = this.pickBigInt(raw, [
+      'refundWindowDeadline',
+      'refund_window_deadline',
+    ]);
+
+    return {
+      projectId,
+      contributor,
+      amount,
+      milestoneId,
+      owner,
+      tokenAddress,
+      refundWindowDeadline,
+      normalizedType,
+    };
+  }
+
+  private pickString(
+    raw: Record<string, unknown>,
+    keys: string[],
+  ): string | null {
+    for (const key of keys) {
+      const v = raw[key];
+      if (typeof v === 'string' && v.length > 0) {
+        return v;
+      }
+    }
+    return null;
+  }
+
+  private pickBigInt(
+    raw: Record<string, unknown>,
+    keys: string[],
+  ): string | null {
+    for (const key of keys) {
+      const v = raw[key];
+      if (v === undefined || v === null) {
+        continue;
+      }
+      return String(v);
+    }
+    return null;
+  }
+
+  private pickInt(raw: Record<string, unknown>, keys: string[]): number | null {
+    for (const key of keys) {
+      const v = raw[key];
+      if (v === undefined || v === null) {
+        continue;
+      }
+      const n = Number(v);
+      if (Number.isFinite(n)) {
+        return n;
+      }
+    }
+    return null;
+  }
+
+  private pickAmount(raw: Record<string, unknown>): string | null {
+    const v = raw.amount ?? raw.value;
+    if (v === undefined || v === null) {
+      return null;
+    }
+    return String(v);
+  }
+
+  private addAmount(current: string, delta: string): string {
+    try {
+      const sum = BigInt(current) + BigInt(delta);
+      return sum.toString();
+    } catch {
+      return current;
+    }
+  }
+
+  private subtractAmount(current: string, delta: string): string {
+    try {
+      const result = BigInt(current) - BigInt(delta);
+      return result < 0n ? '0' : result.toString();
+    } catch {
+      return current;
+    }
+  }
+}
+
+interface ParsedVaultPayload {
+  projectId: string | null;
+  contributor: string | null;
+  amount: string | null;
+  milestoneId: number | null;
+  owner: string | null;
+  tokenAddress: string | null;
+  refundWindowDeadline: string | null;
+  normalizedType: string;
+}

--- a/apps/backend/src/crowdfund-vault-sync/dto/vault-sync-event.dto.ts
+++ b/apps/backend/src/crowdfund-vault-sync/dto/vault-sync-event.dto.ts
@@ -1,0 +1,21 @@
+export interface VaultSyncEventInput {
+  txHash: string;
+  eventIndex: number;
+  contractId: string;
+  eventType: string;
+  rawPayload: Record<string, unknown>;
+  ledgerSeq?: number;
+}
+
+export const VAULT_EVENT_TYPES = {
+  PROJECT_CREATED: 'projectcreatedevent',
+  DEPOSIT: 'depositevent',
+  WITHDRAW: 'withdrawevent',
+  MILESTONE_APPROVED: 'milestoneapprovedevent',
+  MILESTONE_APPROVED_BY_VOTE: 'milestoneapprovedbyvoteevent',
+  PROJECT_CANCELED: 'projectcanceledevent',
+  PROJECT_EXPIRED: 'projectexpiredevent',
+  CONTRIBUTION_REFUNDED: 'contributionrefundedevent',
+  CONTRIBUTION_CLAWED_BACK: 'contributionclawedbackevent',
+  CONTRIBUTOR_PAYOUT: 'contributorpayoutevent',
+} as const;

--- a/apps/backend/src/crowdfund-vault-sync/entities/crowdfund-vault-contributor.entity.ts
+++ b/apps/backend/src/crowdfund-vault-sync/entities/crowdfund-vault-contributor.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('crowdfund_vault_contributors')
+@Unique('UQ_crowdfund_vault_contributors_project_contributor', [
+  'projectId',
+  'contributor',
+])
+export class CrowdfundVaultContributorEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'bigint' })
+  @Index()
+  projectId: string;
+
+  @Column()
+  contributor: string;
+
+  @Column({ default: '0' })
+  totalContributed: string;
+
+  @Column({ type: 'bigint', nullable: true })
+  firstContributionLedger: string | null;
+
+  @Column({ type: 'bigint', nullable: true })
+  lastContributionLedger: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/backend/src/crowdfund-vault-sync/entities/crowdfund-vault-event.entity.ts
+++ b/apps/backend/src/crowdfund-vault-sync/entities/crowdfund-vault-event.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+
+@Entity('crowdfund_vault_events')
+@Unique('UQ_crowdfund_vault_events_tx_event', ['txHash', 'eventIndex'])
+export class CrowdfundVaultEventEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index()
+  contractId: string;
+
+  @Column()
+  txHash: string;
+
+  @Column()
+  eventIndex: number;
+
+  @Column()
+  eventType: string;
+
+  @Column({ type: 'bigint' })
+  @Index()
+  ledgerSeq: string;
+
+  @Column({ type: 'bigint', nullable: true })
+  projectId: string | null;
+
+  @Column({ nullable: true })
+  contributor: string | null;
+
+  @Column({ nullable: true })
+  amount: string | null;
+
+  @Column({ nullable: true })
+  milestoneId: number | null;
+
+  @Column({ type: 'jsonb' })
+  rawPayload: Record<string, unknown>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/apps/backend/src/crowdfund-vault-sync/entities/crowdfund-vault-milestone.entity.ts
+++ b/apps/backend/src/crowdfund-vault-sync/entities/crowdfund-vault-milestone.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('crowdfund_vault_milestones')
+@Unique('UQ_crowdfund_vault_milestones_project_milestone', [
+  'projectId',
+  'milestoneId',
+])
+export class CrowdfundVaultMilestoneEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'bigint' })
+  @Index()
+  projectId: string;
+
+  @Column()
+  milestoneId: number;
+
+  @Column({ default: 'pending' })
+  status: string;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  approvedAt: Date | null;
+
+  @Column({ type: 'bigint', nullable: true })
+  lastLedgerSeq: string | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/backend/src/crowdfund-vault-sync/entities/crowdfund-vault-project.entity.ts
+++ b/apps/backend/src/crowdfund-vault-sync/entities/crowdfund-vault-project.entity.ts
@@ -1,0 +1,55 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('crowdfund_vault_projects')
+export class CrowdfundVaultProjectEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'bigint', unique: true })
+  @Index()
+  projectId: string;
+
+  @Column()
+  contractId: string;
+
+  @Column()
+  owner: string;
+
+  @Column({ nullable: true })
+  tokenAddress: string | null;
+
+  @Column({ default: '0' })
+  totalContributions: string;
+
+  @Column({ default: '0' })
+  totalWithdrawn: string;
+
+  @Column({ default: 0 })
+  uniqueContributors: number;
+
+  @Column({ default: 'active' })
+  @Index()
+  status: string;
+
+  @Column({ type: 'bigint', nullable: true })
+  refundWindowDeadline: string | null;
+
+  @Column({ type: 'bigint', default: 0 })
+  lastLedgerSeq: string;
+
+  @Column()
+  lastTxHash: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/backend/src/crowdfund-vault-sync/entities/crowdfund-vault-sync-checkpoint.entity.ts
+++ b/apps/backend/src/crowdfund-vault-sync/entities/crowdfund-vault-sync-checkpoint.entity.ts
@@ -1,0 +1,27 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('crowdfund_vault_sync_checkpoints')
+export class CrowdfundVaultSyncCheckpointEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  @Index()
+  contractId: string;
+
+  @Column({ type: 'bigint', default: 0 })
+  lastLedger: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/backend/src/database/migrations/1780200000000-CreateCrowdfundVaultSync.ts
+++ b/apps/backend/src/database/migrations/1780200000000-CreateCrowdfundVaultSync.ts
@@ -1,0 +1,114 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateCrowdfundVaultSync1780200000000 implements MigrationInterface {
+  name = 'CreateCrowdfundVaultSync1780200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "crowdfund_vault_sync_checkpoints" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "contractId" character varying NOT NULL,
+        "lastLedger" bigint NOT NULL DEFAULT 0,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "UQ_crowdfund_vault_sync_checkpoints_contractId" UNIQUE ("contractId"),
+        CONSTRAINT "PK_crowdfund_vault_sync_checkpoints" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "crowdfund_vault_events" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "contractId" character varying NOT NULL,
+        "txHash" character varying NOT NULL,
+        "eventIndex" integer NOT NULL,
+        "eventType" character varying NOT NULL,
+        "ledgerSeq" bigint NOT NULL,
+        "projectId" bigint,
+        "contributor" character varying,
+        "amount" character varying,
+        "milestoneId" integer,
+        "rawPayload" jsonb NOT NULL,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "UQ_crowdfund_vault_events_tx_event" UNIQUE ("txHash", "eventIndex"),
+        CONSTRAINT "PK_crowdfund_vault_events" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_crowdfund_vault_events_contract_ledger" ON "crowdfund_vault_events" ("contractId", "ledgerSeq")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_crowdfund_vault_events_project_type" ON "crowdfund_vault_events" ("projectId", "eventType")`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "crowdfund_vault_projects" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "projectId" bigint NOT NULL,
+        "contractId" character varying NOT NULL,
+        "owner" character varying NOT NULL,
+        "tokenAddress" character varying,
+        "totalContributions" character varying NOT NULL DEFAULT '0',
+        "totalWithdrawn" character varying NOT NULL DEFAULT '0',
+        "uniqueContributors" integer NOT NULL DEFAULT 0,
+        "status" character varying NOT NULL DEFAULT 'active',
+        "refundWindowDeadline" bigint,
+        "lastLedgerSeq" bigint NOT NULL DEFAULT 0,
+        "lastTxHash" character varying NOT NULL,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "UQ_crowdfund_vault_projects_projectId" UNIQUE ("projectId"),
+        CONSTRAINT "PK_crowdfund_vault_projects" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_crowdfund_vault_projects_status" ON "crowdfund_vault_projects" ("status")`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "crowdfund_vault_contributors" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "projectId" bigint NOT NULL,
+        "contributor" character varying NOT NULL,
+        "totalContributed" character varying NOT NULL DEFAULT '0',
+        "firstContributionLedger" bigint,
+        "lastContributionLedger" bigint,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "UQ_crowdfund_vault_contributors_project_contributor" UNIQUE ("projectId", "contributor"),
+        CONSTRAINT "PK_crowdfund_vault_contributors" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_crowdfund_vault_contributors_projectId" ON "crowdfund_vault_contributors" ("projectId")`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "crowdfund_vault_milestones" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "projectId" bigint NOT NULL,
+        "milestoneId" integer NOT NULL,
+        "status" character varying NOT NULL DEFAULT 'pending',
+        "approvedAt" TIMESTAMP,
+        "lastLedgerSeq" bigint,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "UQ_crowdfund_vault_milestones_project_milestone" UNIQUE ("projectId", "milestoneId"),
+        CONSTRAINT "PK_crowdfund_vault_milestones" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_crowdfund_vault_milestones_projectId" ON "crowdfund_vault_milestones" ("projectId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "crowdfund_vault_milestones"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "crowdfund_vault_contributors"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "crowdfund_vault_projects"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "crowdfund_vault_events"`);
+    await queryRunner.query(
+      `DROP TABLE IF EXISTS "crowdfund_vault_sync_checkpoints"`,
+    );
+  }
+}

--- a/apps/backend/src/soroban-events/soroban-events.module.ts
+++ b/apps/backend/src/soroban-events/soroban-events.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BullModule } from '@nestjs/bullmq';
 import { SorobanEvent } from './entities/soroban-event.entity';
@@ -11,11 +11,13 @@ import { SorobanEventsController } from './soroban-events.controller';
 import { SorobanEventIngestionGuard } from './guards/soroban-event-ingestion.guard';
 
 import { ProjectRegistryEntity } from '../database/entities/project-registry.entity';
+import { CrowdfundVaultSyncModule } from '../crowdfund-vault-sync/crowdfund-vault-sync.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([SorobanEvent, ProjectRegistryEntity]),
     BullModule.registerQueue({ name: SOROBAN_EVENTS_QUEUE }),
+    forwardRef(() => CrowdfundVaultSyncModule),
   ],
   controllers: [SorobanEventsController],
   providers: [
@@ -23,5 +25,6 @@ import { ProjectRegistryEntity } from '../database/entities/project-registry.ent
     SorobanEventsProcessor,
     SorobanEventIngestionGuard,
   ],
+  exports: [SorobanEventsService],
 })
 export class SorobanEventsModule {}

--- a/apps/backend/src/soroban-events/soroban-events.processor.ts
+++ b/apps/backend/src/soroban-events/soroban-events.processor.ts
@@ -13,6 +13,8 @@ import {
   SOROBAN_EVENTS_QUEUE,
   PROCESS_EVENT_JOB,
 } from './soroban-events.service';
+import { CrowdfundVaultSyncService } from '../crowdfund-vault-sync/crowdfund-vault-sync.service';
+import { config } from '../lib/config';
 
 @Processor(SOROBAN_EVENTS_QUEUE)
 @Injectable()
@@ -24,6 +26,7 @@ export class SorobanEventsProcessor extends WorkerHost {
     private readonly eventRepo: Repository<SorobanEvent>,
 
     private readonly sorobanEventsService: SorobanEventsService,
+    private readonly vaultSyncService: CrowdfundVaultSyncService,
   ) {
     super();
   }
@@ -63,25 +66,41 @@ export class SorobanEventsProcessor extends WorkerHost {
     await this.eventRepo.save(event);
 
     try {
-      if (contractId === process.env.PROJECT_REGISTRY_CONTRACT_ID) {
-        // Cast rawPayload to any so we can access its nested properties safely
-        const payloadData = rawPayload as Record<string, any>;
+      const registryContractId =
+        config.stellar.contracts.projectRegistry ??
+        process.env.PROJECT_REGISTRY_CONTRACT_ID;
+
+      if (contractId && contractId === registryContractId) {
+        const payloadData = rawPayload as Record<string, unknown>;
 
         const projectData = {
-          projectId: String(payloadData?.projectId || ''),
-          owner: String(payloadData?.owner || ''),
-          name: String(payloadData?.name || ''),
+          projectId: String(payloadData?.projectId ?? ''),
+          owner: String(payloadData?.owner ?? ''),
+          name: String(payloadData?.name ?? ''),
           metadataCid: payloadData?.metadataCid
             ? String(payloadData.metadataCid)
             : undefined,
-          // If ledgerSeq isn't in job.data, it should be in rawPayload.
-          // Fallback to 0 if it's missing to satisfy the interface.
-          ledgerSeq: Number(payloadData?.ledgerSeq || 0),
+          ledgerSeq: Number(payloadData?.ledgerSeq ?? payloadData?.ledger ?? 0),
           txHash: String(txHash),
         };
 
         await this.sorobanEventsService.syncProjectRegistryEvent(projectData);
         this.logger.log(`Project Registry sync successful for tx ${txHash}`);
+      }
+
+      if (this.vaultSyncService.isVaultContract(contractId)) {
+        const payloadData = rawPayload as Record<string, unknown>;
+        await this.vaultSyncService.syncVaultEvent({
+          txHash,
+          eventIndex,
+          contractId: contractId!,
+          eventType: eventType ?? 'unknown',
+          rawPayload: payloadData,
+          ledgerSeq: Number(
+            payloadData?.ledgerSeq ?? payloadData?.ledger ?? 0,
+          ),
+        });
+        this.logger.log(`Crowdfund vault sync successful for tx ${txHash}`);
       }
 
       event.status = SorobanEventStatus.PROCESSED;


### PR DESCRIPTION
## Summary

Closes #711 

Adds a backend worker that tracks **crowdfund vault** Soroban events on testnet and materializes them into Postgres:

- **Deposits / contributions** → `crowdfund_vault_projects`, `crowdfund_vault_contributors`
- **Milestone approvals** → `crowdfund_vault_milestones`
- **Refund window / reversals** → project status + contribution adjustments (`ProjectExpiredEvent`, `ContributionRefundedEvent`, `ContributionClawedBackEvent`)

Events flow through the existing **soroban-events** BullMQ pipeline (webhook ingest) and an optional **RPC poller** (`getEvents`) when `STELLAR_CONTRACT_CROWDFUND_VAULT` is configured.

## Design

- **Idempotency:** `UNIQUE (txHash, eventIndex)` on raw events; BullMQ `jobId` unchanged
- **Ledger sequencing:** skip materialization when `incomingLedgerSeq < stored lastLedgerSeq` (same pattern as `project_registry`)
- **Replay-safe:** re-delivering the same event is a no-op after the raw row exists

## Schema

New migration: `1780200000000-CreateCrowdfundVaultSync.ts`

## Test plan

- [x] `npx jest --testPathPattern=crowdfund-vault-sync` (6 tests)
- [x] `npm run build`
- [ ] Run migration: `npm run migration:run` (from `apps/backend`)
- [ ] Set `STELLAR_CONTRACT_CROWDFUND_VAULT` + `STELLAR_SOROBAN_RPC_URL` on testnet
- [ ] POST a sample `DepositEvent` to `/soroban-events/ingest` and verify rows in `crowdfund_vault_*` tables
- [ ] Confirm cron poller queues events when contract ID is set (check logs)

## Notes

- `CrowdfundService` remains in-memory for now; API can be wired to `crowdfund_vault_projects` in a follow-up.
- Project registry routing now prefers `config.stellar.contracts.projectRegistry` over the legacy `PROJECT_REGISTRY_CONTRACT_ID` env var.