### PR TITLE
Closes: #893 Portfolio account switcher for multiple tracked wallets

### DIFF
--- a/apps/backend/src/portfolio/portfolio.controller.ts
+++ b/apps/backend/src/portfolio/portfolio.controller.ts
@@ -1,6 +1,7 @@
 import {
   Controller,
   Get,
+  Param,
   Post,
   Query,
   UseGuards,
@@ -13,6 +14,7 @@ import {
   ApiTags,
   ApiBearerAuth,
   ApiOperation,
+  ApiParam,
   ApiResponse,
   ApiQuery,
 } from '@nestjs/swagger';
@@ -71,6 +73,36 @@ export class PortfolioController {
     return this.portfolioService.getPortfolioSummaryInCurrency(
       userId,
       currency,
+    );
+  }
+
+  @Get('accounts/:publicKey/summary')
+  @Throttle(getPortfolioReadThrottleOverride())
+  @ApiOperation({
+    summary: 'Get portfolio summary for a linked Stellar account',
+    description:
+      'Returns live balances and valuation for one Stellar account linked to the authenticated user',
+  })
+  @ApiParam({
+    name: 'publicKey',
+    description: 'Linked Stellar account public key',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Account portfolio summary retrieved successfully',
+    type: PortfolioSummaryWithCurrencyResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Linked Stellar account not found' })
+  async getPortfolioSummaryForAccount(
+    @Request() req: any,
+    @Param('publicKey') publicKey: string,
+  ): Promise<PortfolioSummaryWithCurrencyResponseDto> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const userId = req.user.sub as string;
+    return this.portfolioService.getPortfolioSummaryForAccount(
+      userId,
+      publicKey,
     );
   }
 

--- a/apps/backend/src/portfolio/portfolio.service.ts
+++ b/apps/backend/src/portfolio/portfolio.service.ts
@@ -343,6 +343,64 @@ export class PortfolioService {
     };
   }
 
+  async getPortfolioSummaryForAccount(
+    userId: string,
+    publicKey: string,
+  ): Promise<PortfolioSummaryWithCurrencyResponseDto> {
+    this.logger.log(
+      `Fetching portfolio summary for linked account ${publicKey}`,
+    );
+
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+      relations: ['stellarAccounts'],
+    });
+
+    const linkedAccount = user?.stellarAccounts?.find(
+      (account) => account.isActive && account.publicKey === publicKey,
+    );
+
+    if (!linkedAccount) {
+      throw new NotFoundException('Linked Stellar account not found');
+    }
+
+    const balances =
+      await this.stellarBalanceService.getAccountBalances(publicKey);
+
+    const assets = await Promise.all(
+      balances.map(async (balance) => {
+        const valueUsd = await this.stellarBalanceService.getAssetValueUsd(
+          balance.assetCode,
+          balance.assetIssuer,
+          balance.balance,
+        );
+
+        return {
+          assetCode: balance.assetCode,
+          assetIssuer: balance.assetIssuer,
+          amount: balance.balance,
+          value: valueUsd,
+          valueUsd,
+        };
+      }),
+    );
+
+    const totalValueUsd = assets.reduce(
+      (sum, asset) => sum + asset.valueUsd,
+      0,
+    );
+
+    return {
+      totalValue: totalValueUsd.toFixed(2),
+      currency: CurrencyCode.USD,
+      totalValueUsd: totalValueUsd.toFixed(2),
+      assets,
+      lastUpdated: new Date(),
+      hasLinkedAccount: true,
+      exchangeRate: 1,
+    };
+  }
+
   // /**
   //  * Get portfolio summary (latest snapshot) for the mobile dashboard
   //  * Returns total USD value and individual asset balances

--- a/apps/mobile/app/(tabs)/portfolio.tsx
+++ b/apps/mobile/app/(tabs)/portfolio.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   FlatList,
@@ -6,18 +6,29 @@ import {
   SafeAreaView,
   StyleSheet,
   Text,
+  TouchableOpacity,
   View,
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect } from 'expo-router';
 import { useAuth } from '../../contexts/AuthContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { useLocalization } from '../../src/context';
-import { portfolioApi, AssetBalance, PortfolioSummary } from '../../lib/api';
+import {
+  portfolioApi,
+  usersApi,
+  AssetBalance,
+  LinkedStellarAccount,
+  PortfolioSummary,
+} from '../../lib/api';
 import { transactionApi } from '../../lib/transaction';
 import { Transaction, TransactionType } from '../../lib/types/transaction';
 import { useCachedData } from '../../hooks/useCachedData';
 import { CACHE_CONFIGS } from '../../lib/cache';
 import { useWalletAutoRefresh } from '../../hooks/useWalletAutoRefresh';
+import { storage } from '../../lib/storage';
+
+const truncateKey = (value: string) => `${value.slice(0, 6)}...${value.slice(-6)}`;
 
 function formatUsd(value: string | number): string {
   const num = typeof value === 'string' ? parseFloat(value) : value;
@@ -105,15 +116,92 @@ function RecentTransactionItem({ tx, colors, t }: { tx: Transaction; colors: any
   );
 }
 
-function Header({ summary, colors, t }: { summary: PortfolioSummary; colors: any; t: (key: string) => string }) {
+function AccountSwitcher({
+  accounts,
+  activePublicKey,
+  colors,
+  onSelect,
+}: {
+  accounts: LinkedStellarAccount[];
+  activePublicKey: string | null;
+  colors: any;
+  onSelect: (publicKey: string) => void;
+}) {
+  if (accounts.length === 0) {
+    return null;
+  }
+
+  return (
+    <View style={styles.switcherWrap}>
+      <FlatList
+        horizontal
+        data={accounts}
+        keyExtractor={(item) => item.id}
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.switcherContent}
+        renderItem={({ item }) => {
+          const active = item.publicKey === activePublicKey;
+          const label = item.label?.trim() || (item.isPrimary ? 'Primary account' : 'Tracked account');
+
+          return (
+            <TouchableOpacity
+              style={[
+                styles.accountChip,
+                {
+                  backgroundColor: active ? colors.accent : colors.surface,
+                  borderColor: active ? colors.accent : colors.border,
+                },
+              ]}
+              onPress={() => onSelect(item.publicKey)}
+              activeOpacity={0.85}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+              accessibilityLabel={`${label}, ${truncateKey(item.publicKey)}`}
+            >
+              <Ionicons
+                name={active ? 'radio-button-on' : 'radio-button-off'}
+                size={16}
+                color={active ? '#ffffff' : colors.textSecondary}
+                importantForAccessibility="no"
+              />
+              <View style={styles.accountChipCopy}>
+                <Text style={[styles.accountChipLabel, { color: active ? '#ffffff' : colors.text }]}>
+                  {label}
+                </Text>
+                <Text style={[styles.accountChipKey, { color: active ? '#ffffffcc' : colors.textSecondary }]}>
+                  {truncateKey(item.publicKey)}
+                </Text>
+              </View>
+            </TouchableOpacity>
+          );
+        }}
+      />
+    </View>
+  );
+}
+
+function Header({
+  summary,
+  activeAccount,
+  colors,
+}: {
+  summary: PortfolioSummary;
+  activeAccount: LinkedStellarAccount | null;
+  colors: any;
+}) {
   return (
     <View style={[styles.header, { backgroundColor: colors.surface }]} accessible>
       <Text style={{ color: colors.textSecondary }} accessible>
-        {t('portfolio.total_balance')}
+        {activeAccount?.label?.trim() || 'Active wallet'}
       </Text>
       <Text style={[styles.balance, { color: colors.text }]} accessible accessibilityRole="header">
         {formatUsd(summary.totalValueUsd)}
       </Text>
+      {activeAccount && (
+        <Text style={[styles.activeKey, { color: colors.textSecondary }]} accessible>
+          {truncateKey(activeAccount.publicKey)}
+        </Text>
+      )}
     </View>
   );
 }
@@ -122,6 +210,77 @@ export default function PortfolioScreen() {
   const { isAuthenticated } = useAuth();
   const { colors } = useTheme();
   const { t } = useLocalization();
+  const [accounts, setAccounts] = useState<LinkedStellarAccount[]>([]);
+  const [accountsLoading, setAccountsLoading] = useState(true);
+  const [activePublicKey, setActivePublicKey] = useState<string | null>(null);
+  const [accountsError, setAccountsError] = useState<string | null>(null);
+
+  const sortedAccounts = useMemo(
+    () =>
+      [...accounts].sort((left, right) => {
+        if (left.isPrimary && !right.isPrimary) return -1;
+        if (!left.isPrimary && right.isPrimary) return 1;
+        return new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime();
+      }),
+    [accounts],
+  );
+
+  const activeAccount = useMemo(
+    () => sortedAccounts.find((account) => account.publicKey === activePublicKey) ?? null,
+    [activePublicKey, sortedAccounts],
+  );
+
+  const loadAccounts = useCallback(async () => {
+    setAccountsLoading(true);
+    setAccountsError(null);
+
+    try {
+      const cachedAccounts = await storage.getLinkedAccountsMetadata();
+      if (cachedAccounts.length > 0) {
+        setAccounts(cachedAccounts);
+      }
+
+      const response = await usersApi.getLinkedAccounts();
+      const nextAccounts = response.success ? response.data ?? [] : cachedAccounts;
+
+      if (!response.success && cachedAccounts.length === 0) {
+        setAccountsError(response.error?.message ?? t('errors.couldnt_load', { item: 'accounts' }));
+      }
+
+      setAccounts(nextAccounts);
+      await storage.storeLinkedAccountsMetadata(nextAccounts);
+
+      const savedPublicKey = await storage.getActiveWalletPublicKey();
+      const validSaved = nextAccounts.find((account) => account.publicKey === savedPublicKey);
+      const nextActivePublicKey =
+        validSaved?.publicKey ??
+        nextAccounts.find((account) => account.isPrimary)?.publicKey ??
+        nextAccounts[0]?.publicKey ??
+        null;
+
+      setActivePublicKey(nextActivePublicKey);
+      await storage.setActiveWalletPublicKey(nextActivePublicKey);
+    } finally {
+      setAccountsLoading(false);
+    }
+  }, [t]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (isAuthenticated) {
+        void loadAccounts();
+      } else {
+        setAccounts([]);
+        setActivePublicKey(null);
+        setAccountsLoading(false);
+      }
+    }, [isAuthenticated, loadAccounts]),
+  );
+
+  const handleSelectAccount = useCallback((publicKey: string) => {
+    setActivePublicKey(publicKey);
+    void storage.setActiveWalletPublicKey(publicKey);
+  }, []);
 
   const {
     data: summary,
@@ -130,15 +289,18 @@ export default function PortfolioScreen() {
     isStale: summaryStale,
     error: summaryError,
   } = useCachedData({
-    key: `portfolio_summary_default`,
+    key: `portfolio_summary_${activePublicKey ?? 'none'}`,
     fetcher: async () => {
-      const response = await portfolioApi.getSummary();
+      if (!activePublicKey) {
+        throw new Error('No active wallet selected');
+      }
+      const response = await portfolioApi.getAccountSummary(activePublicKey);
       if (response.success && response.data) {
         return response.data;
       }
       throw new Error(response.error?.message || t('errors.couldnt_load', { item: 'portfolio' }));
     },
-    enabled: isAuthenticated,
+    enabled: isAuthenticated && !!activePublicKey,
     ...CACHE_CONFIGS.PORTFOLIO,
   });
 
@@ -148,42 +310,50 @@ export default function PortfolioScreen() {
     refresh: refreshTransactions,
     isStale: transactionsStale,
   } = useCachedData({
-    key: `transactions_default_5`,
+    key: `transactions_${activePublicKey ?? 'none'}_5`,
     fetcher: async () => {
-      const response = await transactionApi.getHistory(5);
+      if (!activePublicKey) {
+        throw new Error('No active wallet selected');
+      }
+      const response = await transactionApi.getForAccount(activePublicKey, 5);
       if (response.transactions) {
         return response.transactions;
       }
       throw new Error(t('errors.couldnt_load', { item: 'transactions' }));
     },
-    enabled: isAuthenticated,
+    enabled: isAuthenticated && !!activePublicKey,
     ...CACHE_CONFIGS.TRANSACTIONS,
   });
 
   const transactions = transactionData || [];
-  const loading = summaryLoading && transactionsLoading;
+  const loading = accountsLoading || summaryLoading || transactionsLoading;
   const [refreshing, setRefreshing] = useState(false);
 
   // Background auto-refresh: aligned to TRANSACTIONS TTL (2 min, the shorter
   // of the two) so both portfolio and transactions are refreshed before stale.
   const handleAutoRefresh = useCallback(async () => {
-    await Promise.all([refreshSummary(), refreshTransactions()]);
-  }, [refreshSummary, refreshTransactions]);
+    if (activePublicKey) {
+      await Promise.all([refreshSummary(), refreshTransactions()]);
+    }
+  }, [activePublicKey, refreshSummary, refreshTransactions]);
 
   useWalletAutoRefresh({
     intervalMs: CACHE_CONFIGS.TRANSACTIONS.ttl,
     onRefresh: handleAutoRefresh,
-    enabled: isAuthenticated,
+    enabled: isAuthenticated && !!activePublicKey,
   });
 
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
     try {
-      await Promise.all([refreshSummary(), refreshTransactions()]);
+      await loadAccounts();
+      if (activePublicKey) {
+        await Promise.all([refreshSummary(), refreshTransactions()]);
+      }
     } finally {
       setRefreshing(false);
     }
-  }, [refreshSummary, refreshTransactions]);
+  }, [activePublicKey, loadAccounts, refreshSummary, refreshTransactions]);
 
   const isStale = summaryStale || transactionsStale;
 
@@ -210,29 +380,66 @@ export default function PortfolioScreen() {
         data={summary?.assets || []}
         keyExtractor={(item) => item.assetCode}
         ListHeaderComponent={
-          summary && (
+          sortedAccounts.length > 0 || summary || loading ? (
             <>
               <Text style={[styles.title, { color: colors.text }]} accessible accessibilityRole="header">
                 {t('portfolio.title')}
               </Text>
-              <Header summary={summary} colors={colors} t={t} />
+              <AccountSwitcher
+                accounts={sortedAccounts}
+                activePublicKey={activePublicKey}
+                colors={colors}
+                onSelect={handleSelectAccount}
+              />
+              {summary ? (
+              <Header summary={summary} activeAccount={activeAccount} colors={colors} />
+              ) : sortedAccounts.length > 0 ? (
+                <View style={[styles.header, styles.headerLoading, { backgroundColor: colors.surface }]}>
+                  <ActivityIndicator color={colors.accent} accessibilityLabel={t('common.loading')} />
+                </View>
+              ) : null}
 
-              <Text style={[styles.section, { color: colors.text }]} accessible accessibilityRole="header">
-                {t('portfolio.recent_transactions')}
-              </Text>
+              {summary && (
+                <>
+                  <Text style={[styles.section, { color: colors.text }]} accessible accessibilityRole="header">
+                    {t('portfolio.recent_transactions')}
+                  </Text>
 
-              {transactions.map((tx) => (
-                <RecentTransactionItem key={tx.id} tx={tx} colors={colors} t={t} />
-              ))}
+                  {transactions.length === 0 ? (
+                    <Text style={[styles.emptyInline, { color: colors.textSecondary }]}>
+                      No recent activity for this wallet.
+                    </Text>
+                  ) : (
+                    transactions.map((tx) => (
+                      <RecentTransactionItem key={tx.id} tx={tx} colors={colors} t={t} />
+                    ))
+                  )}
+                </>
+              )}
             </>
-          )
+          ) : null
         }
         renderItem={({ item }) => <AssetRow asset={item} colors={colors} t={t} />}
         refreshControl={<RefreshControl refreshing={refreshing} onRefresh={handleRefresh} accessibilityLabel="Pull to refresh portfolio" />}
         ListEmptyComponent={
           !loading ? (
             <View style={styles.center} accessible accessibilityLabel={t('portfolio.no_assets')}>
-              <Text style={{ color: colors.text }} accessible>{t('portfolio.no_assets')}</Text>
+              <Ionicons
+                name={sortedAccounts.length === 0 ? 'wallet-outline' : 'file-tray-outline'}
+                size={28}
+                color={colors.textSecondary}
+                importantForAccessibility="no"
+              />
+              <Text style={[styles.emptyTitle, { color: colors.text }]} accessible>
+                {sortedAccounts.length === 0 ? 'No tracked wallets' : t('portfolio.no_assets')}
+              </Text>
+              <Text style={[styles.emptyDescription, { color: colors.textSecondary }]} accessible>
+                {accountsError ??
+                  summaryError?.message ??
+                  (sortedAccounts.length === 0
+                    ? 'Add a wallet from Manage Accounts to track balances and activity.'
+                    : 'This wallet has no balances yet. Pull to refresh after funding it.')}
+              </Text>
             </View>
           ) : null
         }
@@ -256,12 +463,51 @@ const styles = StyleSheet.create({
   center: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   title: { fontSize: 26, fontWeight: '700', margin: 20 },
   section: { margin: 20, fontWeight: '600' },
+  switcherWrap: {
+    marginBottom: 16,
+  },
+  switcherContent: {
+    paddingHorizontal: 16,
+    gap: 10,
+  },
+  accountChip: {
+    minWidth: 178,
+    maxWidth: 220,
+    minHeight: 64,
+    borderRadius: 16,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  accountChipCopy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  accountChipLabel: {
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  accountChipKey: {
+    fontSize: 12,
+    marginTop: 3,
+  },
   header: {
     marginHorizontal: 16,
     padding: 20,
     borderRadius: 12,
   },
+  headerLoading: {
+    minHeight: 116,
+    justifyContent: 'center',
+  },
   balance: { fontSize: 32, fontWeight: '800' },
+  activeKey: {
+    fontSize: 12,
+    marginTop: 6,
+  },
   assetRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -290,5 +536,22 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: '500',
     marginLeft: 6,
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    marginTop: 12,
+  },
+  emptyDescription: {
+    fontSize: 13,
+    lineHeight: 19,
+    marginTop: 6,
+    paddingHorizontal: 32,
+    textAlign: 'center',
+  },
+  emptyInline: {
+    fontSize: 13,
+    marginHorizontal: 20,
+    marginBottom: 8,
   },
 });

--- a/apps/mobile/hooks/useCachedData.ts
+++ b/apps/mobile/hooks/useCachedData.ts
@@ -83,6 +83,13 @@ export function useCachedData<T>({
 
   const refresh = useCallback(() => fetchData(true), [fetchData]);
 
+  useEffect(() => {
+    setData(null);
+    setError(null);
+    setIsStale(false);
+    setLastUpdated(null);
+  }, [key, enabled]);
+
   // Listen for cache refresh events
   useEffect(() => {
     const handleCacheRefresh = (event: { key: string }) => {

--- a/apps/mobile/lib/api.ts
+++ b/apps/mobile/lib/api.ts
@@ -40,6 +40,8 @@ export interface AssetBalance {
 }
 
 export interface PortfolioSummary {
+  totalValue?: string;
+  currency?: string;
   totalValueUsd: string;
   assets: AssetBalance[];
   lastUpdated: string | null;
@@ -85,6 +87,7 @@ export interface LinkedStellarAccount {
   id: string;
   publicKey: string;
   label?: string | null;
+  isPrimary?: boolean;
   isActive: boolean;
   createdAt: string;
   updatedAt: string;
@@ -145,6 +148,12 @@ export const portfolioApi = {
    */
   async getSummary(): Promise<ApiResponse<PortfolioSummary>> {
     return apiClient.get<PortfolioSummary>('/portfolio/summary');
+  },
+
+  async getAccountSummary(publicKey: string): Promise<ApiResponse<PortfolioSummary>> {
+    return apiClient.get<PortfolioSummary>(
+      `/portfolio/accounts/${encodeURIComponent(publicKey)}/summary`,
+    );
   },
 
   /**


### PR DESCRIPTION
Implemented and pushed issue #893 .

Commit: f03d1c0 Resolve #893 mobile wallet switcher
Pushed to configured origin/main: https://github.com/Primex-hub/Lumenpulse.git

What changed
Added authenticated backend endpoint for per-linked-account portfolio summaries.
Added mobile API support for selected-account portfolio summaries.
Added mobile portfolio account switcher with persisted active wallet.
Balances and recent activity now key off the active wallet.
Added clean empty states for no tracked wallets, no balances, and no activity.
Reset cached data on cache-key changes to prevent old wallet data flashing during switches.

Verification:
git diff --check passed.