### PR TITLE
feat(grants): add matching round leaderboard aggregate API

### DIFF
--- a/apps/backend/src/grants/dto/grants.dto.ts
+++ b/apps/backend/src/grants/dto/grants.dto.ts
@@ -283,6 +283,125 @@ export class RoundSummaryDto {
   projects: ProjectAllocationDto[];
 }
 
+
+export class LeaderboardQueryDto {
+  @ApiProperty({
+    description: 'ID of the grant round',
+    example: 1,
+    required: true,
+  })
+  @IsNumber()
+  @IsInt()
+  @Min(0)
+  roundId: number;
+
+  @ApiProperty({
+    description: 'Maximum number of projects to return (top-N). Defaults to 10, max 100.',
+    example: 10,
+    required: false,
+    default: 10,
+  })
+  @IsNumber()
+  @IsInt()
+  @Min(1)
+  topN?: number = 10;
+
+  @ApiProperty({
+    description: 'Page number for pagination (1-indexed). Ignored when topN is set.',
+    example: 1,
+    required: false,
+    default: 1,
+  })
+  @IsNumber()
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({
+    description: 'Number of results per page. Defaults to 10, max 100.',
+    example: 10,
+    required: false,
+    default: 10,
+  })
+  @IsNumber()
+  @IsInt()
+  @Min(1)
+  limit?: number = 10;
+}
+
+export class LeaderboardEntryDto {
+  @ApiProperty({ description: 'Leaderboard rank (1-indexed)', example: 1 })
+  rank: number;
+
+  @ApiProperty({ description: 'Project ID', example: 42 })
+  projectId: number;
+
+  @ApiProperty({
+    description: 'Total contribution amount received (stroops)',
+    example: '150000000',
+  })
+  totalContributions: string;
+
+  @ApiProperty({
+    description: 'Number of unique contributors',
+    example: 25,
+  })
+  contributorCount: number;
+
+  @ApiProperty({
+    description: 'Quadratic Funding score',
+    example: '144.50',
+  })
+  qfScore: string;
+
+  @ApiProperty({
+    description: 'Estimated match amount from pool (stroops)',
+    example: '350000000',
+  })
+  estimatedMatch: string;
+
+  @ApiProperty({
+    description: 'Percentage share of the matching pool',
+    example: '18.4',
+  })
+  matchPercentage: string;
+}
+
+export class LeaderboardResponseDto {
+  @ApiProperty({ description: 'Grant round details', type: RoundDto })
+  round: RoundDto;
+
+  @ApiProperty({
+    description: 'Ranked list of projects for this round',
+    type: [LeaderboardEntryDto],
+  })
+  entries: LeaderboardEntryDto[];
+
+  @ApiProperty({
+    description: 'Total number of eligible projects in the round',
+    example: 42,
+  })
+  totalProjects: number;
+
+  @ApiProperty({
+    description: 'Total pool balance available for matching (stroops)',
+    example: '5000000000000',
+  })
+  poolBalance: string;
+
+  @ApiProperty({
+    description: 'Page number returned (1-indexed)',
+    example: 1,
+  })
+  page: number;
+
+  @ApiProperty({
+    description: 'Number of entries per page',
+    example: 10,
+  })
+  limit: number;
+}
+
 export class RoundExportDto extends RoundSummaryDto {
   @ApiProperty({
     description: 'List of all individual contributions in the round',

--- a/apps/backend/src/grants/grants-leaderboard.service.spec.ts
+++ b/apps/backend/src/grants/grants-leaderboard.service.spec.ts
@@ -1,0 +1,137 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { NotFoundException } from '@nestjs/common';
+import { GrantsService } from './grants.service';
+
+describe('GrantsService.getLeaderboard', () => {
+  let service: GrantsService;
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = 'test';
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        GrantsService,
+        { provide: ConfigService, useValue: { get: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<GrantsService>(GrantsService);
+
+    // Seed a round with 3 projects
+    const round = service.createRound({
+      name: 'Test Round',
+      tokenAddress: 'CTOKEN',
+      startTime: Math.floor(Date.now() / 1000) - 3600,
+      endTime: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    service.approveProject({ roundId: round.id, projectId: 1 });
+    service.approveProject({ roundId: round.id, projectId: 2 });
+    service.approveProject({ roundId: round.id, projectId: 3 });
+
+    // Project 1: 3 contributors
+    service.recordContribution({ roundId: round.id, projectId: 1, contributor: 'GA1', amount: '100' });
+    service.recordContribution({ roundId: round.id, projectId: 1, contributor: 'GB1', amount: '100' });
+    service.recordContribution({ roundId: round.id, projectId: 1, contributor: 'GC1', amount: '100' });
+
+    // Project 2: 1 contributor (lower QF score)
+    service.recordContribution({ roundId: round.id, projectId: 2, contributor: 'GA2', amount: '300' });
+
+    // Project 3: 2 contributors
+    service.recordContribution({ roundId: round.id, projectId: 3, contributor: 'GA3', amount: '100' });
+    service.recordContribution({ roundId: round.id, projectId: 3, contributor: 'GB3', amount: '100' });
+  });
+
+  it('returns ranked entries with rank, contributions, and match figures', () => {
+    const rounds = service.listRounds();
+    const roundId = rounds[rounds.length - 1].id;
+
+    const result = service.getLeaderboard({ roundId, limit: 10 });
+
+    expect(result.entries.length).toBeGreaterThan(0);
+    expect(result.entries[0].rank).toBe(1);
+    expect(result.entries[0].projectId).toBeDefined();
+    expect(result.entries[0].qfScore).toBeDefined();
+    expect(result.entries[0].estimatedMatch).toBeDefined();
+    expect(result.entries[0].totalContributions).toBeDefined();
+  });
+
+  it('entries are sorted by QF score descending', () => {
+    const rounds = service.listRounds();
+    const roundId = rounds[rounds.length - 1].id;
+
+    const result = service.getLeaderboard({ roundId, limit: 10 });
+
+    for (let i = 1; i < result.entries.length; i++) {
+      expect(Number(result.entries[i - 1].qfScore)).toBeGreaterThanOrEqual(
+        Number(result.entries[i].qfScore),
+      );
+    }
+  });
+
+  it('supports top-N response', () => {
+    const rounds = service.listRounds();
+    const roundId = rounds[rounds.length - 1].id;
+
+    const result = service.getLeaderboard({ roundId, topN: 2 });
+
+    expect(result.entries.length).toBeLessThanOrEqual(2);
+    expect(result.entries[0].rank).toBe(1);
+  });
+
+  it('supports pagination', () => {
+    const rounds = service.listRounds();
+    const roundId = rounds[rounds.length - 1].id;
+
+    const page1 = service.getLeaderboard({ roundId, page: 1, limit: 2 });
+    const page2 = service.getLeaderboard({ roundId, page: 2, limit: 2 });
+
+    expect(page1.entries.length).toBeLessThanOrEqual(2);
+    expect(page1.page).toBe(1);
+    expect(page2.page).toBe(2);
+
+    // No overlap between pages
+    const page1Ids = page1.entries.map((e) => e.projectId);
+    const page2Ids = page2.entries.map((e) => e.projectId);
+    expect(page1Ids.some((id) => page2Ids.includes(id))).toBe(false);
+  });
+
+  it('returns empty entries for a round with no projects', () => {
+    const emptyRound = service.createRound({
+      name: 'Empty Round',
+      tokenAddress: 'CTOKEN',
+      startTime: Math.floor(Date.now() / 1000) - 3600,
+      endTime: Math.floor(Date.now() / 1000) + 3600,
+    });
+
+    const result = service.getLeaderboard({ roundId: emptyRound.id, limit: 10 });
+
+    expect(result.entries).toEqual([]);
+    expect(result.totalProjects).toBe(0);
+  });
+
+  it('throws NotFoundException for unknown roundId', () => {
+    expect(() =>
+      service.getLeaderboard({ roundId: 99999, limit: 10 }),
+    ).toThrow(NotFoundException);
+  });
+
+  it('returns correct totalProjects count', () => {
+    const rounds = service.listRounds();
+    const roundId = rounds[rounds.length - 1].id;
+
+    const result = service.getLeaderboard({ roundId, limit: 10 });
+
+    expect(result.totalProjects).toBe(3);
+  });
+
+  it('includes poolBalance in response', () => {
+    const rounds = service.listRounds();
+    const roundId = rounds[rounds.length - 1].id;
+
+    const result = service.getLeaderboard({ roundId, limit: 10 });
+
+    expect(result.poolBalance).toBeDefined();
+    expect(typeof result.poolBalance).toBe('string');
+  });
+});

--- a/apps/backend/src/grants/grants.controller.ts
+++ b/apps/backend/src/grants/grants.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  Query,
   Post,
   UseGuards,
 } from '@nestjs/common';
@@ -26,6 +27,8 @@ import {
   RoundDto,
   RoundSummaryDto,
   RoundExportDto,
+  LeaderboardQueryDto,
+  LeaderboardResponseDto,
 } from './dto/grants.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
@@ -250,5 +253,22 @@ export class GrantsController {
   @ApiResponse({ status: 404, description: 'Round not found' })
   distribute(@Body() dto: DistributeDto) {
     return this.grantsService.distribute(dto);
+  }
+  @Get('leaderboard')
+  @ApiOperation({
+    summary: 'Get leaderboard for a matching round',
+    description:
+      'Returns ranked projects for a round with contribution and match figures. ' +
+      'Supports top-N (e.g. ?roundId=1&topN=5) or paginated responses ' +
+      '(e.g. ?roundId=1&page=2&limit=10). Projects are ranked by QF score descending.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Leaderboard retrieved successfully',
+    type: LeaderboardResponseDto,
+  })
+  @ApiResponse({ status: 404, description: 'Round not found' })
+  getLeaderboard(@Query() query: LeaderboardQueryDto): LeaderboardResponseDto {
+    return this.grantsService.getLeaderboard(query);
   }
 }

--- a/apps/backend/src/grants/grants.service.ts
+++ b/apps/backend/src/grants/grants.service.ts
@@ -18,6 +18,9 @@ import {
   ApproveProjectDto,
   RecordContributionDto,
   DistributeDto,
+  LeaderboardQueryDto,
+  LeaderboardResponseDto,
+  LeaderboardEntryDto,
 } from './dto/grants.dto';
 
 /**
@@ -471,6 +474,88 @@ export class GrantsService {
       poolBalance: record.totalPool.toString(),
       participationMetrics,
       projects,
+    };
+  }
+
+  /**
+   * Return a ranked leaderboard of projects for a round.
+   *
+   * Projects are sorted by QF score descending (higher match = higher rank).
+   * Supports top-N and paginated responses. Returns an empty entries list
+   * when the round exists but has no eligible projects.
+   *
+   * @throws NotFoundException when the round does not exist.
+   */
+  getLeaderboard(query: LeaderboardQueryDto): LeaderboardResponseDto {
+    const { roundId, topN, page = 1, limit = 10 } = query;
+    const record = this.getRecord(roundId);
+
+    const scores = new Map<number, bigint>();
+    let totalQf = 0n;
+
+    for (const pid of record.eligibleProjects) {
+      const contribs = record.contributions.get(pid) ?? new Map<string, bigint>();
+      const score = this.computeQfScore(contribs);
+      scores.set(pid, score);
+      totalQf += score;
+    }
+
+    // Build ranked entries sorted by QF score descending
+    const allEntries: LeaderboardEntryDto[] = Array.from(scores.entries())
+      .sort(([, a], [, b]) => (b > a ? 1 : b < a ? -1 : 0))
+      .map(([projectId, score], index) => {
+        const contribs = record.contributions.get(projectId) ?? new Map<string, bigint>();
+        const totalContributions = Array.from(contribs.values()).reduce(
+          (sum, v) => sum + v,
+          0n,
+        );
+        const contributorCount = contribs.size;
+        const estimatedMatch =
+          totalQf > 0n
+            ? (record.totalPool * score) / totalQf
+            : 0n;
+        const matchPercentage =
+          totalQf > 0n
+            ? ((score * 10000n) / totalQf).toString()
+            : '0';
+
+        return {
+          rank: index + 1,
+          projectId,
+          totalContributions: totalContributions.toString(),
+          contributorCount,
+          qfScore: score.toString(),
+          estimatedMatch: estimatedMatch.toString(),
+          matchPercentage: (Number(matchPercentage) / 100).toFixed(2),
+        };
+      });
+
+    const totalProjects = allEntries.length;
+
+    // Apply top-N or pagination
+    let entries: LeaderboardEntryDto[];
+    let effectivePage: number;
+    let effectiveLimit: number;
+
+    if (topN !== undefined) {
+      const cap = Math.min(topN, 100);
+      entries = allEntries.slice(0, cap);
+      effectivePage = 1;
+      effectiveLimit = cap;
+    } else {
+      effectiveLimit = Math.min(limit, 100);
+      effectivePage = page;
+      const start = (effectivePage - 1) * effectiveLimit;
+      entries = allEntries.slice(start, start + effectiveLimit);
+    }
+
+    return {
+      round: this.toRoundDto(record),
+      entries,
+      totalProjects,
+      poolBalance: record.totalPool.toString(),
+      page: effectivePage,
+      limit: effectiveLimit,
     };
   }
 


### PR DESCRIPTION
Closes #845

## What this PR does
Exposes a leaderboard-style GET /grants/leaderboard endpoint that returns
ranked projects for a matching round with contribution and match figures,
supporting both top-N and paginated responses.

## Changes

### apps/backend/src/grants/dto/grants.dto.ts
- Added LeaderboardQueryDto — query params (roundId, topN, page, limit)
- Added LeaderboardEntryDto — ranked entry with rank, contributions,
  contributorCount, qfScore, estimatedMatch, matchPercentage
- Added LeaderboardResponseDto — entries, totalProjects, poolBalance,
  round, page, limit

### apps/backend/src/grants/grants.service.ts
- Added getLeaderboard() — aggregates QF scores, sorts by score descending,
  supports top-N (capped at 100) and pagination
- Returns empty entries list when round exists but has no eligible projects

### apps/backend/src/grants/grants.controller.ts
- Added GET /grants/leaderboard endpoint
- Full Swagger documentation with response types and error codes

### apps/backend/src/grants/grants-leaderboard.service.spec.ts (new)
- 8 tests covering:
  - Ranked entries with correct fields
  - Entries sorted by QF score descending
  - Top-N response
  - Pagination with no overlap between pages
  - Empty entries for round with no projects
  - NotFoundException for unknown roundId
  - totalProjects count
  - poolBalance included in response

## Acceptance Criteria
- [x] Returns ranked projects with contribution and match figures
- [x] Supports top-N responses (?topN=5)
- [x] Supports pagination (?page=2&limit=10)
- [x] Backed by efficient in-memory aggregated reads
- [x] Empty and not-found handled cleanly
- [x] 8 tests passing
