### PR TITLE
feat: add background auto-refresh for wallet views

### DIFF
--- a/apps/mobile/app/(tabs)/portfolio.tsx
+++ b/apps/mobile/app/(tabs)/portfolio.tsx
@@ -17,6 +17,7 @@ import { transactionApi } from '../../lib/transaction';
 import { Transaction, TransactionType } from '../../lib/types/transaction';
 import { useCachedData } from '../../hooks/useCachedData';
 import { CACHE_CONFIGS } from '../../lib/cache';
+import { useWalletAutoRefresh } from '../../hooks/useWalletAutoRefresh';
 
 function formatUsd(value: string | number): string {
   const num = typeof value === 'string' ? parseFloat(value) : value;
@@ -163,6 +164,18 @@ export default function PortfolioScreen() {
   const transactions = transactionData || [];
   const loading = summaryLoading && transactionsLoading;
   const [refreshing, setRefreshing] = useState(false);
+
+  // Background auto-refresh: aligned to TRANSACTIONS TTL (2 min, the shorter
+  // of the two) so both portfolio and transactions are refreshed before stale.
+  const handleAutoRefresh = useCallback(async () => {
+    await Promise.all([refreshSummary(), refreshTransactions()]);
+  }, [refreshSummary, refreshTransactions]);
+
+  useWalletAutoRefresh({
+    intervalMs: CACHE_CONFIGS.TRANSACTIONS.ttl,
+    onRefresh: handleAutoRefresh,
+    enabled: isAuthenticated,
+  });
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);

--- a/apps/mobile/app/(tabs)/transaction-history.tsx
+++ b/apps/mobile/app/(tabs)/transaction-history.tsx
@@ -8,6 +8,8 @@ import { transactionApi } from '../../lib/transaction';
 import { Transaction, TransactionType } from '../../lib/types/transaction';
 import StandardList from '@/components/StandardList';
 import { buildExplorerUrl } from '../../lib/stellar';
+import { CACHE_CONFIGS } from '../../lib/cache';
+import { useWalletAutoRefresh } from '../../hooks/useWalletAutoRefresh';
 
 function formatAmount(amount: string, assetCode: string): string {
   const num = parseFloat(amount);
@@ -192,6 +194,16 @@ export default function TransactionHistoryScreen() {
   useEffect(() => {
     if (isAuthenticated) fetchTransactions(true);
   }, [isAuthenticated, fetchTransactions]);
+
+  // Background auto-refresh: aligned to TRANSACTIONS TTL (2 min).
+  // fetchTransactions(true) is already error-safe and swallows network failures.
+  const handleAutoRefresh = useCallback(() => fetchTransactions(true), [fetchTransactions]);
+
+  useWalletAutoRefresh({
+    intervalMs: CACHE_CONFIGS.TRANSACTIONS.ttl,
+    onRefresh: handleAutoRefresh,
+    enabled: isAuthenticated,
+  });
 
   const handleLoadMore = () => {
     if (nextPage && !isLoading) fetchTransactions(false);

--- a/apps/mobile/hooks/useWalletAutoRefresh.ts
+++ b/apps/mobile/hooks/useWalletAutoRefresh.ts
@@ -1,0 +1,81 @@
+import { useEffect, useRef } from 'react';
+import { AppState, AppStateStatus } from 'react-native';
+import { cache } from '../lib/cache';
+
+export interface WalletAutoRefreshOptions {
+  /** How often to attempt a refresh while the app is active (ms). */
+  intervalMs: number;
+  /** Called when the interval fires and conditions are met. Must be stable (useCallback). */
+  onRefresh: () => void | Promise<void>;
+  /** Pass false to disable (e.g. user is not authenticated). */
+  enabled?: boolean;
+}
+
+/**
+ * Runs `onRefresh` on a bounded interval only while the app is in the
+ * foreground and the device is online.  Stops ticking when the app goes
+ * to the background, preventing battery drain.
+ *
+ * Error handling is left to the caller — a thrown error from `onRefresh`
+ * will be caught here and silently suppressed so foreground UI is not
+ * affected by a background refresh failure.
+ */
+export function useWalletAutoRefresh({
+  intervalMs,
+  onRefresh,
+  enabled = true,
+}: WalletAutoRefreshOptions): void {
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+
+  // Keep a stable ref to the latest callback so the interval closure never
+  // captures a stale version without needing to restart the interval.
+  const onRefreshRef = useRef(onRefresh);
+  useEffect(() => {
+    onRefreshRef.current = onRefresh;
+  }, [onRefresh]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const startInterval = () => {
+      if (timerRef.current !== null) return; // already running
+      timerRef.current = setInterval(() => {
+        // Only refresh when online; offline state is handled by useCachedData
+        if (!cache.isOnlineStatus()) return;
+        Promise.resolve()
+          .then(() => onRefreshRef.current())
+          .catch(() => {
+            // Silently swallow background refresh errors — foreground
+            // error states are owned by the individual data hooks.
+          });
+      }, intervalMs);
+    };
+
+    const stopInterval = () => {
+      if (timerRef.current !== null) {
+        clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+
+    // Start immediately if already active
+    if (appStateRef.current === 'active') {
+      startInterval();
+    }
+
+    const subscription = AppState.addEventListener('change', (nextState: AppStateStatus) => {
+      appStateRef.current = nextState;
+      if (nextState === 'active') {
+        startInterval();
+      } else {
+        stopInterval();
+      }
+    });
+
+    return () => {
+      stopInterval();
+      subscription.remove();
+    };
+  }, [enabled, intervalMs]);
+}


### PR DESCRIPTION
Closes #895

---

Keeps portfolio balances and transaction history fresh without requiring manual pull-to-refresh.
  
  Changes
  
  - hooks/useWalletAutoRefresh.ts — new hook that runs a refresh callback on a fixed interval, gated by AppState (stops when app is
  backgrounded) and NetInfo (skips when offline). Errors from background refreshes are silently suppressed.
  - portfolio.tsx — wired in with a 2-minute interval (aligned to TRANSACTIONS TTL), refreshing both summary and recent transactions.
  - transaction-history.tsx — wired in with the same 2-minute interval.
  
  Behaviour
  
  - Interval fires every 2 minutes only while the app is in the foreground
  - Skips fetch when device is offline — cached data and the stale indicator banner handle that case
  - Background refresh errors are swallowed; they cannot break the foreground UI
  - Pull-to-refresh still works independently.
  
closes @#895
