### PR TITLE
feat(webapp): centralize Stellar explorer URL generation with contract support

### DIFF
--- a/apps/webapp/.env.local.example
+++ b/apps/webapp/.env.local.example
@@ -6,3 +6,7 @@ BACKEND_API_URL=http://localhost:3001
 # Public API base URL for client-side requests.
 # On Vercel, set this to the backend deployment URL for pages that call the API directly.
 NEXT_PUBLIC_API_URL=http://localhost:3001
+
+# Stellar explorer base URL used to generate links for accounts, transactions and contracts.
+# Defaults to https://stellar.expert/explorer if not set.
+# NEXT_PUBLIC_STELLAR_EXPLORER_URL=https://stellar.expert/explorer

--- a/apps/webapp/app/grants/components.tsx
+++ b/apps/webapp/app/grants/components.tsx
@@ -9,7 +9,7 @@ import { useWatchlist } from "@/contexts/WatchlistContext";
 import { TransactionReceiptModal } from "@/components/TransactionReceiptModal";
 import { signTransaction } from "@stellar/freighter-api";
 import { Address, Contract, TransactionBuilder, nativeToScVal, rpc } from "@stellar/stellar-sdk";
-import { getExplorerUrl } from "@/lib/utils";
+import { useExplorerUrl } from "@/hooks/useExplorerUrl";
 
 export interface GrantRound {
   id: number;
@@ -144,6 +144,7 @@ export function ProjectAllocationRow({
 
   const { config } = useStellarConfig();
   const { publicKey, status: walletStatus, connect: connectWallet } = useStellarWallet();
+  const buildExplorerUrl = useExplorerUrl();
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [amount, setAmount] = useState("");
@@ -286,6 +287,17 @@ export function ProjectAllocationRow({
         <div className="mt-2 p-4 rounded-xl border border-white/10 bg-white/[0.01] backdrop-blur-md space-y-4 transition-all duration-300">
           <div className="flex items-center justify-between">
             <h4 className="text-sm font-semibold text-white/80">Contribute to Project #{item.projectId}</h4>
+            {config?.contracts?.crowdfundVault && (
+              <a
+                href={buildExplorerUrl("contract", config.contracts.crowdfundVault)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[10px] text-primary/60 hover:text-primary underline underline-offset-2 transition-colors"
+                title="View Crowdfund Vault contract on explorer"
+              >
+                Vault ↗
+              </a>
+            )}
           </div>
 
           {!publicKey ? (

--- a/apps/webapp/components/navbar.tsx
+++ b/apps/webapp/components/navbar.tsx
@@ -8,11 +8,14 @@ import { WalletButton } from "./wallet-button";
 import { ThemeSelector } from "./theme-selector";
 import { WalletSwitcher } from "@/components/wallet-switcher";
 import { useStellarConfig } from "@/contexts/StellarConfigContext";
+import { useExplorerUrl } from "@/hooks/useExplorerUrl";
 
 export function Navbar() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { config } = useStellarConfig();
+  const buildExplorerUrl = useExplorerUrl();
   const isTestnet = config?.network === "testnet";
+  const vaultContractId = config?.contracts?.crowdfundVault;
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 bg-black/80 backdrop-blur-xl border-b border-primary/20">
@@ -101,7 +104,7 @@ export function Navbar() {
             <ThemeSelector variant="segmented" />
           </div>
 
-          {/* Testnet badge + Wallet Button */}
+          {/* Testnet badge + Contract link + Wallet Button */}
           <div className="hidden md:flex items-center gap-2">
             {isTestnet && (
               <span
@@ -111,6 +114,17 @@ export function Navbar() {
                 <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
                 Testnet
               </span>
+            )}
+            {vaultContractId && (
+              <a
+                href={buildExplorerUrl("contract", vaultContractId)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[10px] font-semibold bg-primary/10 text-primary/70 border border-primary/20 hover:bg-primary/20 hover:text-primary transition-colors"
+                title="View Crowdfund Vault contract on explorer"
+              >
+                Vault ↗
+              </a>
             )}
             <WalletButton />
           </div>
@@ -186,7 +200,7 @@ export function Navbar() {
               <span className="absolute bottom-0 left-0 w-full h-0.5 bg-[#db74cf] transform scale-x-0 origin-left transition-transform duration-300 group-hover:scale-x-100"></span>
             </Link>
 
-            {/* Testnet badge + Wallet connect in mobile menu */}
+            {/* Testnet badge + Contract link + Wallet connect in mobile menu */}
             <div className="w-full mt-2 flex flex-col items-center gap-2">
               {isTestnet && (
                 <span
@@ -197,7 +211,17 @@ export function Navbar() {
                   Testnet
                 </span>
               )}
-              <WalletButton className="w-full justify-center" />
+              {vaultContractId && (
+              <a
+                href={buildExplorerUrl("contract", vaultContractId)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[10px] font-semibold bg-primary/10 text-primary/70 border border-primary/20 hover:bg-primary/20 hover:text-primary transition-colors"
+              >
+                View Vault Contract ↗
+              </a>
+            )}
+            <WalletButton className="w-full justify-center" />
             </div>
 
             {/* Theme Selector in mobile menu */}

--- a/apps/webapp/hooks/useExplorerUrl.ts
+++ b/apps/webapp/hooks/useExplorerUrl.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useCallback } from "react";
+import { getExplorerUrl } from "@/lib/utils";
+import type { ExplorerDestination } from "@/lib/utils";
+import { useStellarConfig } from "@/contexts/StellarConfigContext";
+
+/**
+ * Returns a URL builder that automatically picks the correct Stellar
+ * network from the runtime config, so callers only provide the
+ * destination type and id.
+ *
+ * @example
+ * const buildUrl = useExplorerUrl();
+ * <a href={buildUrl("contract", vaultContractId)}>View on Explorer</a>
+ */
+export function useExplorerUrl() {
+  const { config } = useStellarConfig();
+  const network = (config?.network ?? "testnet") as "testnet" | "mainnet";
+
+  const buildUrl = useCallback(
+    (type: ExplorerDestination, id: string): string =>
+      getExplorerUrl(type, id, network),
+    [network]
+  );
+
+  return buildUrl;
+}

--- a/apps/webapp/lib/utils.ts
+++ b/apps/webapp/lib/utils.ts
@@ -19,13 +19,20 @@ export const formatNumber = (num: number) => {
 };
 
 // Stellar explorer URL helpers
-const STELLAR_EXPERT_BASE = "https://stellar.expert/explorer";
+// Override via NEXT_PUBLIC_STELLAR_EXPLORER_URL to switch explorer (e.g. stellar.expert, steexp.com).
+// Must be the base path before the /{network}/{type}/{id} segments.
+const STELLAR_EXPLORER_BASE =
+  process.env.NEXT_PUBLIC_STELLAR_EXPLORER_URL ?? "https://stellar.expert/explorer";
 
+/** Destination types supported by the Stellar explorer. */
+export type ExplorerDestination = "tx" | "account" | "contract";
+
+/** Build a Stellar explorer URL for transactions, accounts, or Soroban contracts. */
 export function getExplorerUrl(
-  type: "tx" | "account",
+  type: ExplorerDestination,
   id: string,
   network: "testnet" | "mainnet" = "testnet"
 ): string {
   const net = network === "mainnet" ? "public" : "testnet";
-  return `${STELLAR_EXPERT_BASE}/${net}/${type}/${id}`;
+  return `${STELLAR_EXPLORER_BASE}/${net}/${type}/${id}`;
 }


### PR DESCRIPTION
## Summary

Centralizes Stellar explorer URL generation so all account, transaction, and contract links stay consistent across the webapp.

## Changes

### Core
- **`lib/utils.ts`**: Extended `getExplorerUrl` to support `contract` destinations (in addition to `tx` and `account`). Made the explorer base URL configurable via `NEXT_PUBLIC_STELLAR_EXPLORER_URL` env var (defaults to `stellar.expert/explorer`). Exported `ExplorerDestination` type.

- **`hooks/useExplorerUrl.ts`** (new): React hook that reads the network from `useStellarConfig` and returns a URL builder that auto-fills the network parameter. Callers only pass type + id.

### Surface integration (2+ surfaces)
- **`app/grants/components.tsx`**: Added a "Vault ↗" explorer link next to the contribution form header, linking to the Crowdfund Vault contract on the explorer.
- **`components/navbar.tsx`**: Added a "Vault ↗" / "View Vault Contract ↗" badge in desktop/mobile nav, linking to the Crowdfund Vault contract on the explorer.

### Configuration
- **`.env.local.example`**: Added commented `NEXT_PUBLIC_STELLAR_EXPLORER_URL` entry with documentation.

## Acceptance Criteria

| Criteria | Status |
|---|---|
| Supports account, transaction, and contract destinations | ✅ `getExplorerUrl` accepts `"tx" | "account" | "contract"` |
| Used by at least two webapp surfaces | ✅ Grants page + Navbar (plus existing tx/account usage in wallet-button, transaction-detail, TransactionReceiptModal, dashboard) |
| Easy to switch explorer base URLs later | ✅ Single env var `NEXT_PUBLIC_STELLAR_EXPLORER_URL` |
| Avoids duplicated string construction | ✅ All explorer URLs flow through `getExplorerUrl` |

## Related

Closes #904