### PR TITLE
Add synthetic dataset generator and related files for local testing

### DIFF
--- a/apps/data-processing/README.md
+++ b/apps/data-processing/README.md
@@ -53,7 +53,31 @@ Create a `.env` file in the root of `apps/data-processing` and add any necessary
 python src/main.py
 ```
 
-## Telegram Alert Bot Setup
+## 6. Synthetic Data Generator
+
+A synthetic dataset generator is available for local development, dashboard stress testing, and API validation. It writes clearly separated JSON fixtures under `data/synthetic` and can optionally persist data to PostgreSQL.
+
+```bash
+python scripts/generate_synthetic_data.py \
+  --seed 42 \
+  --project-count 12 \
+  --contributors-per-project 8 \
+  --articles 120 \
+  --social-posts 100 \
+  --analytics-records 80 \
+  --contract-events 60 \
+  --output-dir data/synthetic
+```
+
+To persist synthetic records into the local database:
+
+```bash
+python scripts/generate_synthetic_data.py --save-to-db --create-tables
+```
+
+This generator keeps synthetic data separate by writing a dedicated output directory and by marking each record with a synthetic source label.
+
+## 7. Telegram Alert Bot Setup
 
 The data processing service can send Telegram alerts when high sentiment scores (>0.8) are detected. Follow these steps to enable alerts:
 

--- a/apps/data-processing/data/synthetic_test/analytics_records.json
+++ b/apps/data-processing/data/synthetic_test/analytics_records.json
@@ -1,0 +1,32 @@
+[
+  {
+    "record_type": "sentiment_summary",
+    "asset": "XLM",
+    "metric_name": "volume",
+    "window": "7d",
+    "value": 43.133,
+    "previous_value": 48.458,
+    "change_percentage": -10.99,
+    "trend_direction": "down",
+    "extra_data": {
+      "source": "SyntheticDataGenerator",
+      "project_slug": "pulse-project-1"
+    },
+    "timestamp": "2026-06-23T16:27:07.654272+00:00"
+  },
+  {
+    "record_type": "volume_snapshot",
+    "asset": "BTC",
+    "metric_name": "engagement",
+    "window": "24h",
+    "value": 48.028,
+    "previous_value": 54.231,
+    "change_percentage": -11.44,
+    "trend_direction": "down",
+    "extra_data": {
+      "source": "SyntheticDataGenerator",
+      "project_slug": "pulse-project-2"
+    },
+    "timestamp": "2026-06-23T12:48:07.654297+00:00"
+  }
+]

--- a/apps/data-processing/data/synthetic_test/articles.json
+++ b/apps/data-processing/data/synthetic_test/articles.json
@@ -1,0 +1,146 @@
+[
+  {
+    "article_id": "synthetic_article_00001",
+    "title": "PulseProject 1 Update: Community sentiment remains upbeat after the most recent protocol upgrade.",
+    "content": "Community sentiment remains upbeat after the most recent protocol upgrade. This synthetic article is designed for local development and stress testing.",
+    "summary": "Synthetic news item about XLM and community contributions.",
+    "source": "SyntheticDataGenerator",
+    "url": "https://synthetic.lumenpulse.dev/article/00001",
+    "asset_codes": [
+      "XLM"
+    ],
+    "primary_asset": "XLM",
+    "categories": [
+      "synthetic",
+      "news",
+      "crypto"
+    ],
+    "sentiment_score": -0.483,
+    "positive_score": 0.0,
+    "negative_score": 0.483,
+    "neutral_score": 0.517,
+    "sentiment_label": "negative",
+    "keywords": [
+      "XLM",
+      "synthetic",
+      "portfolio"
+    ],
+    "detected_entities": [
+      "XLM",
+      "PulseProject 1"
+    ],
+    "onchain_entity_links": [
+      {
+        "stable_entity_id": "project:10001",
+        "entity_type": "project",
+        "display_name": "PulseProject 1",
+        "matched_text": "PulseProject 1",
+        "confidence": 0.95,
+        "source": "SyntheticDataGenerator",
+        "asset_code": "XLM",
+        "project_id": 10001,
+        "contract_id": "CONTRACT_10001"
+      }
+    ],
+    "language": "en",
+    "published_at": "2026-06-14T08:36:07.653938+00:00",
+    "fetched_at": "2026-06-23T16:36:07.654002+00:00",
+    "analyzed_at": "2026-06-23T16:36:07.654010+00:00"
+  },
+  {
+    "article_id": "synthetic_article_00002",
+    "title": "PulseProject 1 Update: Developers are closely watching liquidity metrics and reward incentives.",
+    "content": "Developers are closely watching liquidity metrics and reward incentives. This synthetic article is designed for local development and stress testing.",
+    "summary": "Synthetic news item about XLM and community contributions.",
+    "source": "SyntheticDataGenerator",
+    "url": "https://synthetic.lumenpulse.dev/article/00002",
+    "asset_codes": [
+      "XLM"
+    ],
+    "primary_asset": "XLM",
+    "categories": [
+      "synthetic",
+      "news",
+      "crypto"
+    ],
+    "sentiment_score": 0.666,
+    "positive_score": 0.666,
+    "negative_score": 0.0,
+    "neutral_score": 0.334,
+    "sentiment_label": "positive",
+    "keywords": [
+      "XLM",
+      "synthetic",
+      "portfolio"
+    ],
+    "detected_entities": [
+      "XLM",
+      "PulseProject 1"
+    ],
+    "onchain_entity_links": [
+      {
+        "stable_entity_id": "project:10001",
+        "entity_type": "project",
+        "display_name": "PulseProject 1",
+        "matched_text": "PulseProject 1",
+        "confidence": 0.95,
+        "source": "SyntheticDataGenerator",
+        "asset_code": "XLM",
+        "project_id": 10001,
+        "contract_id": "CONTRACT_10001"
+      }
+    ],
+    "language": "en",
+    "published_at": "2026-06-18T23:36:07.654022+00:00",
+    "fetched_at": "2026-06-23T16:36:07.654067+00:00",
+    "analyzed_at": "2026-06-23T16:36:07.654075+00:00"
+  },
+  {
+    "article_id": "synthetic_article_00003",
+    "title": "PulseProject 2 Update: New wallet inflows signal investor interest ahead of the next governance vote.",
+    "content": "New wallet inflows signal investor interest ahead of the next governance vote. This synthetic article is designed for local development and stress testing.",
+    "summary": "Synthetic news item about BTC and community contributions.",
+    "source": "SyntheticDataGenerator",
+    "url": "https://synthetic.lumenpulse.dev/article/00003",
+    "asset_codes": [
+      "BTC"
+    ],
+    "primary_asset": "BTC",
+    "categories": [
+      "synthetic",
+      "news",
+      "crypto"
+    ],
+    "sentiment_score": 0.746,
+    "positive_score": 0.746,
+    "negative_score": 0.0,
+    "neutral_score": 0.254,
+    "sentiment_label": "positive",
+    "keywords": [
+      "BTC",
+      "synthetic",
+      "portfolio"
+    ],
+    "detected_entities": [
+      "BTC",
+      "PulseProject 2"
+    ],
+    "onchain_entity_links": [
+      {
+        "stable_entity_id": "project:10002",
+        "entity_type": "project",
+        "display_name": "PulseProject 2",
+        "matched_text": "PulseProject 2",
+        "confidence": 0.95,
+        "source": "SyntheticDataGenerator",
+        "asset_code": "BTC",
+        "project_id": 10002,
+        "contract_id": "CONTRACT_10002"
+      }
+    ],
+    "language": "en",
+    "published_at": "2026-06-08T22:36:07.654092+00:00",
+    "fetched_at": "2026-06-23T16:36:07.654130+00:00",
+    "analyzed_at": "2026-06-23T16:36:07.654135+00:00"
+  }
+]

--- a/apps/data-processing/data/synthetic_test/contract_events.json
+++ b/apps/data-processing/data/synthetic_test/contract_events.json
@@ -1,0 +1,48 @@
+[
+  {
+    "contract_id": "CONTRACT_10001",
+    "event_id": "synthetic_event_00001",
+    "ledger": 200002,
+    "event_type": "reward_granted",
+    "project_id": 10001,
+    "contributor": "GPJF5BX5DIYZF3BWDS5CK77EGCYXNGRO6X767JHVB35VUQY3Y4ZAFOO2",
+    "amount": 643.62,
+    "milestone_id": 3,
+    "status": "completed",
+    "topics": [
+      "XLM",
+      "reward_granted"
+    ],
+    "raw_data": {
+      "summary": "Synthetic reward_granted event for pulse-project-1",
+      "details": {
+        "contribution_reason": "stress test data generation",
+        "metric": "growth"
+      }
+    },
+    "timestamp": "2026-06-23T08:36:07.654325+00:00"
+  },
+  {
+    "contract_id": "CONTRACT_10002",
+    "event_id": "synthetic_event_00002",
+    "ledger": 200004,
+    "event_type": "submission_minted",
+    "project_id": 10002,
+    "contributor": "G5VIMPS5XLECNLQZXXIF7PGQQHS2XQWKBNRHVMW2UD32WY6FD2U4TRO3",
+    "amount": 1500.8,
+    "milestone_id": 2,
+    "status": "completed",
+    "topics": [
+      "BTC",
+      "submission_minted"
+    ],
+    "raw_data": {
+      "summary": "Synthetic submission_minted event for pulse-project-2",
+      "details": {
+        "contribution_reason": "stress test data generation",
+        "metric": "growth"
+      }
+    },
+    "timestamp": "2026-06-22T05:36:07.654349+00:00"
+  }
+]

--- a/apps/data-processing/data/synthetic_test/project_contributors.json
+++ b/apps/data-processing/data/synthetic_test/project_contributors.json
@@ -1,0 +1,42 @@
+[
+  {
+    "project_id": 10001,
+    "contributor": "GP7C5IDDPWCJP65C2QEFGQ5ROTIRBUY7HET7DKFUT5HNHUUTNCGMNACZ",
+    "total_contributed": 6753.45,
+    "first_contribution_ledger": 200002,
+    "last_contribution_ledger": 200003,
+    "extra_data": {
+      "handle": "contributor_10001_1"
+    }
+  },
+  {
+    "project_id": 10001,
+    "contributor": "G5VIMPS5XLECNLQZXXIF7PGQQHS2XQWKBNRHVMW2UD32WY6FD2U4TRO3",
+    "total_contributed": 4512.8,
+    "first_contribution_ledger": 200004,
+    "last_contribution_ledger": 200005,
+    "extra_data": {
+      "handle": "contributor_10001_2"
+    }
+  },
+  {
+    "project_id": 10002,
+    "contributor": "GDXBMSZJPFUHIYKTGA52PQ6V6ZP42XAH33AORZB2J3CWAZLMCJX2VRJ7",
+    "total_contributed": 6111.24,
+    "first_contribution_ledger": 200007,
+    "last_contribution_ledger": 200008,
+    "extra_data": {
+      "handle": "contributor_10002_1"
+    }
+  },
+  {
+    "project_id": 10002,
+    "contributor": "GPJF5BX5DIYZF3BWDS5CK77EGCYXNGRO6X767JHVB35VUQY3Y4ZAFOO2",
+    "total_contributed": 2875.82,
+    "first_contribution_ledger": 200009,
+    "last_contribution_ledger": 200010,
+    "extra_data": {
+      "handle": "contributor_10002_2"
+    }
+  }
+]

--- a/apps/data-processing/data/synthetic_test/project_milestones.json
+++ b/apps/data-processing/data/synthetic_test/project_milestones.json
@@ -1,0 +1,68 @@
+[
+  {
+    "project_id": 10001,
+    "milestone_id": 1,
+    "status": "rejected",
+    "approved_at": null,
+    "last_event_ledger": 200002,
+    "extra_data": {
+      "title": "Milestone 1 for pulse-project-1",
+      "description": "Synthetic milestone measuring community adoption and technical progress."
+    }
+  },
+  {
+    "project_id": 10001,
+    "milestone_id": 2,
+    "status": "approved",
+    "approved_at": "2026-06-20T16:36:07.653857+00:00",
+    "last_event_ledger": 200003,
+    "extra_data": {
+      "title": "Milestone 2 for pulse-project-1",
+      "description": "Synthetic milestone measuring community adoption and technical progress."
+    }
+  },
+  {
+    "project_id": 10001,
+    "milestone_id": 3,
+    "status": "rejected",
+    "approved_at": null,
+    "last_event_ledger": 200004,
+    "extra_data": {
+      "title": "Milestone 3 for pulse-project-1",
+      "description": "Synthetic milestone measuring community adoption and technical progress."
+    }
+  },
+  {
+    "project_id": 10002,
+    "milestone_id": 1,
+    "status": "rejected",
+    "approved_at": null,
+    "last_event_ledger": 200003,
+    "extra_data": {
+      "title": "Milestone 1 for pulse-project-2",
+      "description": "Synthetic milestone measuring community adoption and technical progress."
+    }
+  },
+  {
+    "project_id": 10002,
+    "milestone_id": 2,
+    "status": "approved",
+    "approved_at": "2026-06-13T16:36:07.653907+00:00",
+    "last_event_ledger": 200004,
+    "extra_data": {
+      "title": "Milestone 2 for pulse-project-2",
+      "description": "Synthetic milestone measuring community adoption and technical progress."
+    }
+  },
+  {
+    "project_id": 10002,
+    "milestone_id": 3,
+    "status": "pending",
+    "approved_at": null,
+    "last_event_ledger": 200005,
+    "extra_data": {
+      "title": "Milestone 3 for pulse-project-2",
+      "description": "Synthetic milestone measuring community adoption and technical progress."
+    }
+  }
+]

--- a/apps/data-processing/data/synthetic_test/projects.json
+++ b/apps/data-processing/data/synthetic_test/projects.json
@@ -1,0 +1,42 @@
+[
+  {
+    "project_id": 10001,
+    "contract_id": "CONTRACT_10001",
+    "owner": "GL2DSURE6AJHS3MOYLJBP7UQ6LTVLDWKCBOIB6QSUG3O63O3LA2BK3S2",
+    "total_contributions": 11266.25,
+    "unique_contributors": 2,
+    "status": "funding",
+    "last_event_ledger": 200001,
+    "extra_data": {
+      "name": "PulseProject 1",
+      "slug": "pulse-project-1",
+      "symbol": "XLM",
+      "asset_code": "XLM",
+      "description": "Synthetic project supporting Stellar research and on-chain data.",
+      "aliases": [
+        "xlm",
+        "pulse-project-1"
+      ]
+    }
+  },
+  {
+    "project_id": 10002,
+    "contract_id": "CONTRACT_10002",
+    "owner": "GMDB5A6XVLTWL5X7AUZES7IA2ED22RJ3LEO7WBYFZ72GMZJ5MW6MACQ4",
+    "total_contributions": 8987.06,
+    "unique_contributors": 2,
+    "status": "active",
+    "last_event_ledger": 200002,
+    "extra_data": {
+      "name": "PulseProject 2",
+      "slug": "pulse-project-2",
+      "symbol": "BTC",
+      "asset_code": "BTC",
+      "description": "Synthetic project supporting Bitcoin research and on-chain data.",
+      "aliases": [
+        "btc",
+        "pulse-project-2"
+      ]
+    }
+  }
+]

--- a/apps/data-processing/data/synthetic_test/social_posts.json
+++ b/apps/data-processing/data/synthetic_test/social_posts.json
@@ -1,0 +1,56 @@
+[
+  {
+    "post_id": "synthetic_post_00001",
+    "platform": "reddit",
+    "content": "Users are discussing projected staking yields. #BTC #LumenPulse",
+    "author": "synthetic_user_1",
+    "url": "https://synthetic.social/reddit/00001",
+    "likes": 932,
+    "comments": 137,
+    "shares": 474,
+    "asset_codes": [
+      "BTC"
+    ],
+    "primary_asset": "BTC",
+    "hashtags": [
+      "BTC",
+      "LumenPulse",
+      "synthetic"
+    ],
+    "sentiment_score": 0.132,
+    "positive_score": 0.132,
+    "negative_score": 0.0,
+    "neutral_score": 0.868,
+    "sentiment_label": "neutral",
+    "posted_at": "2026-06-20T16:36:07.654147+00:00",
+    "fetched_at": "2026-06-23T16:36:07.654183+00:00",
+    "analyzed_at": "2026-06-23T16:36:07.654187+00:00"
+  },
+  {
+    "post_id": "synthetic_post_00002",
+    "platform": "twitter",
+    "content": "A new dApp proposal is driving positive momentum. #BTC #LumenPulse",
+    "author": "synthetic_user_2",
+    "url": "https://synthetic.social/twitter/00002",
+    "likes": 118,
+    "comments": 1,
+    "shares": 193,
+    "asset_codes": [
+      "BTC"
+    ],
+    "primary_asset": "BTC",
+    "hashtags": [
+      "BTC",
+      "LumenPulse",
+      "synthetic"
+    ],
+    "sentiment_score": 0.582,
+    "positive_score": 0.582,
+    "negative_score": 0.0,
+    "neutral_score": 0.418,
+    "sentiment_label": "positive",
+    "posted_at": "2026-06-19T14:36:07.654193+00:00",
+    "fetched_at": "2026-06-23T16:36:07.654246+00:00",
+    "analyzed_at": "2026-06-23T16:36:07.654251+00:00"
+  }
+]

--- a/apps/data-processing/scripts/generate_synthetic_data.py
+++ b/apps/data-processing/scripts/generate_synthetic_data.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""
+Synthetic dataset generator for LumenPulse data processing.
+
+Usage:
+    python scripts/generate_synthetic_data.py --seed 42 --project-count 10 \
+        --contributors-per-project 8 --articles 120 --social-posts 80 \
+        --analytics-records 60 --contract-events 40 --output-dir data/synthetic
+
+    python scripts/generate_synthetic_data.py --save-to-db
+"""
+
+import argparse
+import json
+import random
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT_DIR = SCRIPT_DIR.parent
+SRC_DIR = ROOT_DIR / "src"
+
+sys.path.insert(0, str(SRC_DIR))
+
+SYNTHETIC_SOURCE = "SyntheticDataGenerator"
+ASSET_CANDIDATES = [
+    {"symbol": "XLM", "asset_code": "XLM", "name": "Stellar", "categories": ["payments", "layer1"]},
+    {"symbol": "BTC", "asset_code": "BTC", "name": "Bitcoin", "categories": ["store-of-value", "layer1"]},
+    {"symbol": "ETH", "asset_code": "ETH", "name": "Ethereum", "categories": ["smart-contracts", "layer1"]},
+    {"symbol": "SOL", "asset_code": "SOL", "name": "Solana", "categories": ["smart-contracts", "layer1"]},
+    {"symbol": "ADA", "asset_code": "ADA", "name": "Cardano", "categories": ["smart-contracts", "layer1"]},
+    {"symbol": "DOT", "asset_code": "DOT", "name": "Polkadot", "categories": ["interoperability", "layer1"]},
+]
+PROJECT_STATUSES = ["active", "funding", "completed", "pending"]
+EVENT_TYPES = ["contribution", "reward_granted", "milestone_approved", "submission_minted"]
+SOCIAL_PLATFORMS = ["twitter", "reddit"]
+TREND_WINDOWS = ["1h", "24h", "7d"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate repeatable synthetic datasets for LumenPulse dashboards and APIs."
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Random seed for repeatable data")
+    parser.add_argument("--project-count", type=int, default=8, help="Number of synthetic projects to create")
+    parser.add_argument(
+        "--contributors-per-project",
+        type=int,
+        default=6,
+        help="Average number of unique contributors per synthetic project",
+    )
+    parser.add_argument("--milestones-per-project", type=int, default=3, help="Number of milestones per synthetic project")
+    parser.add_argument("--articles", type=int, default=80, help="Number of synthetic articles to generate")
+    parser.add_argument("--social-posts", type=int, default=80, help="Number of synthetic social posts to generate")
+    parser.add_argument("--analytics-records", type=int, default=50, help="Number of synthetic analytics records to generate")
+    parser.add_argument("--contract-events", type=int, default=50, help="Number of synthetic contract events to generate")
+    parser.add_argument("--output-dir", default="data/synthetic", help="Directory to write synthetic JSON data files")
+    parser.add_argument(
+        "--save-to-db",
+        action="store_true",
+        help="Persist generated synthetic data into the configured PostgreSQL database",
+    )
+    parser.add_argument(
+        "--create-tables",
+        action="store_true",
+        help="Create database tables before saving synthetic data",
+    )
+    return parser.parse_args()
+
+
+def deterministic_stellar_address(index: int) -> str:
+    alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+    random.seed(index)
+    address = "G" + "".join(random.choices(alphabet, k=55))
+    return address
+
+
+def project_name_for_id(project_id: int) -> str:
+    return f"PulseProject {project_id}"
+
+
+def project_slug_for_id(project_id: int) -> str:
+    return f"pulse-project-{project_id}"
+
+
+def contract_id_for_project(project_id: int) -> str:
+    return f"CONTRACT_{project_id:05d}"
+
+
+def build_projects(project_count: int) -> List[Dict[str, Any]]:
+    projects: List[Dict[str, Any]] = []
+    for idx in range(1, project_count + 1):
+        base_asset = ASSET_CANDIDATES[(idx - 1) % len(ASSET_CANDIDATES)]
+        projects.append(
+            {
+                "project_id": 10000 + idx,
+                "contract_id": contract_id_for_project(10000 + idx),
+                "owner": deterministic_stellar_address(10000 + idx),
+                "status": random.choice(PROJECT_STATUSES),
+                "last_event_ledger": 200000 + idx,
+                "extra_data": {
+                    "name": project_name_for_id(idx),
+                    "slug": project_slug_for_id(idx),
+                    "symbol": base_asset["asset_code"],
+                    "asset_code": base_asset["asset_code"],
+                    "description": f"Synthetic project supporting {base_asset['name']} research and on-chain data.",
+                    "aliases": [
+                        base_asset["asset_code"].lower(),
+                        project_slug_for_id(idx),
+                    ],
+                },
+            }
+        )
+    return projects
+
+
+def build_project_contributors(
+    projects: List[Dict[str, Any]], contributors_per_project: int
+) -> List[Dict[str, Any]]:
+    contributors = []
+    contribution_id = 1
+    for project in projects:
+        for idx in range(1, contributors_per_project + 1):
+            contributors.append(
+                {
+                    "project_id": project["project_id"],
+                    "contributor": deterministic_stellar_address(
+                        project["project_id"] * 100 + idx
+                    ),
+                    "total_contributed": round(random.uniform(300.0, 6800.0), 2),
+                    "first_contribution_ledger": project["last_event_ledger"] + contribution_id,
+                    "last_contribution_ledger": project["last_event_ledger"] + contribution_id + 1,
+                    "extra_data": {
+                        "handle": f"contributor_{project['project_id']}_{idx}",
+                    },
+                }
+            )
+            contribution_id += 2
+    return contributors
+
+
+def build_project_views(
+    projects: List[Dict[str, Any]], contributors: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    views: List[Dict[str, Any]] = []
+    by_project = {}
+    for contributor in contributors:
+        by_project.setdefault(contributor["project_id"], []).append(contributor)
+
+    for project in projects:
+        assets = project["extra_data"]["asset_code"]
+        project_contributors = by_project.get(project["project_id"], [])
+        total = round(sum(c["total_contributed"] for c in project_contributors), 2)
+        views.append(
+            {
+                "project_id": project["project_id"],
+                "contract_id": project["contract_id"],
+                "owner": project["owner"],
+                "total_contributions": total,
+                "unique_contributors": len(project_contributors),
+                "status": project["status"],
+                "last_event_ledger": project["last_event_ledger"],
+                "extra_data": project["extra_data"],
+            }
+        )
+    return views
+
+
+def build_project_milestones(
+    projects: List[Dict[str, Any]], milestones_per_project: int
+) -> List[Dict[str, Any]]:
+    milestones: List[Dict[str, Any]] = []
+    for project in projects:
+        for idx in range(1, milestones_per_project + 1):
+            status = random.choice(["pending", "approved", "rejected"])
+            approved_at = None
+            if status == "approved":
+                approved_at = (datetime.now(timezone.utc) - timedelta(days=random.randint(1, 14))).isoformat()
+            milestones.append(
+                {
+                    "project_id": project["project_id"],
+                    "milestone_id": idx,
+                    "status": status,
+                    "approved_at": approved_at,
+                    "last_event_ledger": project["last_event_ledger"] + idx,
+                    "extra_data": {
+                        "title": f"Milestone {idx} for {project['extra_data']['slug']}",
+                        "description": f"Synthetic milestone measuring community adoption and technical progress.",
+                    },
+                }
+            )
+    return milestones
+
+
+def build_contract_events(
+    projects: List[Dict[str, Any]], contributors: List[Dict[str, Any]], contract_events: int
+) -> List[Dict[str, Any]]:
+    events: List[Dict[str, Any]] = []
+    candidate_contributors = contributors or []
+    for idx in range(1, contract_events + 1):
+        project = random.choice(projects)
+        contributor = random.choice(candidate_contributors)
+        event_type = random.choice(EVENT_TYPES)
+        amount = round(random.uniform(20.0, 2000.0), 2)
+        status = "completed" if event_type != "milestone_approved" else random.choice(["approved", "pending"])
+        events.append(
+            {
+                "contract_id": project["contract_id"],
+                "event_id": f"synthetic_event_{idx:05d}",
+                "ledger": project["last_event_ledger"] + idx,
+                "event_type": event_type,
+                "project_id": project["project_id"],
+                "contributor": contributor["contributor"],
+                "amount": amount,
+                "milestone_id": random.randint(1, 3),
+                "status": status,
+                "topics": [project["extra_data"]["asset_code"], event_type],
+                "raw_data": {
+                    "summary": f"Synthetic {event_type} event for {project['extra_data']['slug']}",
+                    "details": {
+                        "contribution_reason": "stress test data generation",
+                        "metric": random.choice(["velocity", "growth", "engagement"]),
+                    },
+                },
+                "timestamp": (datetime.now(timezone.utc) - timedelta(hours=random.randint(0, 96))).isoformat(),
+            }
+        )
+    return events
+
+
+def build_articles(projects: List[Dict[str, Any]], total_articles: int) -> List[Dict[str, Any]]:
+    articles: List[Dict[str, Any]] = []
+    sentences = [
+        "Market momentum is shifting as traders digest the latest on-chain activity.",
+        "Community sentiment remains upbeat after the most recent protocol upgrade.",
+        "Developers are closely watching liquidity metrics and reward incentives.",
+        "New wallet inflows signal investor interest ahead of the next governance vote.",
+        "Synthetic analysis shows a stable trend in asset performance this week.",
+    ]
+
+    for idx in range(1, total_articles + 1):
+        project = random.choice(projects)
+        published_delta = random.randint(0, 14)
+        published_at = (datetime.now(timezone.utc) - timedelta(days=published_delta, hours=random.randint(0, 23))).isoformat()
+        sentiment_score = round(random.uniform(-1.0, 1.0), 3)
+        label = "positive" if sentiment_score > 0.2 else "negative" if sentiment_score < -0.2 else "neutral"
+        symbol = project["extra_data"]["asset_code"]
+        articles.append(
+            {
+                "article_id": f"synthetic_article_{idx:05d}",
+                "title": f"{project['extra_data']['name']} Update: {sentences[idx % len(sentences)]}",
+                "content": f"{sentences[idx % len(sentences)]} This synthetic article is designed for local development and stress testing.",
+                "summary": f"Synthetic news item about {symbol} and community contributions.",
+                "source": SYNTHETIC_SOURCE,
+                "url": f"https://synthetic.lumenpulse.dev/article/{idx:05d}",
+                "asset_codes": [symbol],
+                "primary_asset": symbol,
+                "categories": ["synthetic", "news", "crypto"],
+                "sentiment_score": sentiment_score,
+                "positive_score": round(max(0.0, sentiment_score), 3),
+                "negative_score": round(max(0.0, -sentiment_score), 3),
+                "neutral_score": round(1.0 - abs(sentiment_score), 3),
+                "sentiment_label": label,
+                "keywords": [symbol, "synthetic", "portfolio"],
+                "detected_entities": [symbol, project["extra_data"]["name"]],
+                "onchain_entity_links": [
+                    {
+                        "stable_entity_id": f"project:{project['project_id']}",
+                        "entity_type": "project",
+                        "display_name": project["extra_data"]["name"],
+                        "matched_text": project["extra_data"]["name"],
+                        "confidence": 0.95,
+                        "source": SYNTHETIC_SOURCE,
+                        "asset_code": symbol,
+                        "project_id": project["project_id"],
+                        "contract_id": project["contract_id"],
+                    }
+                ],
+                "language": "en",
+                "published_at": published_at,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+                "analyzed_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+    return articles
+
+
+def build_social_posts(projects: List[Dict[str, Any]], total_posts: int) -> List[Dict[str, Any]]:
+    posts: List[Dict[str, Any]] = []
+    messages = [
+        "Community reward mechanics are moving ahead.",
+        "Users are discussing projected staking yields.",
+        "A new dApp proposal is driving positive momentum.",
+        "A governance update could improve network utility.",
+        "A liability risk signal is drawing analyst attention.",
+    ]
+
+    for idx in range(1, total_posts + 1):
+        project = random.choice(projects)
+        posted_at = (datetime.now(timezone.utc) - timedelta(hours=random.randint(1, 120))).isoformat()
+        sentiment_score = round(random.uniform(-1.0, 1.0), 3)
+        label = "positive" if sentiment_score > 0.2 else "negative" if sentiment_score < -0.2 else "neutral"
+        platform = random.choice(SOCIAL_PLATFORMS)
+        symbol = project["extra_data"]["asset_code"]
+        posts.append(
+            {
+                "post_id": f"synthetic_post_{idx:05d}",
+                "platform": platform,
+                "content": f"{messages[idx % len(messages)]} #{symbol} #LumenPulse",
+                "author": f"synthetic_user_{idx}",
+                "url": f"https://synthetic.social/{platform}/{idx:05d}",
+                "likes": random.randint(0, 1500),
+                "comments": random.randint(0, 200),
+                "shares": random.randint(0, 500),
+                "asset_codes": [symbol],
+                "primary_asset": symbol,
+                "hashtags": [symbol, "LumenPulse", "synthetic"],
+                "sentiment_score": sentiment_score,
+                "positive_score": round(max(0.0, sentiment_score), 3),
+                "negative_score": round(max(0.0, -sentiment_score), 3),
+                "neutral_score": round(1.0 - abs(sentiment_score), 3),
+                "sentiment_label": label,
+                "posted_at": posted_at,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+                "analyzed_at": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+    return posts
+
+
+def build_analytics_records(projects: List[Dict[str, Any]], total_records: int) -> List[Dict[str, Any]]:
+    records: List[Dict[str, Any]] = []
+    metric_names = ["sentiment_score", "volume", "price_change", "engagement"]
+    for idx in range(1, total_records + 1):
+        project = random.choice(projects)
+        asset = project["extra_data"]["asset_code"]
+        current_value = round(random.uniform(0.1, 98.0), 3)
+        previous_value = round(current_value * random.uniform(0.8, 1.2), 3)
+        change = round(((current_value - previous_value) / max(previous_value, 1e-6)) * 100.0, 2)
+        if change > 2:
+            trend_direction = "up"
+        elif change < -2:
+            trend_direction = "down"
+        else:
+            trend_direction = "stable"
+        records.append(
+            {
+                "record_type": random.choice(["sentiment_summary", "trend", "volume_snapshot"]),
+                "asset": asset,
+                "metric_name": random.choice(metric_names),
+                "window": random.choice(TREND_WINDOWS),
+                "value": current_value,
+                "previous_value": previous_value,
+                "change_percentage": change,
+                "trend_direction": trend_direction,
+                "extra_data": {
+                    "source": SYNTHETIC_SOURCE,
+                    "project_slug": project["extra_data"]["slug"],
+                },
+                "timestamp": (datetime.now(timezone.utc) - timedelta(minutes=random.randint(0, 360))).isoformat(),
+            }
+        )
+    return records
+
+
+def dump_json(data: List[Dict[str, Any]], output_dir: Path, filename: str) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    file_path = output_dir / filename
+    with file_path.open("w", encoding="utf-8") as file_handle:
+        json.dump(data, file_handle, indent=2, default=str)
+    print(f"Wrote {len(data)} records to {file_path}")
+
+
+def write_all(output_dir: Path, dataset: Dict[str, List[Dict[str, Any]]]) -> None:
+    for filename, payload in dataset.items():
+        dump_json(payload, output_dir, filename)
+
+
+def instantiate_model(model_cls: Any, payload: Dict[str, Any]) -> Any:
+    return model_cls(**payload)
+
+
+def save_dataset_to_db(dataset: Dict[str, List[Dict[str, Any]]], create_tables: bool = False) -> None:
+    try:
+        from src.db.models import (
+            AnalyticsRecord,
+            Article,
+            ContractEvent,
+            ProjectContributor,
+            ProjectMilestone,
+            ProjectView,
+            SocialPost,
+        )
+        from src.db.postgres_service import PostgresService
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "Cannot persist synthetic data because database dependencies are missing. "
+            "Install requirements and ensure SQLAlchemy/psycopg2 are available."
+        ) from exc
+
+    db_service = PostgresService()
+    if create_tables:
+        db_service.create_tables()
+    with db_service.get_session() as session:
+        mapping = {
+            "projects.json": ProjectView,
+            "project_contributors.json": ProjectContributor,
+            "project_milestones.json": ProjectMilestone,
+            "articles.json": Article,
+            "social_posts.json": SocialPost,
+            "analytics_records.json": AnalyticsRecord,
+            "contract_events.json": ContractEvent,
+        }
+        for file_name, rows in dataset.items():
+            model_cls = mapping.get(file_name)
+            if not model_cls:
+                continue
+            objects = [instantiate_model(model_cls, row) for row in rows]
+            session.add_all(objects)
+            print(f"Persisted {len(objects)} {model_cls.__name__} records")
+
+
+def main() -> int:
+    args = parse_args()
+    random.seed(args.seed)
+
+    print("Generating synthetic dataset with seed", args.seed)
+    projects = build_projects(args.project_count)
+    contributors = build_project_contributors(projects, args.contributors_per_project)
+    project_views = build_project_views(projects, contributors)
+    milestones = build_project_milestones(projects, args.milestones_per_project)
+    articles = build_articles(projects, args.articles)
+    social_posts = build_social_posts(projects, args.social_posts)
+    analytics_records = build_analytics_records(projects, args.analytics_records)
+    contract_events = build_contract_events(projects, contributors, args.contract_events)
+
+    output_dir = Path(args.output_dir)
+    dataset = {
+        "projects.json": project_views,
+        "project_contributors.json": contributors,
+        "project_milestones.json": milestones,
+        "articles.json": articles,
+        "social_posts.json": social_posts,
+        "analytics_records.json": analytics_records,
+        "contract_events.json": contract_events,
+    }
+
+    write_all(output_dir, dataset)
+
+    if args.save_to_db:
+        print("Saving synthetic data to PostgreSQL database...")
+        save_dataset_to_db(dataset, create_tables=args.create_tables)
+        print("Synthetic data persisted to database")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/data-processing/tests/test_synthetic_data_generator.py
+++ b/apps/data-processing/tests/test_synthetic_data_generator.py
@@ -1,0 +1,52 @@
+import json
+import random
+from pathlib import Path
+
+from scripts.generate_synthetic_data import (
+    build_articles,
+    build_contract_events,
+    build_project_contributors,
+    build_project_milestones,
+    build_project_views,
+    build_projects,
+    build_social_posts,
+    build_analytics_records,
+    dump_json,
+)
+
+
+def test_synthetic_generator_produces_repeatable_projects():
+    random.seed(42)
+    projects_a = build_projects(5)
+    random.seed(42)
+    projects_b = build_projects(5)
+
+    assert projects_a == projects_b
+    assert len(projects_a) == 5
+    assert projects_a[0]["project_id"] == 10001
+
+
+def test_synthetic_generator_writes_json_files(tmp_path: Path):
+    random.seed(42)
+    projects = build_projects(2)
+    contributors = build_project_contributors(projects, 2)
+    views = build_project_views(projects, contributors)
+    articles = build_articles(projects, 3)
+    social_posts = build_social_posts(projects, 2)
+    analytics_records = build_analytics_records(projects, 2)
+    milestones = build_project_milestones(projects, 1)
+    contract_events = build_contract_events(projects, contributors, 2)
+
+    output_dir = tmp_path / "synthetic"
+    dump_json(projects, output_dir, "projects.json")
+    dump_json(views, output_dir, "project_views.json")
+    dump_json(articles, output_dir, "articles.json")
+    dump_json(social_posts, output_dir, "social_posts.json")
+    dump_json(analytics_records, output_dir, "analytics_records.json")
+    dump_json(milestones, output_dir, "project_milestones.json")
+    dump_json(contract_events, output_dir, "contract_events.json")
+
+    files = list(output_dir.glob("*.json"))
+    assert len(files) == 7
+    loaded = json.loads((output_dir / "projects.json").read_text(encoding="utf-8"))
+    assert loaded[0]["project_id"] == 10001

--- a/document/LOCAL_SETUP.md
+++ b/document/LOCAL_SETUP.md
@@ -395,6 +395,24 @@ npx ts-node deploy.ts
 
 The backend does not ship an automatic seed script yet. To populate basic data for local testing, run the backend with `USE_MOCK_TRANSACTIONS=true` (already set in the example `.env`). This flag makes the portfolio and transaction endpoints return synthetic Stellar data without requiring live on-chain calls.
 
+### Synthetic datasets for dashboards and APIs
+
+The data-processing service includes a synthetic dataset generator for local stress testing and API validation. Run it from `apps/data-processing`:
+
+```bash
+python scripts/generate_synthetic_data.py \
+  --seed 42 \
+  --project-count 10 \
+  --contributors-per-project 5 \
+  --articles 80 \
+  --social-posts 80 \
+  --analytics-records 50 \
+  --contract-events 40 \
+  --output-dir data/synthetic
+```
+
+The generated files are stored under `apps/data-processing/data/synthetic`, keeping test data distinct from real ingested news.
+
 ### Testnet XLM
 
 Use the [Stellar Friendbot](https://laboratory.stellar.org/#?network=test) to fund any testnet address with 10,000 XLM. This is free and instant.


### PR DESCRIPTION
closes
#881 

Add [generate_synthetic_data.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Support configurable project/contributor/article/social/analytics/contract event counts
Keep synthetic data separate via dedicated JSON output
Add unit tests for repeatability and JSON output
Document usage in [README.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [LOCAL_SETUP.md](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)