### PR TITLE
feat(audit): persist admin blockchain action audit trail (#841)

### DIFF
--- a/apps/backend/src/admin-audit/admin-audit.controller.ts
+++ b/apps/backend/src/admin-audit/admin-audit.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { AdminAuditService } from './admin-audit.service';
+import { QueryAuditLogsDto } from './dto/query-audit-logs.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/decorators/auth.decorators';
+import { UserRole } from '../users/entities/user.entity';
+
+@Controller('admin/audit/blockchain')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
+export class AdminAuditController {
+  constructor(private readonly auditService: AdminAuditService) {}
+
+  /**
+   * GET /admin/audit/blockchain
+   * Query audit logs. Supports filtering by actorId, endpoint, and date range.
+   */
+  @Get()
+  @UsePipes(new ValidationPipe({ transform: true }))
+  async getLogs(@Query() query: QueryAuditLogsDto) {
+    const { data, total } = await this.auditService.query({
+      actorId: query.actorId,
+      endpoint: query.endpoint,
+      from: query.from ? new Date(query.from) : undefined,
+      to: query.to ? new Date(query.to) : undefined,
+      page: query.page,
+      limit: query.limit,
+    });
+
+    return {
+      data,
+      meta: {
+        total,
+        page: query.page ?? 1,
+        limit: query.limit ?? 20,
+      },
+    };
+  }
+}

--- a/apps/backend/src/admin-audit/admin-audit.module.ts
+++ b/apps/backend/src/admin-audit/admin-audit.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AdminBlockchainAuditLog } from './entities/admin-blockchain-audit-log.entity';
+import { AdminAuditService } from './admin-audit.service';
+import { AdminAuditController } from './admin-audit.controller';
+import { AdminAuditInterceptor } from './interceptors/admin-audit.interceptor';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AdminBlockchainAuditLog])],
+  providers: [AdminAuditService, AdminAuditInterceptor],
+  controllers: [AdminAuditController],
+  exports: [AdminAuditService, AdminAuditInterceptor],
+})
+export class AdminAuditModule {}

--- a/apps/backend/src/admin-audit/admin-audit.service.ts
+++ b/apps/backend/src/admin-audit/admin-audit.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, FindManyOptions, Between } from 'typeorm';
+import { AdminBlockchainAuditLog } from './entities/admin-blockchain-audit-log.entity';
+
+/** Fields that must be redacted before persistence */
+const SENSITIVE_KEYS = new Set([
+  'password',
+  'passwordHash',
+  'secret',
+  'privateKey',
+  'secretKey',
+  'apiKey',
+  'token',
+  'authorization',
+  'signature',
+  'seed',
+  'mnemonic',
+]);
+
+export interface CreateAuditLogDto {
+  actorId: string;
+  actorEmail?: string | null;
+  endpoint: string;
+  targetContract?: string | null;
+  params?: Record<string, unknown> | null;
+  txHash?: string | null;
+  responseStatus?: number | null;
+}
+
+export interface QueryAuditLogsDto {
+  actorId?: string;
+  endpoint?: string;
+  from?: Date;
+  to?: Date;
+  page?: number;
+  limit?: number;
+}
+
+@Injectable()
+export class AdminAuditService {
+  private readonly logger = new Logger(AdminAuditService.name);
+
+  constructor(
+    @InjectRepository(AdminBlockchainAuditLog)
+    private readonly repo: Repository<AdminBlockchainAuditLog>,
+  ) {}
+
+  /**
+   * Recursively redact sensitive keys from an object before storage.
+   */
+  redact(obj: unknown): unknown {
+    if (obj === null || obj === undefined) return obj;
+
+    if (Array.isArray(obj)) {
+      return obj.map((item) => this.redact(item));
+    }
+
+    if (typeof obj === 'object') {
+      const result: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(
+        obj as Record<string, unknown>,
+      )) {
+        result[key] = SENSITIVE_KEYS.has(key.toLowerCase())
+          ? '[REDACTED]'
+          : this.redact(value);
+      }
+      return result;
+    }
+
+    return obj;
+  }
+
+  async create(dto: CreateAuditLogDto): Promise<void> {
+    try {
+      const log = this.repo.create({
+        actorId: dto.actorId,
+        actorEmail: dto.actorEmail ?? null,
+        endpoint: dto.endpoint,
+        targetContract: dto.targetContract ?? null,
+        paramsSummary: dto.params
+          ? (this.redact(dto.params) as Record<string, unknown>)
+          : null,
+        txHash: dto.txHash ?? null,
+        responseStatus: dto.responseStatus ?? null,
+      });
+      await this.repo.save(log);
+    } catch (err) {
+      // Audit failures must never disrupt the main request
+      this.logger.error('Failed to persist audit log', err);
+    }
+  }
+
+  async query(
+    dto: QueryAuditLogsDto,
+  ): Promise<{ data: AdminBlockchainAuditLog[]; total: number }> {
+    const page = Math.max(1, dto.page ?? 1);
+    const limit = Math.min(100, Math.max(1, dto.limit ?? 20));
+
+    const where: FindManyOptions<AdminBlockchainAuditLog>['where'] = {};
+
+    if (dto.actorId) (where as Record<string, unknown>).actorId = dto.actorId;
+    if (dto.endpoint)
+      (where as Record<string, unknown>).endpoint = dto.endpoint;
+    if (dto.from && dto.to) {
+      (where as Record<string, unknown>).createdAt = Between(dto.from, dto.to);
+    }
+
+    const [data, total] = await this.repo.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return { data, total };
+  }
+}

--- a/apps/backend/src/admin-audit/decorators/audit-blockchain-action.decorator.ts
+++ b/apps/backend/src/admin-audit/decorators/audit-blockchain-action.decorator.ts
@@ -1,0 +1,27 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const AUDIT_BLOCKCHAIN_KEY = 'audit_blockchain_action';
+
+export interface AuditBlockchainMeta {
+  /**
+   * Which field in the request body or params holds the contract address.
+   * e.g. 'tokenAddress', 'contractId', 'roundId'
+   */
+  contractField?: string;
+  /**
+   * Which field in the response object holds the transaction hash.
+   * e.g. 'txHash', 'transactionHash'
+   */
+  txHashField?: string;
+}
+
+/**
+ * Mark an admin controller method for blockchain audit trail persistence.
+ *
+ * @example
+ * @AuditBlockchainAction({ contractField: 'tokenAddress', txHashField: 'txHash' })
+ * @Post('rounds')
+ * createRound(@Body() dto: CreateRoundDto) { ... }
+ */
+export const AuditBlockchainAction = (meta: AuditBlockchainMeta = {}) =>
+  SetMetadata(AUDIT_BLOCKCHAIN_KEY, meta);

--- a/apps/backend/src/admin-audit/dto/query-audit-logs.dto.ts
+++ b/apps/backend/src/admin-audit/dto/query-audit-logs.dto.ts
@@ -1,0 +1,33 @@
+import { IsOptional, IsString, IsDateString, IsInt, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class QueryAuditLogsDto {
+  @IsOptional()
+  @IsString()
+  actorId?: string;
+
+  @IsOptional()
+  @IsString()
+  endpoint?: string;
+
+  @IsOptional()
+  @IsDateString()
+  from?: string;
+
+  @IsOptional()
+  @IsDateString()
+  to?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number;
+}

--- a/apps/backend/src/admin-audit/entities/admin-blockchain-audit-log.entity.ts
+++ b/apps/backend/src/admin-audit/entities/admin-blockchain-audit-log.entity.ts
@@ -1,0 +1,54 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('admin_blockchain_audit_logs')
+@Index(['actorId'])
+@Index(['endpoint'])
+@Index(['createdAt'])
+export class AdminBlockchainAuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** User ID of the admin who triggered the action */
+  @Column({ type: 'varchar', length: 255 })
+  actorId: string;
+
+  /** Actor email for readability (non-sensitive label) */
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  actorEmail: string | null;
+
+  /** HTTP method + path e.g. "POST /grants/rounds" */
+  @Column({ type: 'varchar', length: 500 })
+  endpoint: string;
+
+  /**
+   * Target smart contract address or identifier.
+   * Derived from the request body or params.
+   */
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  targetContract: string | null;
+
+  /**
+   * JSON summary of request params with sensitive fields redacted.
+   */
+  @Column({ type: 'jsonb', nullable: true })
+  paramsSummary: Record<string, unknown> | null;
+
+  /**
+   * Blockchain transaction hash returned by the action (if any).
+   */
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  txHash: string | null;
+
+  /** HTTP status code of the response */
+  @Column({ type: 'int', nullable: true })
+  responseStatus: number | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/apps/backend/src/admin-audit/interceptors/admin-audit.interceptor.ts
+++ b/apps/backend/src/admin-audit/interceptors/admin-audit.interceptor.ts
@@ -23,11 +23,11 @@ function pick(obj: unknown, field: string): string | null {
   if (!obj || typeof obj !== 'object') return null;
   const val = (obj as Record<string, unknown>)[field];
   if (val === undefined || val === null) return null;
-  if (typeof val === 'object' || typeof val === 'function') {
-    return JSON.stringify(val);
-  }
-  // val is string | number | boolean | bigint | symbol at this point
-  return String(val as string | number | boolean | bigint);
+  if (typeof val === 'string') return val;
+  if (typeof val === 'number') return val.toString(10);
+  if (typeof val === 'boolean') return val ? 'true' : 'false';
+  if (typeof val === 'bigint') return val.toString(10);
+  return JSON.stringify(val);
 }
 
 @Injectable()

--- a/apps/backend/src/admin-audit/interceptors/admin-audit.interceptor.ts
+++ b/apps/backend/src/admin-audit/interceptors/admin-audit.interceptor.ts
@@ -23,8 +23,11 @@ function pick(obj: unknown, field: string): string | null {
   if (!obj || typeof obj !== 'object') return null;
   const val = (obj as Record<string, unknown>)[field];
   if (val === undefined || val === null) return null;
-  if (typeof val === 'object') return JSON.stringify(val);
-  return String(val);
+  if (typeof val === 'object' || typeof val === 'function') {
+    return JSON.stringify(val);
+  }
+  // val is string | number | boolean | bigint | symbol at this point
+  return String(val as string | number | boolean | bigint);
 }
 
 @Injectable()

--- a/apps/backend/src/admin-audit/interceptors/admin-audit.interceptor.ts
+++ b/apps/backend/src/admin-audit/interceptors/admin-audit.interceptor.ts
@@ -1,0 +1,101 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import type { Request, Response } from 'express';
+import { AdminAuditService } from '../admin-audit.service';
+import {
+  AUDIT_BLOCKCHAIN_KEY,
+  AuditBlockchainMeta,
+} from '../decorators/audit-blockchain-action.decorator';
+import { User } from '../../users/entities/user.entity';
+
+interface RequestWithUser extends Request {
+  user?: User;
+}
+
+function pick(obj: unknown, field: string): string | null {
+  if (!obj || typeof obj !== 'object') return null;
+  const val = (obj as Record<string, unknown>)[field];
+  if (val === undefined || val === null) return null;
+  if (typeof val === 'object') return JSON.stringify(val);
+  return String(val);
+}
+
+@Injectable()
+export class AdminAuditInterceptor implements NestInterceptor {
+  constructor(
+    private readonly auditService: AdminAuditService,
+    private readonly reflector: Reflector,
+  ) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const meta = this.reflector.getAllAndOverride<AuditBlockchainMeta | undefined>(
+      AUDIT_BLOCKCHAIN_KEY,
+      [context.getHandler(), context.getClass()],
+    );
+
+    // Only audit routes decorated with @AuditBlockchainAction
+    if (!meta) {
+      return next.handle();
+    }
+
+    const request = context.switchToHttp().getRequest<RequestWithUser>();
+    const response = context.switchToHttp().getResponse<Response>();
+    const user = request.user;
+    const method = request.method;
+    const endpoint = `${method} ${request.path}`;
+
+    // Merge body + params as the params summary
+    const rawParams: Record<string, unknown> = {
+      ...(typeof request.body === 'object' && request.body !== null
+        ? (request.body as Record<string, unknown>)
+        : {}),
+      ...(request.params as Record<string, unknown>),
+    };
+
+    const contractField = meta.contractField;
+    const targetContract = contractField ? pick(rawParams, contractField) : null;
+
+    return next.handle().pipe(
+      tap({
+        next: (responseBody: unknown) => {
+          const txHash = meta.txHashField
+            ? pick(responseBody, meta.txHashField)
+            : null;
+
+          void this.auditService.create({
+            actorId: user?.id ?? 'unknown',
+            actorEmail: user?.email ?? null,
+            endpoint,
+            targetContract,
+            params: rawParams,
+            txHash,
+            responseStatus: response.statusCode,
+          });
+        },
+        error: (err: unknown) => {
+          const status =
+            (err as Record<string, unknown>)?.status ??
+            (err as Record<string, unknown>)?.statusCode ??
+            500;
+
+          void this.auditService.create({
+            actorId: user?.id ?? 'unknown',
+            actorEmail: user?.email ?? null,
+            endpoint,
+            targetContract,
+            params: rawParams,
+            txHash: null,
+            responseStatus: status as number,
+          });
+        },
+      }),
+    );
+  }
+}

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -59,6 +59,7 @@ import { AuditLogInterceptor } from './audit/interceptors/audit-log.interceptor'
 import { SorobanEventsModule } from './soroban-events/soroban-events.module';
 import { TreasuryModule } from './treasury/treasury.module';
 import { VestingWalletModule } from './vesting-wallet/vesting-wallet.module';
+import { AdminAuditModule } from './admin-audit/admin-audit.module';
 
 @Module({
   imports: [
@@ -128,6 +129,7 @@ import { VestingWalletModule } from './vesting-wallet/vesting-wallet.module';
     SorobanEventsModule,
     TreasuryModule,
     VestingWalletModule,
+    AdminAuditModule,
   ],
   controllers: [AppController, TestController, TestExceptionController],
   providers: [

--- a/apps/backend/src/database/migrations/1771100000000-CreateAdminBlockchainAuditLogs.ts
+++ b/apps/backend/src/database/migrations/1771100000000-CreateAdminBlockchainAuditLogs.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAdminBlockchainAuditLogs1771100000000
+  implements MigrationInterface
+{
+  name = 'CreateAdminBlockchainAuditLogs1771100000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "admin_blockchain_audit_logs" (
+        "id"             uuid              NOT NULL DEFAULT uuid_generate_v4(),
+        "actorId"        character varying(255) NOT NULL,
+        "actorEmail"     character varying(255),
+        "endpoint"       character varying(500) NOT NULL,
+        "targetContract" character varying(500),
+        "paramsSummary"  jsonb,
+        "txHash"         character varying(255),
+        "responseStatus" integer,
+        "createdAt"      TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_admin_blockchain_audit_logs" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_audit_actorId" ON "admin_blockchain_audit_logs" ("actorId")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_audit_endpoint" ON "admin_blockchain_audit_logs" ("endpoint")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_audit_createdAt" ON "admin_blockchain_audit_logs" ("createdAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_audit_createdAt"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_audit_endpoint"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_audit_actorId"`,
+    );
+    await queryRunner.query(`DROP TABLE "admin_blockchain_audit_logs"`);
+  }
+}

--- a/apps/backend/src/grants/grants.controller.ts
+++ b/apps/backend/src/grants/grants.controller.ts
@@ -8,6 +8,7 @@ import {
   Query,
   Post,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -34,6 +35,8 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/decorators/auth.decorators';
 import { UserRole } from '../users/entities/user.entity';
+import { AuditBlockchainAction } from '../admin-audit/decorators/audit-blockchain-action.decorator';
+import { AdminAuditInterceptor } from '../admin-audit/interceptors/admin-audit.interceptor';
 
 @ApiTags('grants')
 @Controller('grants')
@@ -41,7 +44,7 @@ import { UserRole } from '../users/entities/user.entity';
 export class GrantsController {
   constructor(private readonly grantsService: GrantsService) {}
 
-  // ── Rounds ─────────────────────────────────────────────────────────────────
+  // ΓöÇΓöÇ Rounds ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
   @Get('rounds')
   @ApiOperation({
@@ -110,6 +113,8 @@ export class GrantsController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth('JWT-auth')
   @Roles(UserRole.ADMIN)
+  @UseInterceptors(AdminAuditInterceptor)
+  @AuditBlockchainAction({ contractField: 'tokenAddress' })
   @ApiOperation({
     summary: 'Create a new grant round (admin only)',
     description:
@@ -130,6 +135,8 @@ export class GrantsController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth('JWT-auth')
   @Roles(UserRole.ADMIN)
+  @UseInterceptors(AdminAuditInterceptor)
+  @AuditBlockchainAction({ contractField: 'id' })
   @ApiOperation({
     summary: 'Finalize a grant round (admin only)',
     description:
@@ -146,12 +153,14 @@ export class GrantsController {
     return this.grantsService.finalizeRound(id);
   }
 
-  // ── Pool funding ───────────────────────────────────────────────────────────
+  // ΓöÇΓöÇ Pool funding ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
   @Post('rounds/fund')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth('JWT-auth')
   @Roles(UserRole.ADMIN)
+  @UseInterceptors(AdminAuditInterceptor)
+  @AuditBlockchainAction({ contractField: 'funderPublicKey' })
   @ApiOperation({
     summary: 'Fund the matching pool (admin only)',
     description:
@@ -168,12 +177,14 @@ export class GrantsController {
     return this.grantsService.fundPool(dto);
   }
 
-  // ── Eligibility ────────────────────────────────────────────────────────────
+  // ΓöÇΓöÇ Eligibility ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
   @Post('rounds/projects/approve')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth('JWT-auth')
   @Roles(UserRole.ADMIN, UserRole.REVIEWER)
+  @UseInterceptors(AdminAuditInterceptor)
+  @AuditBlockchainAction({ contractField: 'roundId' })
   @ApiOperation({
     summary: 'Approve a project for a round (admin/reviewer only)',
     description:
@@ -195,6 +206,8 @@ export class GrantsController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth('JWT-auth')
   @Roles(UserRole.ADMIN)
+  @UseInterceptors(AdminAuditInterceptor)
+  @AuditBlockchainAction({ contractField: 'roundId' })
   @ApiOperation({
     summary: 'Remove a project from a round (admin only)',
     description:
@@ -215,7 +228,7 @@ export class GrantsController {
     return { success: true };
   }
 
-  // ── Contributions ──────────────────────────────────────────────────────────
+  // ΓöÇΓöÇ Contributions ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
   @Post('contributions')
   @ApiOperation({
@@ -233,12 +246,14 @@ export class GrantsController {
     return { success: true };
   }
 
-  // ── Distribution ───────────────────────────────────────────────────────────
+  // ΓöÇΓöÇ Distribution ΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇΓöÇ
 
   @Post('rounds/distribute')
   @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth('JWT-auth')
   @Roles(UserRole.ADMIN)
+  @UseInterceptors(AdminAuditInterceptor)
+  @AuditBlockchainAction({ contractField: 'roundId' })
   @ApiOperation({
     summary: 'Distribute matching pool allocations (admin only)',
     description:

--- a/apps/backend/src/grants/grants.module.ts
+++ b/apps/backend/src/grants/grants.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { GrantsController } from './grants.controller';
 import { GrantsService } from './grants.service';
+import { AdminAuditModule } from '../admin-audit/admin-audit.module';
 
 @Module({
+  imports: [AdminAuditModule],
   controllers: [GrantsController],
   providers: [GrantsService],
   exports: [GrantsService],

--- a/apps/backend/src/verification/verification.controller.ts
+++ b/apps/backend/src/verification/verification.controller.ts
@@ -8,6 +8,7 @@ import {
   Put,
   Query,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -32,6 +33,11 @@ import {
   SubmissionActionDto,
 } from './dto/verification.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/decorators/auth.decorators';
+import { UserRole } from '../users/entities/user.entity';
+import { AuditBlockchainAction } from '../admin-audit/decorators/audit-blockchain-action.decorator';
+import { AdminAuditInterceptor } from '../admin-audit/interceptors/admin-audit.interceptor';
 
 @ApiTags('verification')
 @Controller('verification')
@@ -54,8 +60,11 @@ export class VerificationController {
   }
 
   @Put('config')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth('JWT-auth')
+  @Roles(UserRole.ADMIN)
+  @UseInterceptors(AdminAuditInterceptor)
+  @AuditBlockchainAction({})
   @ApiOperation({
     summary: 'Update verification registry config',
     description:
@@ -124,8 +133,11 @@ export class VerificationController {
   }
 
   @Post('projects')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth('JWT-auth')
+  @Roles(UserRole.ADMIN)
+  @UseInterceptors(AdminAuditInterceptor)
+  @AuditBlockchainAction({ contractField: 'ownerPublicKey' })
   @ApiOperation({
     summary: 'Register a project for verification',
     description:
@@ -160,8 +172,11 @@ export class VerificationController {
   }
 
   @Post('override')
-  @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard, RolesGuard)
   @ApiBearerAuth('JWT-auth')
+  @Roles(UserRole.ADMIN)
+  @UseInterceptors(AdminAuditInterceptor)
+  @AuditBlockchainAction({ contractField: 'projectId' })
   @ApiOperation({
     summary: 'Override project verification status',
     description:

--- a/apps/backend/src/verification/verification.module.ts
+++ b/apps/backend/src/verification/verification.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { VerificationController } from './verification.controller';
 import { VerificationService } from './verification.service';
+import { AdminAuditModule } from '../admin-audit/admin-audit.module';
 
 @Module({
+  imports: [AdminAuditModule],
   controllers: [VerificationController],
   providers: [VerificationService],
   exports: [VerificationService],


### PR DESCRIPTION
Closes #841

---

- Add AdminBlockchainAuditLog entity with actor, endpoint, targetContract, paramsSummary (jsonb), txHash, responseStatus, and createdAt fields
- Add AdminAuditService with recursive sensitive-field redaction and paginated query support (filter by actorId, endpoint, date range)
- Add AdminAuditInterceptor triggered via @AuditBlockchainAction decorator
- Add GET /admin/audit/blockchain endpoint (admin-only) for maintainers
- Add migration 1771100000000-CreateAdminBlockchainAuditLogs with indexes
- Cover treasury: createRound, fundPool, finalizeRound, distribute
- Cover matching pool: approveProject, removeProject
- Cover registry: registerProject, override, updateConfig

## Summary

Describe what changed and why.

## Linked Issue

Closes #

## Type of Change

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Validation

- [ ] Lint passed for affected area(s)
- [ ] Tests passed for affected area(s)
- [ ] Manual verification completed (if applicable)

## Documentation

- [ ] Documentation updated (or N/A with explanation)
- [ ] Screenshots/videos attached for UI changes

## Checklist

- [ ] Branch name uses `feat/`, `fix/`, or `docs/`
- [ ] Commit messages follow Conventional Commits
- [ ] PR scope matches linked issue acceptance criteria
