### PR TITLE
feat(matching_pool): round contribution caps and anti-whale guardrails

### DIFF
--- a/apps/onchain/contracts/matching_pool/src/errors.rs
+++ b/apps/onchain/contracts/matching_pool/src/errors.rs
@@ -21,4 +21,11 @@ pub enum MatchingPoolError {
     InvalidRoundDates = 15,
     ContractPaused = 16,
     Reentrancy = 17,
+    /// Contribution would exceed the round-level total cap
+    RoundCapExceeded = 18,
+    /// Contribution would exceed the per-contributor (anti-whale) cap
+    ContributorCapExceeded = 19,
+    /// Cap value must be non-negative
+    InvalidCapValue = 20,
 }
+

--- a/apps/onchain/contracts/matching_pool/src/events.rs
+++ b/apps/onchain/contracts/matching_pool/src/events.rs
@@ -69,3 +69,27 @@ pub struct AllMatchesDistributedEvent {
     pub round_id: u64,
     pub total_distributed: i128,
 }
+
+/// Emitted when an admin configures or updates contribution caps for a round.
+#[contractevent]
+pub struct CapConfiguredEvent {
+    #[topic]
+    pub round_id: u64,
+    pub round_total_cap: i128,
+    pub per_contributor_cap: i128,
+}
+
+/// Emitted when a contribution is partially accepted because the full amount
+/// would have exceeded a cap. `original_amount` is what was requested,
+/// `accepted_amount` is what was actually recorded.
+#[contractevent]
+pub struct ContributionCappedEvent {
+    #[topic]
+    pub round_id: u64,
+    #[topic]
+    pub project_id: u64,
+    pub contributor: Address,
+    pub original_amount: i128,
+    pub accepted_amount: i128,
+}
+

--- a/apps/onchain/contracts/matching_pool/src/lib.rs
+++ b/apps/onchain/contracts/matching_pool/src/lib.rs
@@ -10,7 +10,7 @@ use math::{sqrt_scaled, unscale};
 use reentrancy_guard::{acquire as acquire_reentrancy, release as release_reentrancy};
 use soroban_sdk::token::TokenClient;
 use soroban_sdk::{contract, contractimpl, vec, Address, BytesN, Env, Symbol, Vec};
-use storage::{DataKey, RoundData};
+use storage::{CapConfig, DataKey, RoundData};
 
 #[contract]
 pub struct MatchingPoolContract;
@@ -276,6 +276,55 @@ impl MatchingPoolContract {
         {
             return Err(MatchingPoolError::ProjectNotEligible);
         }
+
+        // ── Cap enforcement ──────────────────────────────────────────────
+        let mut effective_amount = amount;
+        let cap_config: Option<CapConfig> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RoundCapConfig(round_id));
+
+        if let Some(ref caps) = cap_config {
+            // Per-contributor (anti-whale) cap
+            if caps.per_contributor_cap > 0 {
+                let contributor_total_key =
+                    DataKey::ContributorRoundTotal(round_id, contributor.clone());
+                let contributor_total: i128 = env
+                    .storage()
+                    .persistent()
+                    .get(&contributor_total_key)
+                    .unwrap_or(0);
+                let headroom = caps.per_contributor_cap - contributor_total;
+                if headroom <= 0 {
+                    return Err(MatchingPoolError::ContributorCapExceeded);
+                }
+                if effective_amount > headroom {
+                    effective_amount = headroom;
+                }
+            }
+
+            // Round-level total cap
+            if caps.round_total_cap > 0 {
+                // Compute the aggregate round contributions across all projects.
+                let round_total = Self::get_round_contributions_total(&env, round_id);
+                let headroom = caps.round_total_cap - round_total;
+                if headroom <= 0 {
+                    return Err(MatchingPoolError::RoundCapExceeded);
+                }
+                if effective_amount > headroom {
+                    effective_amount = headroom;
+                }
+            }
+        }
+
+        // If caps reduced amount to zero, reject
+        if effective_amount <= 0 {
+            return Err(MatchingPoolError::RoundCapExceeded);
+        }
+
+        let was_capped = effective_amount < amount;
+        // ── End cap enforcement ──────────────────────────────────────────
+
         let contrib_key = DataKey::ContributorAmount(round_id, project_id, contributor.clone());
         let prev: i128 = env.storage().persistent().get(&contrib_key).unwrap_or(0);
         if prev == 0 {
@@ -289,17 +338,44 @@ impl MatchingPoolContract {
         }
         env.storage()
             .persistent()
-            .set(&contrib_key, &(prev + amount));
+            .set(&contrib_key, &(prev + effective_amount));
         let total_key = DataKey::ProjectContributions(round_id, project_id);
         let total: i128 = env.storage().persistent().get(&total_key).unwrap_or(0);
         env.storage()
             .persistent()
-            .set(&total_key, &(total + amount));
+            .set(&total_key, &(total + effective_amount));
+
+        // Update contributor round total for anti-whale tracking
+        if cap_config.is_some() {
+            let contributor_total_key =
+                DataKey::ContributorRoundTotal(round_id, contributor.clone());
+            let contributor_total: i128 = env
+                .storage()
+                .persistent()
+                .get(&contributor_total_key)
+                .unwrap_or(0);
+            env.storage().persistent().set(
+                &contributor_total_key,
+                &(contributor_total + effective_amount),
+            );
+        }
+
+        if was_capped {
+            events::ContributionCappedEvent {
+                round_id,
+                project_id,
+                contributor: contributor.clone(),
+                original_amount: amount,
+                accepted_amount: effective_amount,
+            }
+            .publish(&env);
+        }
+
         events::ContributionRecordedEvent {
             round_id,
             project_id,
             contributor,
-            amount,
+            amount: effective_amount,
         }
         .publish(&env);
         Ok(())
@@ -681,6 +757,118 @@ impl MatchingPoolContract {
         Self::require_admin(&env, &caller)?;
         env.deployer().update_current_contract_wasm(new_wasm_hash);
         Ok(())
+    }
+
+    // ── Contribution cap management ──────────────────────────────────────
+
+    /// Configure contribution caps for a round. Admin-only.
+    ///
+    /// - `round_total_cap`: Maximum aggregate contributions across all projects
+    ///   in the round. Pass 0 to disable the round-level cap.
+    /// - `per_contributor_cap`: Maximum total a single address may contribute
+    ///   across all projects in the round (anti-whale). Pass 0 to disable.
+    ///
+    /// Caps can be updated at any time before the round is finalized.
+    pub fn configure_round_caps(
+        env: Env,
+        admin: Address,
+        round_id: u64,
+        round_total_cap: i128,
+        per_contributor_cap: i128,
+    ) -> Result<(), MatchingPoolError> {
+        Self::require_admin(&env, &admin)?;
+        if round_total_cap < 0 || per_contributor_cap < 0 {
+            return Err(MatchingPoolError::InvalidCapValue);
+        }
+        let round: RoundData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Round(round_id))
+            .ok_or(MatchingPoolError::RoundNotFound)?;
+        if round.is_finalized {
+            return Err(MatchingPoolError::RoundAlreadyFinalized);
+        }
+        let config = CapConfig {
+            round_total_cap,
+            per_contributor_cap,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::RoundCapConfig(round_id), &config);
+        events::CapConfiguredEvent {
+            round_id,
+            round_total_cap,
+            per_contributor_cap,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Query the current cap configuration for a round.
+    /// Returns `CapConfig { round_total_cap: 0, per_contributor_cap: 0 }` if
+    /// no caps have been configured (i.e., unlimited).
+    pub fn get_round_caps(env: Env, round_id: u64) -> Result<CapConfig, MatchingPoolError> {
+        env.storage()
+            .persistent()
+            .get::<_, RoundData>(&DataKey::Round(round_id))
+            .ok_or(MatchingPoolError::RoundNotFound)?;
+        Ok(env
+            .storage()
+            .persistent()
+            .get(&DataKey::RoundCapConfig(round_id))
+            .unwrap_or(CapConfig {
+                round_total_cap: 0,
+                per_contributor_cap: 0,
+            }))
+    }
+
+    /// Query a contributor's total contributions across all projects in a round.
+    pub fn get_contributor_round_total(
+        env: Env,
+        round_id: u64,
+        contributor: Address,
+    ) -> Result<i128, MatchingPoolError> {
+        env.storage()
+            .persistent()
+            .get::<_, RoundData>(&DataKey::Round(round_id))
+            .ok_or(MatchingPoolError::RoundNotFound)?;
+        Ok(env
+            .storage()
+            .persistent()
+            .get(&DataKey::ContributorRoundTotal(round_id, contributor))
+            .unwrap_or(0))
+    }
+
+    /// Internal helper: sum all project contributions for a round.
+    fn get_round_contributions_total(env: &Env, round_id: u64) -> i128 {
+        let count: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EligibleProjectCount(round_id))
+            .unwrap_or(0);
+        let mut total: i128 = 0;
+        for i in 0..count {
+            let pid: u64 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::EligibleProjectAt(round_id, i))
+                .unwrap_or(u64::MAX);
+            if !env
+                .storage()
+                .persistent()
+                .get::<_, bool>(&DataKey::EligibleProject(round_id, pid))
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let project_total: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::ProjectContributions(round_id, pid))
+                .unwrap_or(0);
+            total = total.saturating_add(project_total);
+        }
+        total
     }
 }
 

--- a/apps/onchain/contracts/matching_pool/src/storage.rs
+++ b/apps/onchain/contracts/matching_pool/src/storage.rs
@@ -18,6 +18,10 @@ pub enum DataKey {
     ContributorAmount(u64, u64, Address), // (round_id, project_id, contributor) -> i128
     MatchDistributed(u64),                // round_id -> bool
     RoundStatus(u64),                     // round_id -> Symbol ("ACTIVE"|"FINALIZED"|"DISTRIBUTED")
+    /// Contribution cap configuration for a round
+    RoundCapConfig(u64),                  // round_id -> CapConfig
+    /// Tracks total contributions across all projects in a round per contributor
+    ContributorRoundTotal(u64, Address),  // (round_id, contributor) -> i128
 }
 
 /// Core data for a funding round
@@ -33,3 +37,16 @@ pub struct RoundData {
     pub is_finalized: bool,
     pub is_distributed: bool,
 }
+
+/// Configurable contribution cap settings for a round.
+///
+/// - `round_total_cap`: Maximum total contributions the round can accept (0 = unlimited).
+/// - `per_contributor_cap`: Maximum total a single contributor can give across all
+///   projects in the round (0 = unlimited). This is the anti-whale guardrail.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CapConfig {
+    pub round_total_cap: i128,
+    pub per_contributor_cap: i128,
+}
+

--- a/apps/onchain/contracts/matching_pool/src/test.rs
+++ b/apps/onchain/contracts/matching_pool/src/test.rs
@@ -484,3 +484,400 @@ fn test_fund_pool_cei_state_written_before_token_balance_assertion() {
     assert_eq!(client.get_pool_balance(&round_id), 250_000);
     assert_eq!(token.balance(&client.address), 250_000);
 }
+
+// ── Contribution caps & anti-whale guardrails ────────────────────────────────
+
+#[test]
+fn test_configure_caps_defaults_to_unlimited() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    let caps = client.get_round_caps(&round_id);
+    assert_eq!(caps.round_total_cap, 0);
+    assert_eq!(caps.per_contributor_cap, 0);
+}
+
+#[test]
+fn test_configure_caps_roundtrip() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    client.configure_round_caps(&admin, &round_id, &500_000, &50_000);
+    let caps = client.get_round_caps(&round_id);
+    assert_eq!(caps.round_total_cap, 500_000);
+    assert_eq!(caps.per_contributor_cap, 50_000);
+}
+
+#[test]
+fn test_configure_caps_rejects_negative() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    assert_eq!(
+        client.try_configure_round_caps(&admin, &round_id, &-1, &0),
+        Err(Ok(MatchingPoolError::InvalidCapValue))
+    );
+    assert_eq!(
+        client.try_configure_round_caps(&admin, &round_id, &0, &-1),
+        Err(Ok(MatchingPoolError::InvalidCapValue))
+    );
+}
+
+#[test]
+fn test_per_contributor_cap_exact_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+    client.configure_round_caps(&admin, &round_id, &0, &100);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+
+    // Exact cap value should succeed
+    client.record_contribution(&round_id, &1u64, &contributor, &100);
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 100);
+    assert_eq!(
+        client.get_contributor_round_total(&round_id, &contributor),
+        100
+    );
+
+    // Any further contribution should be rejected
+    assert_eq!(
+        client.try_record_contribution(&round_id, &1u64, &contributor, &1),
+        Err(Ok(MatchingPoolError::ContributorCapExceeded))
+    );
+}
+
+#[test]
+fn test_per_contributor_cap_bounds_excess() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+    // Anti-whale: cap at 100 per contributor
+    client.configure_round_caps(&admin, &round_id, &0, &100);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+
+    // Contribute 60, then try 80 → only 40 should be accepted
+    client.record_contribution(&round_id, &1u64, &contributor, &60);
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 60);
+
+    client.record_contribution(&round_id, &1u64, &contributor, &80);
+    // Should be clamped to 100 total
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 100);
+    assert_eq!(
+        client.get_contributor_round_total(&round_id, &contributor),
+        100
+    );
+}
+
+#[test]
+fn test_per_contributor_cap_across_projects() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+    client.approve_project(&admin, &round_id, &2u64);
+    // Anti-whale: 150 across all projects
+    client.configure_round_caps(&admin, &round_id, &0, &150);
+
+    let whale = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+
+    client.record_contribution(&round_id, &1u64, &whale, &100);
+    // 50 headroom left, request 80 → only 50 accepted
+    client.record_contribution(&round_id, &2u64, &whale, &80);
+
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 100);
+    assert_eq!(client.get_project_contributions(&round_id, &2u64), 50);
+    assert_eq!(client.get_contributor_round_total(&round_id, &whale), 150);
+}
+
+#[test]
+fn test_round_total_cap_exact_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+    // Round cap: 500 total
+    client.configure_round_caps(&admin, &round_id, &500, &0);
+
+    let c1 = Address::generate(&env);
+    let c2 = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+
+    client.record_contribution(&round_id, &1u64, &c1, &300);
+    client.record_contribution(&round_id, &1u64, &c2, &200);
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 500);
+
+    // Cap reached — new contribution should be rejected
+    let c3 = Address::generate(&env);
+    assert_eq!(
+        client.try_record_contribution(&round_id, &1u64, &c3, &1),
+        Err(Ok(MatchingPoolError::RoundCapExceeded))
+    );
+}
+
+#[test]
+fn test_round_total_cap_bounds_excess() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+    client.configure_round_caps(&admin, &round_id, &500, &0);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+
+    // Request 800 against a 500 cap → only 500 accepted
+    client.record_contribution(&round_id, &1u64, &contributor, &800);
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 500);
+}
+
+#[test]
+fn test_combined_caps_contributor_tighter() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+    // Round cap 1000, contributor cap 200 (tighter)
+    client.configure_round_caps(&admin, &round_id, &1000, &200);
+
+    let whale = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+
+    client.record_contribution(&round_id, &1u64, &whale, &500);
+    // Contributor cap bounds it to 200
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 200);
+}
+
+#[test]
+fn test_combined_caps_round_tighter() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+    // Round cap 100 (tighter), contributor cap 500
+    client.configure_round_caps(&admin, &round_id, &100, &500);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+
+    client.record_contribution(&round_id, &1u64, &contributor, &300);
+    // Round cap bounds it to 100
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 100);
+}
+
+#[test]
+fn test_caps_do_not_affect_other_contributors() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+    client.configure_round_caps(&admin, &round_id, &0, &100);
+
+    let c1 = Address::generate(&env);
+    let c2 = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+
+    client.record_contribution(&round_id, &1u64, &c1, &100);
+    // c1 is at cap, but c2 should still be able to contribute
+    client.record_contribution(&round_id, &1u64, &c2, &100);
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 200);
+}
+
+#[test]
+fn test_no_caps_contribution_unchanged() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+    // No caps configured — unlimited
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &999_999_999);
+    assert_eq!(
+        client.get_project_contributions(&round_id, &1u64),
+        999_999_999
+    );
+}
+
+#[test]
+fn test_caps_update_before_finalization() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    client.configure_round_caps(&admin, &round_id, &100, &50);
+    let caps = client.get_round_caps(&round_id);
+    assert_eq!(caps.round_total_cap, 100);
+    assert_eq!(caps.per_contributor_cap, 50);
+
+    // Update caps
+    client.configure_round_caps(&admin, &round_id, &200, &75);
+    let caps = client.get_round_caps(&round_id);
+    assert_eq!(caps.round_total_cap, 200);
+    assert_eq!(caps.per_contributor_cap, 75);
+}
+
+#[test]
+fn test_caps_rejected_on_finalized_round() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    env.ledger().set_timestamp(4000);
+    client.finalize_round(&admin, &round_id);
+
+    assert_eq!(
+        client.try_configure_round_caps(&admin, &round_id, &100, &50),
+        Err(Ok(MatchingPoolError::RoundAlreadyFinalized))
+    );
+}


### PR DESCRIPTION
## Summary

Closes #867

Introduces configurable contribution caps for matching rounds to reduce contribution skew during testnet experiments. Both round-level aggregate caps and per-contributor (anti-whale) caps are supported, with a bounded/clamp strategy for over-cap contributions.

## Changes

### Storage (`storage.rs`)
- Added `CapConfig` struct with `round_total_cap` and `per_contributor_cap` fields
- Added `RoundCapConfig(round_id)` data key for persisting cap configuration per round
- Added `ContributorRoundTotal(round_id, contributor)` data key for tracking individual contributor totals across all projects in a round

### Errors (`errors.rs`)
- `RoundCapExceeded` (18) — contribution would exceed the round-level total cap
- `ContributorCapExceeded` (19) — contribution would exceed the per-contributor (anti-whale) cap
- `InvalidCapValue` (20) — cap value must be non-negative

### Events (`events.rs`)
- `CapConfiguredEvent` — emitted when an admin configures or updates caps
- `ContributionCappedEvent` — emitted when a contribution is bounded by a cap (includes original and accepted amounts)

### Contract Logic (`lib.rs`)
- **`configure_round_caps(admin, round_id, round_total_cap, per_contributor_cap)`** — Admin-only function to set or update caps. Pass 0 to disable either cap. Can be updated any time before finalization.
- **`record_contribution`** — Enhanced with cap enforcement:
  - Per-contributor cap is checked first (anti-whale guardrail)
  - Round-level aggregate cap is checked second
  - Over-cap contributions are clamped to remaining headroom (bounded strategy)
  - If headroom is zero, the contribution is rejected
  - Contributor round totals are tracked when caps are configured
- **`get_round_caps(round_id)`** — Query current cap configuration (returns unlimited defaults if unconfigured)
- **`get_contributor_round_total(round_id, contributor)`** — Query a contributor's total contributions across all projects in a round

### Tests (`test.rs`)
Added 13 boundary-value tests:
- Default caps (unlimited)
- Cap configuration roundtrip
- Negative cap rejection
- Per-contributor cap exact boundary
- Per-contributor cap bounding excess
- Per-contributor cap across multiple projects
- Round total cap exact boundary
- Round total cap bounding excess
- Combined caps (contributor tighter)
- Combined caps (round tighter)
- Caps isolation between contributors
- Backward compatibility with uncapped rounds
- Cap update before finalization
- Cap rejection on finalized rounds

## Acceptance Criteria Checklist
- [x] Round-level caps are configurable
- [x] Over-cap contributions are bounded consistently (clamp strategy)
- [x] Cap state is queryable (`get_round_caps`, `get_contributor_round_total`)
- [x] Tests cover boundary values (13 tests)