### PR TITLE
feat: implement idempotent execution for batch payout

### DIFF
--- a/apps/onchain/contracts/crowdfund_vault/src/errors.rs
+++ b/apps/onchain/contracts/crowdfund_vault/src/errors.rs
@@ -35,4 +35,5 @@ pub enum CrowdfundError {
     RefundWindowClosed = 29,
     RefundWindowNotOpen = 30,
     Reentrancy = 31,
+    DuplicateExecution = 32,
 }

--- a/apps/onchain/contracts/crowdfund_vault/src/lib.rs
+++ b/apps/onchain/contracts/crowdfund_vault/src/lib.rs
@@ -1791,9 +1791,15 @@ impl CrowdfundVaultContract {
         admin: Address,
         token_address: Address,
         recipients: Vec<(Address, i128)>,
+        batch_id: BytesN<32>,
     ) -> Result<(), CrowdfundError> {
         Self::with_reentrancy_guard(&env, || {
             Self::verify_admin(&env, &admin)?;
+
+            let batch_key = DataKey::ExecutedBatch(batch_id.clone());
+            if env.storage().persistent().has(&batch_key) {
+                return Err(CrowdfundError::DuplicateExecution);
+            }
 
             let is_paused: bool = env
                 .storage()
@@ -1840,6 +1846,8 @@ impl CrowdfundVaultContract {
                 token::transfer(&env, &token_address, &contract_address, &recipient, &amount);
                 events::ContributorPayoutEvent { recipient, amount }.publish(&env);
             }
+
+            env.storage().persistent().set(&batch_key, &true);
 
             Ok(())
         })

--- a/apps/onchain/contracts/crowdfund_vault/src/storage.rs
+++ b/apps/onchain/contracts/crowdfund_vault/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, Symbol};
+use soroban_sdk::{contracttype, Address, BytesN, Symbol};
 
 // TTL constants for Soroban storage rent management.
 // LEDGER_THRESHOLD: if the remaining TTL falls below this value, extend it.
@@ -38,6 +38,7 @@ pub enum DataKey {
     FeeBps,                      // -> u32
     Treasury,                    // -> Address
     Subscribers,
+    ExecutedBatch(BytesN<32>),
 }
 
 #[contracttype]

--- a/apps/onchain/contracts/crowdfund_vault/src/test.rs
+++ b/apps/onchain/contracts/crowdfund_vault/src/test.rs
@@ -1397,7 +1397,8 @@ fn test_batch_payout() {
     ];
 
     // Execute batch payout
-    client.batch_payout(&admin, &token_client.address, &recipients);
+    let batch_id = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    client.batch_payout(&admin, &token_client.address, &recipients, &batch_id);
 
     // Verify reward pool decreased
     assert_eq!(
@@ -1426,7 +1427,8 @@ fn test_batch_payout_empty_recipients() {
 
     // Empty recipients list should fail
     let empty_recipients = vec![&env];
-    let result = client.try_batch_payout(&admin, &token_client.address, &empty_recipients);
+    let batch_id = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    let result = client.try_batch_payout(&admin, &token_client.address, &empty_recipients, &batch_id);
     assert_eq!(result, Err(Ok(CrowdfundError::InvalidAmount)));
 }
 
@@ -1447,7 +1449,8 @@ fn test_batch_payout_invalid_amount() {
     // Recipient with zero amount should fail
     let recipient = Address::generate(&env);
     let recipients = vec![&env, (recipient, 0i128)];
-    let result = client.try_batch_payout(&admin, &token_client.address, &recipients);
+    let batch_id = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    let result = client.try_batch_payout(&admin, &token_client.address, &recipients, &batch_id);
     assert_eq!(result, Err(Ok(CrowdfundError::InvalidAmount)));
 }
 
@@ -1468,7 +1471,8 @@ fn test_batch_payout_insufficient_balance() {
     // Request payout larger than pool balance
     let recipient = Address::generate(&env);
     let recipients = vec![&env, (recipient, 20_000i128)];
-    let result = client.try_batch_payout(&admin, &token_client.address, &recipients);
+    let batch_id = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    let result = client.try_batch_payout(&admin, &token_client.address, &recipients, &batch_id);
     assert_eq!(result, Err(Ok(CrowdfundError::InsufficientBalance)));
 }
 
@@ -1490,7 +1494,8 @@ fn test_batch_payout_unauthorized() {
     // Non-admin tries to execute batch payout
     let recipient = Address::generate(&env);
     let recipients = vec![&env, (recipient, 10_000i128)];
-    let result = client.try_batch_payout(&owner, &token_client.address, &recipients);
+    let batch_id = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    let result = client.try_batch_payout(&owner, &token_client.address, &recipients, &batch_id);
     assert_eq!(result, Err(Ok(CrowdfundError::Unauthorized)));
 }
 
@@ -1515,7 +1520,8 @@ fn test_batch_payout_contract_paused() {
     // Batch payout should fail when paused
     let recipient = Address::generate(&env);
     let recipients = vec![&env, (recipient, 10_000i128)];
-    client.batch_payout(&admin, &token_client.address, &recipients);
+    let batch_id = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    client.batch_payout(&admin, &token_client.address, &recipients, &batch_id);
 }
 
 #[test]
@@ -1535,8 +1541,36 @@ fn test_batch_payout_contract_address_recipient() {
 
     // Using contract address as recipient should fail
     let recipients = vec![&env, (contract_address, 10_000i128)];
-    let result = client.try_batch_payout(&admin, &token_client.address, &recipients);
+    let batch_id = soroban_sdk::BytesN::from_array(&env, &[0u8; 32]);
+    let result = client.try_batch_payout(&admin, &token_client.address, &recipients, &batch_id);
     assert_eq!(result, Err(Ok(CrowdfundError::InvalidRecipient)));
+}
+
+#[test]
+fn test_batch_payout_duplicate_execution() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, _, _, token_client, token_admin_client, _) =
+        setup_test_with_admin(&env);
+
+    client.initialize(&admin);
+
+    // Fund reward pool
+    let pool_amount: i128 = 100_000;
+    token_admin_client.mint(&admin, &pool_amount);
+    client.fund_reward_pool(&admin, &token_client.address, &pool_amount);
+
+    let recipient = Address::generate(&env);
+    let recipients = vec![&env, (recipient, 10_000i128)];
+    let batch_id = soroban_sdk::BytesN::from_array(&env, &[1u8; 32]);
+
+    // First execution should succeed
+    client.batch_payout(&admin, &token_client.address, &recipients, &batch_id);
+
+    // Second execution with the same batch_id should fail
+    let result = client.try_batch_payout(&admin, &token_client.address, &recipients, &batch_id);
+    assert_eq!(result, Err(Ok(CrowdfundError::DuplicateExecution)));
 }
 
 #[test]


### PR DESCRIPTION
# Title: feat(crowdfund): add idempotent retry protection for batch payout

## Summary

This PR implements idempotent retry protection for the `batch_payout` mechanism in the `crowdfund_vault` contract to prevent unintended double-executions of payouts. 

Changes include:
- Added `ExecutedBatch(BytesN<32>)` to the `DataKey` enum in `storage.rs` to persist execution hashes.
- Introduced a new `DuplicateExecution` custom error in `errors.rs`.
- Updated the `batch_payout` function in `lib.rs` to require a `batch_id: BytesN<32>` and reject duplicate calls if the batch hash is already present in persistent storage.
- Added comprehensive tests, including `test_batch_payout_duplicate_execution`, to explicitly verify the idempotency mechanism works correctly.

## Linked Issue

Closes #689

## Type of Change

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Validation

- [x] Lint passed for affected area(s)
- [x] Tests passed for affected area(s)
- [x] Manual verification completed (if applicable)

## Documentation

- [x] Documentation updated (or N/A with explanation)
- [x] Screenshots/videos attached for UI changes

## Screenshots
<img width="1025" height="173" alt="image" src="https://github.com/user-attachments/assets/b163f868-dd23-40fe-a9bd-59222af19cbe" />


## Checklist

- [x] Branch name uses `feat/`, `fix/`, or `docs/`
- [x] Commit messages follow Conventional Commits
- [x] PR scope matches linked issue acceptance criteria
