### PR TITLE
feat: add admin-only demo bootstrap endpoint for testnet review

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -115,6 +115,7 @@ WEBHOOK_PROVIDERS='[{"name":"data-processing","algorithm":"hmac-sha256","secret"
 TELEGRAM_BOT_TOKEN=telegram-bot-token-here
 METRICS_ALLOWED_IPS=127.0.0.1,::1
 USE_MOCK_TRANSACTIONS=true
+BOOTSTRAP_DEMO_DATA_ENABLED=false
 
 # Logging
 LOGGING_ENABLED=true

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -24,6 +24,28 @@ npm run test
 npm run test:e2e
 ```
 
+## Demo bootstrap endpoint
+
+The backend exposes an admin-only demo bootstrap endpoint that can populate a small set of sample crowdfund projects for reviewer/testnet validation.
+
+To enable it locally or in a non-production test environment, set:
+
+```bash
+BOOTSTRAP_DEMO_DATA_ENABLED=true
+```
+
+Then call the endpoint with an admin JWT:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <ADMIN_JWT>" \
+  http://localhost:3000/v1/crowdfund/admin/bootstrap-demo-data
+```
+
+The endpoint returns the created demo project IDs for verification.
+
+> This endpoint is disabled by default and should not be enabled in production unless explicitly required.
+
 ## Security defaults
 
 The backend includes:

--- a/apps/backend/src/crowdfund/crowdfund.controller.ts
+++ b/apps/backend/src/crowdfund/crowdfund.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  ForbiddenException,
   Get,
   Param,
   ParseIntPipe,
@@ -18,6 +19,7 @@ import { Throttle } from '@nestjs/throttler';
 import { CrowdfundService } from './crowdfund.service';
 import { getCrowdfundReadThrottleOverride } from '../common/rate-limit/rate-limit.config';
 import {
+  BootstrapDemoDataResponseDto,
   ContributeDto,
   CreateProjectDto,
   CrowdfundProjectDto,
@@ -25,6 +27,9 @@ import {
   ContributionResponseDto,
 } from './dto/crowdfund.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles, UserRole } from '../auth/decorators/auth.decorators';
+import { config } from '../lib/config';
 
 @ApiTags('crowdfund')
 @Controller('crowdfund')
@@ -95,6 +100,35 @@ export class CrowdfundController {
   })
   contribute(@Body() dto: ContributeDto) {
     return this.svc.contribute(dto);
+  }
+
+  @Post('admin/bootstrap-demo-data')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Bootstrap demo crowdfund data',
+    description:
+      'Creates a small set of demo projects to help reviewers test the MVP in non-production environments.',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Demo data created successfully',
+    type: BootstrapDemoDataResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden or disabled in this environment',
+  })
+  bootstrapDemoData() {
+    if (!config.featureFlags.bootstrapDemoData) {
+      throw new ForbiddenException(
+        'Demo bootstrap is disabled. Set BOOTSTRAP_DEMO_DATA_ENABLED=true to enable it.',
+      );
+    }
+
+    return this.svc.bootstrapDemoData();
   }
 
   @Get('projects/:id/contributors')

--- a/apps/backend/src/crowdfund/crowdfund.service.spec.ts
+++ b/apps/backend/src/crowdfund/crowdfund.service.spec.ts
@@ -1,0 +1,24 @@
+import { CrowdfundService } from './crowdfund.service';
+
+describe('CrowdfundService', () => {
+  let service: CrowdfundService;
+
+  beforeEach(() => {
+    service = new CrowdfundService();
+  });
+
+  it('should bootstrap demo data and return created project IDs', () => {
+    const result = service.bootstrapDemoData();
+
+    expect(result).toBeDefined();
+    expect(Array.isArray(result.projectIds)).toBe(true);
+    expect(result.projectIds.length).toBe(3);
+    expect(result.projectIds.every((id) => typeof id === 'number')).toBe(true);
+
+    const projects = service.listProjects();
+    expect(projects.length).toBeGreaterThanOrEqual(3);
+    expect(projects.map((project) => project.id)).toEqual(
+      expect.arrayContaining(result.projectIds),
+    );
+  });
+});

--- a/apps/backend/src/crowdfund/crowdfund.service.ts
+++ b/apps/backend/src/crowdfund/crowdfund.service.ts
@@ -139,6 +139,79 @@ export class CrowdfundService {
     };
   }
 
+  bootstrapDemoData(): { projectIds: number[] } {
+    const demoProjects: CreateProjectDto[] = [
+      {
+        owner: 'GB5PY6YQF3OZ2IRPII7G3XVG6UJZYE5MVYC2EQNHW4KSYSSFYH7Y7QK3',
+        name: 'Testnet Accelerator Grant',
+        description:
+          'A sample project to demonstrate grant funding workflows on testnet.',
+        targetAmount: '20000',
+        tokenAddress:
+          'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+        contractAddress:
+          'CA6FLKVQZFWURX3P2G7W4D6A4WKE2N4ACWXL6DL5S5Z2JHVV7K72DT2J',
+        roadmap: [
+          {
+            title: 'Launch grant portal',
+            description: 'Open the testnet portal for grant submissions.',
+            targetDate: '2026-07-01',
+          },
+          {
+            title: 'Review proposals',
+            description: 'Evaluate first round of grant applications.',
+            targetDate: '2026-08-01',
+          },
+        ],
+      },
+      {
+        owner: 'GC3RZOB25UVDYLK6B2ZHG2ZGFA25ZV3XCYKZMIKQWRIHJCBBHTC4J6AM',
+        name: 'Stellar UX Workshop',
+        description:
+          'An event-focused project to build onboarding flows for developer communities.',
+        targetAmount: '15000',
+        tokenAddress:
+          'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+        contractAddress:
+          'CCBM7YWZL3AG7F4S4TA7Q3X6UET7HJE26F2EQNOYGSZTVCDBZODHTVCD',
+        roadmap: [
+          {
+            title: 'Finalize workshop curriculum',
+            description:
+              'Create learner-friendly content for Stellar onboarding.',
+            targetDate: '2026-07-15',
+          },
+          {
+            title: 'Host live demo sessions',
+            description: 'Run workshops for testnet users and contributors.',
+            targetDate: '2026-08-15',
+          },
+        ],
+      },
+      {
+        owner: 'GDQJUTQYK2MQX2VGDR2FYWLIYAQIEGXTQVTFEMGH3PRXC7XMGZ3TQKQ',
+        name: 'Mobile App Onboarding',
+        description:
+          'A proof-of-concept mobile onboarding experience for testnet contributors.',
+        targetAmount: '12000',
+        tokenAddress:
+          'CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC',
+        contractAddress:
+          'CDRP4QZJFJDUGBMN35GGRQBIZSGD3CQZIJFM4CLHZLGQDGZQ3JKWFPQ',
+      },
+    ];
+
+    const projectIds = demoProjects.map(
+      (project) => this.createProject(project).id,
+    );
+
+    this.logger.log(
+      `Bootstrapped ${projectIds.length} demo projects: ${projectIds.join(', ')}`,
+    );
+
+    return { projectIds };
+  }
+
   getContributors(projectId: number): ContributorDto[] {
     const project = this.findOrThrow(projectId);
 

--- a/apps/backend/src/crowdfund/dto/crowdfund.dto.ts
+++ b/apps/backend/src/crowdfund/dto/crowdfund.dto.ts
@@ -298,6 +298,15 @@ export class ContributionResponseDto {
   message?: string;
 }
 
+export class BootstrapDemoDataResponseDto {
+  @ApiProperty({
+    description: 'List of created demo project IDs',
+    example: [101, 102, 103],
+    type: [Number],
+  })
+  projectIds: number[];
+}
+
 export class ContributionRecordDto {
   @ApiProperty({ description: 'Project ID', example: 1 })
   projectId: number;

--- a/apps/backend/src/lib/config.ts
+++ b/apps/backend/src/lib/config.ts
@@ -51,6 +51,7 @@ import { z } from 'zod';
  * - TELEGRAM_BOT_TOKEN
  * - METRICS_ALLOWED_IPS
  * - USE_MOCK_TRANSACTIONS
+ * - BOOTSTRAP_DEMO_DATA_ENABLED
  * - LOGGING_ENABLED
  * - LOGGING_LEVEL
  * - LOGGING_INCLUDE_BODY
@@ -460,6 +461,10 @@ const envSchema = z
     USE_MOCK_TRANSACTIONS: z.preprocess(
       parseBoolean,
       z.boolean().default(true),
+    ),
+    BOOTSTRAP_DEMO_DATA_ENABLED: z.preprocess(
+      parseBoolean,
+      z.boolean().default(false),
     ),
 
     LOGGING_ENABLED: z.preprocess(parseBoolean, z.boolean().default(true)),
@@ -1065,6 +1070,7 @@ export const config = Object.freeze({
   }),
   featureFlags: Object.freeze({
     useMockTransactions: parsedEnv.USE_MOCK_TRANSACTIONS,
+    bootstrapDemoData: parsedEnv.BOOTSTRAP_DEMO_DATA_ENABLED,
   }),
   portfolioSnapshot: Object.freeze({
     concurrency: parsedEnv.PORTFOLIO_SNAPSHOT_CONCURRENCY,


### PR DESCRIPTION
Adds an admin-only demo bootstrap endpoint in the backend crowdfund module for testnet review.\n\n- Introduces POST /v1/crowdfund/admin/bootstrap-demo-data\n- Guards the endpoint with JwtAuthGuard, RolesGuard, and @Roles(UserRole.ADMIN)\n- Adds the runtime flag BOOTSTRAP_DEMO_DATA_ENABLED\n- Returns created project IDs for bootstrapped demo data\n- Includes config validation and docs updates\n\nCloses #815