### PR TITLE
docs: add formal incident postmortem template and workflow

### DIFF
--- a/document/BUG_TRIAGE_GUIDE.md
+++ b/document/BUG_TRIAGE_GUIDE.md
@@ -1,0 +1,109 @@
+# Bug Triage Guide
+
+**Version**: 1.0.0
+**Audience**: Contributors, maintainers, and on-call engineers
+**Purpose**: Define how bugs are reported, prioritized, assigned, and escalated — so every issue moves predictably from discovery to resolution.
+
+---
+
+## 1. Reporting a Bug
+
+Before opening an issue, check whether the bug is already tracked:
+
+1. Search open issues with relevant keywords.
+2. Check the [error codes reference](error-codes.md) — some errors are expected behavior with documented recovery steps.
+3. Check the [ETL & Data Pipeline Runbook](ETL_RUNBOOK.md) for data-layer failures.
+
+If no existing issue covers the bug, open a new GitHub issue using the **Bug Report** template. Include:
+
+| Field | What to provide |
+|---|---|
+| **Summary** | One-line description of the problem |
+| **Environment** | Testnet / Mainnet; browser/device; app version |
+| **Steps to reproduce** | Numbered, minimal steps that consistently trigger the bug |
+| **Expected behavior** | What should happen |
+| **Actual behavior** | What actually happens |
+| **Logs / screenshots** | Paste relevant error output or attach screenshots |
+| **Severity estimate** | Your initial read using the table in Section 2 |
+
+---
+
+## 2. Severity Definitions
+
+Assign the severity that best matches the observed impact. A maintainer may adjust it during triage.
+
+| Severity | Definition | Example |
+|---|---|---|
+| **P1** | Full service outage or data loss; mainnet funds at risk | News Feed API returning 503 for all users; wallet auth broken |
+| **P2** | Partial outage or major feature broken; no workaround | Portfolio sync failing for a significant user segment |
+| **P3** | Feature degraded but workaround exists | Sentiment score missing on some articles |
+| **P4** | Cosmetic defect or minor inconvenience | Tooltip text truncated on mobile |
+
+---
+
+## 3. Triage Process
+
+Maintainers review the bug backlog at least once per day. During triage, each new bug issue is:
+
+1. **Confirmed** — a maintainer reproduces the bug or marks it `needs-repro` if more information is required.
+2. **Severity-labeled** — the `P1`, `P2`, `P3`, or `P4` label is applied.
+3. **Area-labeled** — one of `area:frontend`, `area:backend`, `area:contracts`, `area:data-processing`, or `area:mobile` is applied.
+4. **Assigned or queued** — P1/P2 bugs are assigned immediately; P3/P4 enter the backlog milestone.
+
+### Triage checklist
+
+- [ ] Issue has a clear reproduction path or is labeled `needs-repro`.
+- [ ] Severity label applied.
+- [ ] Area label applied.
+- [ ] Duplicate check performed — linked if duplicate found.
+- [ ] P1/P2: owner assigned and acknowledged.
+
+---
+
+## 4. Escalation and Response Targets
+
+| Severity | First response | Resolution target | Escalation path |
+|---|---|---|---|
+| **P1** | Immediate — page on-call | ASAP / continuous work | Escalate to maintainers if not resolved in 1 hour |
+| **P2** | Within 15 minutes | Within 4 hours | Escalate to maintainers if not resolved in 1 business day |
+| **P3** | Within 1 business day | Within the current sprint | Reprioritize if blocking downstream work |
+| **P4** | Within 1 week | Best effort | File and label; revisit at sprint planning |
+
+---
+
+## 5. Hotfix Path
+
+For P1 bugs requiring an emergency merge:
+
+1. Branch from `main` using `fix/critical-<short-description>`.
+2. Apply the minimal fix — no unrelated changes.
+3. Get a single maintainer approval plus a green CI run.
+4. Merge immediately.
+5. Commit message prefix: `fix(critical): <description>`.
+6. File a retrospective or postmortem issue after the fix is live (see Section 6).
+
+---
+
+## 6. When a Postmortem Is Required
+
+P1 and P2 bugs that cause user-facing downtime or data integrity issues require a formal postmortem after resolution.
+
+See the **[Incident Postmortem Workflow](INCIDENT_POSTMORTEM_WORKFLOW.md)** for:
+
+- Full criteria for when a postmortem is required.
+- Step-by-step instructions for drafting, reviewing, and publishing a postmortem.
+- How to track and close action items.
+- The postmortem template: [`POSTMORTEM_TEMPLATE.md`](POSTMORTEM_TEMPLATE.md).
+
+Every P1 incident and any P2 with ≥ 15 minutes of user-facing downtime **must** have a postmortem opened within 24 hours of resolution.
+
+---
+
+## 7. Related Documents
+
+- [Incident Postmortem Workflow](INCIDENT_POSTMORTEM_WORKFLOW.md) — full postmortem process.
+- [Postmortem Template](POSTMORTEM_TEMPLATE.md) — reusable template for postmortem documents.
+- [Error Codes Reference](error-codes.md) — API error codes and meanings.
+- [ETL & Data Pipeline Runbook](ETL_RUNBOOK.md) — recovery procedures for data pipeline failures.
+- [Review Playbook](review-playbook.md) — PR review standards and hotfix guidance.
+- [Contributing Guide](../CONTRIBUTING.md) — branch naming, commit conventions, and PR process.

--- a/document/INCIDENT_POSTMORTEM_WORKFLOW.md
+++ b/document/INCIDENT_POSTMORTEM_WORKFLOW.md
@@ -1,0 +1,130 @@
+# Incident Postmortem Workflow
+
+**Version**: 1.0.0
+**Audience**: On-call engineers, incident leads, and maintainers
+**Purpose**: Define when a postmortem is required, how it must be completed, and how action items are tracked — so every significant incident produces consistent, actionable learnings.
+
+---
+
+## 1. When a Postmortem Is Required
+
+A postmortem is **required** for any incident that meets one or more of the following criteria:
+
+| Trigger | Examples |
+|---|---|
+| P1 or P2 severity | Full service outage, data loss, security breach |
+| User-facing downtime ≥ 15 minutes | News Feed, Portfolio API, or Wallet auth unavailable |
+| Data integrity issue | Missing or corrupted events in the Soroban indexer, portfolio drift |
+| On-call escalation | Incident required waking or pulling in a second engineer |
+| Recurring issue | Same failure mode occurring for the second time within 30 days |
+| Security or compliance event | Any unauthorized access, secret exposure, or contract exploit |
+
+A postmortem is **optional but encouraged** for:
+
+- P3/P4 incidents resolved quickly with no lasting impact, where a contributing factor is newly identified.
+- Near-misses caught before user impact.
+
+When in doubt, write one. Postmortems are blameless learning documents, not performance reviews.
+
+---
+
+## 2. Severity Levels
+
+Use these definitions when filling in the Incident Summary table of the postmortem template.
+
+| Severity | Definition | Response Time |
+|---|---|---|
+| **P1** | Full service outage or data loss affecting all users or mainnet funds | Immediate — page on-call now |
+| **P2** | Partial outage or degraded service affecting a significant user segment | Within 15 minutes |
+| **P3** | Minor degradation or non-critical feature broken; workaround exists | Within 2 hours |
+| **P4** | Cosmetic issue or low-impact bug with no service disruption | Next business day |
+
+---
+
+## 3. How to Complete a Postmortem
+
+### Step 1 — Declare and assign (during or immediately after resolution)
+
+As soon as a P1/P2 incident is resolved, the **incident lead** must:
+
+1. Open a new GitHub issue titled `postmortem: <short incident title>` and label it `postmortem`.
+2. Copy the postmortem template from [`document/POSTMORTEM_TEMPLATE.md`](POSTMORTEM_TEMPLATE.md).
+3. Create a new file at `document/postmortems/POSTMORTEM-<YYYY-MM-DD>-<short-title>.md`.
+4. Fill in the **Incident Summary** and **Timeline** sections while memory is fresh.
+5. Assign the GitHub issue to the incident lead.
+
+### Step 2 — Draft within 24 hours
+
+The incident lead completes all sections of the postmortem document within **24 hours** of resolution:
+
+- [ ] Incident Summary (all fields)
+- [ ] Timeline (all key events with UTC timestamps)
+- [ ] Impact (quantified where possible)
+- [ ] Root Cause (single primary cause, specific)
+- [ ] Contributing Factors (secondary conditions)
+- [ ] Detection (how and when the incident was found)
+- [ ] Resolution (mitigation steps and permanent fix)
+- [ ] Action Items (every item has an owner and due date)
+- [ ] Lessons Learned (what went well, what to improve)
+
+### Step 3 — Review within 48 hours
+
+Open a pull request targeting `main` with the postmortem file. At least one maintainer **not** directly involved in the incident should review it for:
+
+- Accuracy and completeness of the timeline.
+- Clarity of the root cause statement.
+- Reasonableness of action items (actionable, scoped, owned).
+- Blameless tone — focus on systems and processes, not individuals.
+
+### Step 4 — Publish and link
+
+Once merged, add a link to the postmortem document in the GitHub issue created in Step 1, then close the issue. Update the [postmortem index](#5-postmortem-index) at the bottom of this file.
+
+---
+
+## 4. How Action Items Are Tracked
+
+Action items identified in a postmortem must be managed as first-class work, not left as untracked notes.
+
+### Creating action item issues
+
+For each row in the postmortem's **Action Items** table:
+
+1. Open a GitHub issue with title: `[postmortem follow-up] <action description>`.
+2. Label it `postmortem-follow-up`.
+3. Assign it to the named owner.
+4. Set a milestone or due date matching the postmortem table.
+5. Paste the link back into the postmortem's Action Items table.
+
+### Tracking progress
+
+- Action items are reviewed at the next team sync after the postmortem is published.
+- Overdue items (past their due date and not closed) must be escalated to a maintainer.
+- Action items may be closed only when the fix is merged and verified — not when the PR is opened.
+
+### Definition of done for an action item
+
+An action item is **done** when all of the following are true:
+
+- [ ] The fix, alert, runbook update, or process change is merged to `main`.
+- [ ] The GitHub issue is closed with a comment citing the merged PR.
+- [ ] The postmortem document is updated if the action changed the permanent fix or resolution steps.
+
+---
+
+## 5. Postmortem Index
+
+List all published postmortems here in reverse chronological order. Update this table each time a new postmortem is merged.
+
+| Date | Incident Title | Severity | Postmortem |
+|---|---|---|---|
+| _YYYY-MM-DD_ | _Example: Soroban indexer lag caused by missing DB index_ | _P2_ | _[POSTMORTEM-YYYY-MM-DD-short-title.md](postmortems/POSTMORTEM-YYYY-MM-DD-short-title.md)_ |
+
+---
+
+## 6. Related Documents
+
+- [Postmortem Template](POSTMORTEM_TEMPLATE.md) — fill this out for every postmortem.
+- [Bug Triage Guide](BUG_TRIAGE_GUIDE.md) — how bugs are reported, prioritized, and escalated.
+- [ETL & Data Pipeline Runbook](ETL_RUNBOOK.md) — recovery procedures for data pipeline incidents.
+- [Review Playbook](review-playbook.md) — PR review standards, including hotfix path for critical incidents.

--- a/document/POSTMORTEM_TEMPLATE.md
+++ b/document/POSTMORTEM_TEMPLATE.md
@@ -1,0 +1,131 @@
+# Incident Postmortem Template
+
+**Version**: 1.0.0
+**Audience**: On-call engineers, incident leads, and maintainers
+**Purpose**: Provide a consistent, reusable structure for documenting incident postmortems so that every incident produces actionable learnings and traceable follow-up tasks.
+
+> **How to use this template**: Copy this file, rename it to `POSTMORTEM-<YYYY-MM-DD>-<short-title>.md`, place it under `document/postmortems/`, and fill in every section. Remove this callout block before publishing.
+
+---
+
+## Incident Summary
+
+| Field | Value |
+|---|---|
+| **Incident ID** | INC-XXXX |
+| **Title** | _One-line description of the incident_ |
+| **Date / Time (UTC)** | YYYY-MM-DD HH:MM – HH:MM UTC |
+| **Duration** | _e.g., 47 minutes_ |
+| **Severity** | _P1 / P2 / P3 / P4_ |
+| **Status** | _Resolved / Monitoring / Ongoing_ |
+| **Incident Lead** | _@handle_ |
+| **Scribe** | _@handle_ |
+| **Reviewers** | _@handle, @handle_ |
+
+---
+
+## Timeline
+
+List events in chronological order. Include detection, escalation, key debugging steps, mitigation, and resolution. Use UTC timestamps.
+
+| Time (UTC) | Event |
+|---|---|
+| HH:MM | _Brief description of what happened_ |
+| HH:MM | _Alert fired / page sent_ |
+| HH:MM | _On-call engineer acknowledged_ |
+| HH:MM | _Root cause identified_ |
+| HH:MM | _Mitigation applied_ |
+| HH:MM | _Service fully restored_ |
+
+---
+
+## Impact
+
+Describe the observable effect on users and systems during the incident window.
+
+- **Services affected**: _e.g., News Feed API, Portfolio sync, Soroban event indexer_
+- **User-facing impact**: _e.g., 100% of requests to /api/news returned 503 for 34 minutes_
+- **Data impact**: _e.g., ~12 minutes of Soroban events not indexed; backfilled after resolution_
+- **Financial / reward impact**: _e.g., No reward contract calls were attempted during the window_
+- **Blast radius**: _e.g., Testnet only / Mainnet / All environments_
+
+---
+
+## Root Cause
+
+State the single primary cause of the incident. Be specific — name the component, line of code, configuration value, or external dependency that failed.
+
+> _Example: A missing index on the `soroban_events.ledger_sequence` column caused query time to exceed the 5-second NestJS timeout under load introduced by the v1.4 deployment._
+
+---
+
+## Contributing Factors
+
+List conditions that made the incident worse or more likely to occur. These are not root causes but are important for prevention.
+
+- _e.g., No alerting threshold was set for query latency on the soroban-events endpoint._
+- _e.g., The staging environment did not mirror production data volume, so the regression was not caught in QA._
+- _e.g., Runbook for Soroban RPC failures did not cover database-side latency spikes._
+
+---
+
+## Detection
+
+Explain how the incident was identified and whether detection was timely.
+
+- **Detected by**: _Automated alert / User report / On-call observation_
+- **Alert / signal**: _e.g., Prometheus alert `soroban_event_lag_seconds > 60` fired at HH:MM_
+- **Time to detection**: _e.g., 8 minutes after first user impact_
+- **Detection gap**: _Describe any delay and why it occurred_
+
+---
+
+## Resolution
+
+Describe the steps taken to resolve the incident, including any temporary mitigations and the final fix.
+
+### Immediate Mitigation
+
+_e.g., Restarted the soroban-event-indexer service to clear in-flight query backlog._
+
+### Permanent Fix
+
+_e.g., Added `CREATE INDEX CONCURRENTLY idx_soroban_events_ledger ON soroban_events(ledger_sequence)` in migration `0042_add_soroban_ledger_index.sql`._
+
+### Verification
+
+_e.g., Confirmed event lag returned to < 5 seconds via Grafana dashboard; backfilled missing events using `backfill_contract_events.py`._
+
+---
+
+## Action Items
+
+Each action item must have a single owner and a concrete due date. Track these as GitHub issues and link them here.
+
+| # | Action | Owner | Due Date | Issue |
+|---|---|---|---|---|
+| 1 | _Add Prometheus alert for DB query latency on soroban-events endpoint_ | @handle | YYYY-MM-DD | #XXX |
+| 2 | _Update staging data volume to match production for load-sensitive paths_ | @handle | YYYY-MM-DD | #XXX |
+| 3 | _Add runbook entry for database latency spikes affecting the indexer_ | @handle | YYYY-MM-DD | #XXX |
+
+---
+
+## Lessons Learned
+
+Summarize the key insights from this incident. Focus on what the team will do differently going forward.
+
+### What went well
+
+- _e.g., On-call acknowledged the page within 3 minutes._
+- _e.g., The Soroban indexer cursor mechanism prevented data loss after restart._
+
+### What could be improved
+
+- _e.g., Alerting coverage for database-side performance was incomplete._
+- _e.g., The runbook did not provide a clear decision tree for this failure mode._
+
+### Follow-up questions
+
+_Optional: List any open questions that need investigation but are not yet action items._
+
+- _e.g., Is query latency also a risk for the portfolio reconciliation job?_


### PR DESCRIPTION
Closes Waffle-finance/waffle-finance-core#182

## Summary

This PR adds a formal incident postmortem template and workflow to the repository, addressing issue [#182](https://github.com/Waffle-finance/waffle-finance-core/issues/182) in Waffle-finance/waffle-finance-core.

The implementation includes:
- A structured postmortem template with required sections (timeline, root cause, impact, action items)
- An incident postmortem workflow guide linked to the bug triage guide
- A repeatable postmortem process to ensure incidents produce actionable learnings

## Linked Issue

Closes Waffle-finance/waffle-finance-core#182

## Type of Change

- [ ] feat
- [ ] fix
- [x] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Validation

- [ ] Lint passed for affected area(s)
- [ ] Tests passed for affected area(s)
- [x] Manual verification completed (if applicable)

## Documentation

- [x] Documentation updated (or N/A with explanation)
- [ ] Screenshots/videos attached for UI changes

## Checklist

- [x] Branch name uses `feat/`, `fix/`, or `docs/`
- [x] Commit messages follow Conventional Commits
- [x] PR scope matches linked issue acceptance criteria     close #182