### PR TITLE
feat: implement  Testnet account bootstrap endpoint using Friendbot s…

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -71,6 +71,9 @@ RATE_LIMIT_SEARCH_READ_BLOCK_MS=60000
 RATE_LIMIT_ANALYTICS_READ_LIMIT=60
 RATE_LIMIT_ANALYTICS_READ_TTL_MS=60000
 RATE_LIMIT_ANALYTICS_READ_BLOCK_MS=60000
+RATE_LIMIT_FRIENDBOT_BOOTSTRAP_LIMIT=5
+RATE_LIMIT_FRIENDBOT_BOOTSTRAP_TTL_MS=3600000
+RATE_LIMIT_FRIENDBOT_BOOTSTRAP_BLOCK_MS=3600000
 IP_ALLOWLIST=
 IP_DENYLIST=
 
@@ -81,6 +84,12 @@ STELLAR_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 STELLAR_TIMEOUT=30000
 STELLAR_RETRY_ATTEMPTS=3
 STELLAR_RETRY_DELAY=1000
+
+# Friendbot bootstrap (testnet only — requires STELLAR_NETWORK=testnet)
+# Set FRIENDBOT_BOOTSTRAP_ENABLED=true to allow the POST /stellar/bootstrap endpoint.
+# This endpoint is JWT-protected and rate-limited. Never enable in production.
+FRIENDBOT_BOOTSTRAP_ENABLED=false
+FRIENDBOT_URL=https://friendbot.stellar.org
 
 # Dependency latency budget health thresholds
 # Latency (ms) above which a dependency is flagged as "degraded" (HTTP 200).

--- a/apps/backend/src/common/rate-limit/rate-limit.config.ts
+++ b/apps/backend/src/common/rate-limit/rate-limit.config.ts
@@ -22,6 +22,7 @@ export interface RateLimitSettings {
   stellarRead: RateLimitProfile;
   searchRead: RateLimitProfile;
   analyticsRead: RateLimitProfile;
+  friendbotBootstrap: RateLimitProfile;
   tracker: {
     useIp: boolean;
     useApiKey: boolean;
@@ -45,6 +46,7 @@ const DEFAULTS = {
     stellarRead: { limit: 60, ttl: 60_000, blockDuration: 60_000 },
     searchRead: { limit: 60, ttl: 60_000, blockDuration: 60_000 },
     analyticsRead: { limit: 60, ttl: 60_000, blockDuration: 60_000 },
+    friendbotBootstrap: { limit: 5, ttl: 3600_000, blockDuration: 3600_000 },
   },
   staging: {
     global: { limit: 180, ttl: 60_000, blockDuration: 60_000 },
@@ -59,6 +61,7 @@ const DEFAULTS = {
     stellarRead: { limit: 40, ttl: 60_000, blockDuration: 60_000 },
     searchRead: { limit: 40, ttl: 60_000, blockDuration: 60_000 },
     analyticsRead: { limit: 40, ttl: 60_000, blockDuration: 60_000 },
+    friendbotBootstrap: { limit: 3, ttl: 3600_000, blockDuration: 3600_000 },
   },
   production: {
     global: { limit: 120, ttl: 60_000, blockDuration: 60_000 },
@@ -73,6 +76,7 @@ const DEFAULTS = {
     stellarRead: { limit: 30, ttl: 60_000, blockDuration: 60_000 },
     searchRead: { limit: 30, ttl: 60_000, blockDuration: 60_000 },
     analyticsRead: { limit: 30, ttl: 60_000, blockDuration: 60_000 },
+    friendbotBootstrap: { limit: 2, ttl: 3600_000, blockDuration: 3600_000 },
   },
 } as const;
 
@@ -121,7 +125,8 @@ function resolveProfile(
     | 'crowdfundRead'
     | 'stellarRead'
     | 'searchRead'
-    | 'analyticsRead',
+    | 'analyticsRead'
+    | 'friendbotBootstrap',
 ): RateLimitProfile {
   const profileDefaults = DEFAULTS[getEnvironmentName(env.NODE_ENV)][key];
   const envKeyPrefix = key
@@ -161,6 +166,7 @@ export function getRateLimitSettings(
       stellarRead: config.rateLimit.stellarRead,
       searchRead: config.rateLimit.searchRead,
       analyticsRead: config.rateLimit.analyticsRead,
+      friendbotBootstrap: config.rateLimit.friendbotBootstrap,
       tracker: config.rateLimit.tracker,
       redisUrl: config.rateLimit.redisUrl,
       redisNamespace: config.rateLimit.redisNamespace,
@@ -180,6 +186,7 @@ export function getRateLimitSettings(
     stellarRead: resolveProfile(env, 'stellarRead'),
     searchRead: resolveProfile(env, 'searchRead'),
     analyticsRead: resolveProfile(env, 'analyticsRead'),
+    friendbotBootstrap: resolveProfile(env, 'friendbotBootstrap'),
     tracker: {
       useIp: parseBoolean(env.RATE_LIMIT_TRACK_BY_IP, true),
       useApiKey: parseBoolean(env.RATE_LIMIT_TRACK_BY_API_KEY, false),
@@ -307,5 +314,11 @@ export function getSearchReadThrottleOverride() {
 export function getAnalyticsReadThrottleOverride() {
   return {
     default: getRateLimitSettings().analyticsRead,
+  };
+}
+
+export function getFriendbotBootstrapThrottleOverride() {
+  return {
+    default: getRateLimitSettings().friendbotBootstrap,
   };
 }

--- a/apps/backend/src/lib/config.ts
+++ b/apps/backend/src/lib/config.ts
@@ -155,6 +155,7 @@ const RATE_LIMIT_DEFAULTS = {
     stellarRead: { limit: 60, ttl: 60_000, blockDuration: 60_000 },
     searchRead: { limit: 60, ttl: 60_000, blockDuration: 60_000 },
     analyticsRead: { limit: 60, ttl: 60_000, blockDuration: 60_000 },
+    friendbotBootstrap: { limit: 5, ttl: 3600_000, blockDuration: 3600_000 },
   },
   staging: {
     global: { limit: 180, ttl: 60_000, blockDuration: 60_000 },
@@ -169,6 +170,7 @@ const RATE_LIMIT_DEFAULTS = {
     stellarRead: { limit: 40, ttl: 60_000, blockDuration: 60_000 },
     searchRead: { limit: 40, ttl: 60_000, blockDuration: 60_000 },
     analyticsRead: { limit: 40, ttl: 60_000, blockDuration: 60_000 },
+    friendbotBootstrap: { limit: 3, ttl: 3600_000, blockDuration: 3600_000 },
   },
   production: {
     global: { limit: 120, ttl: 60_000, blockDuration: 60_000 },
@@ -183,6 +185,7 @@ const RATE_LIMIT_DEFAULTS = {
     stellarRead: { limit: 30, ttl: 60_000, blockDuration: 60_000 },
     searchRead: { limit: 30, ttl: 60_000, blockDuration: 60_000 },
     analyticsRead: { limit: 30, ttl: 60_000, blockDuration: 60_000 },
+    friendbotBootstrap: { limit: 2, ttl: 3600_000, blockDuration: 3600_000 },
   },
 } as const;
 
@@ -301,6 +304,11 @@ const envSchema = z
   .object({
     NODE_ENV: z.enum(['development', 'test', 'staging', 'production']),
     ENVIRONMENT: z.string().min(1).default(runtime.environment),
+    FRIENDBOT_BOOTSTRAP_ENABLED: z.preprocess(
+      parseBoolean,
+      z.boolean().default(false),
+    ),
+    FRIENDBOT_URL: z.string().url().optional(),
 
     PORT: z.coerce.number().int().min(1).max(65535),
 
@@ -665,6 +673,17 @@ const resolvedRateLimit = {
     blockDuration:
       parsedEnv.RATE_LIMIT_ANALYTICS_READ_BLOCK_MS ??
       rateLimitDefaults.analyticsRead.blockDuration,
+  },
+  friendbotBootstrap: {
+    limit:
+      parsedEnv.RATE_LIMIT_FRIENDBOT_BOOTSTRAP_LIMIT ??
+      rateLimitDefaults.friendbotBootstrap.limit,
+    ttl:
+      parsedEnv.RATE_LIMIT_FRIENDBOT_BOOTSTRAP_TTL_MS ??
+      rateLimitDefaults.friendbotBootstrap.ttl,
+    blockDuration:
+      parsedEnv.RATE_LIMIT_FRIENDBOT_BOOTSTRAP_BLOCK_MS ??
+      rateLimitDefaults.friendbotBootstrap.blockDuration,
   },
 };
 
@@ -1147,6 +1166,15 @@ export const config = Object.freeze({
       ttl: resolvedRateLimit.analyticsRead.ttl,
       blockDuration: resolvedRateLimit.analyticsRead.blockDuration,
     }),
+    friendbotBootstrap: Object.freeze({
+      limit: resolvedRateLimit.friendbotBootstrap.limit,
+      ttl: resolvedRateLimit.friendbotBootstrap.ttl,
+      blockDuration: resolvedRateLimit.friendbotBootstrap.blockDuration,
+    }),
+  }),
+  friendbot: Object.freeze({
+    enabled: parsedEnv.FRIENDBOT_BOOTSTRAP_ENABLED,
+    url: parsedEnv.FRIENDBOT_URL ?? 'https://friendbot.stellar.org',
   }),
   ipAccess: Object.freeze({
     allowlist: parsedEnv.IP_ALLOWLIST ?? null,

--- a/apps/backend/src/stellar/dto/friendbot.dto.ts
+++ b/apps/backend/src/stellar/dto/friendbot.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
+
+export class BootstrapAccountRequestDto {
+  @ApiProperty({
+    description: 'Stellar testnet public key to fund (starts with G, 56 chars)',
+    example: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^G[A-Z2-7]{55}$/, {
+    message: 'publicKey must be a valid Stellar public key (starts with G, 56 base32 characters)',
+  })
+  publicKey: string;
+}
+
+export class BootstrapAccountResponseDto {
+  @ApiProperty({
+    description: 'Success status of the bootstrap request',
+    example: true,
+  })
+  success: boolean;
+
+  @ApiProperty({
+    description: 'Message describing the result',
+    example: 'Account funded successfully',
+  })
+  message: string;
+
+  @ApiProperty({
+    description: 'The public key that was funded',
+    example: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  })
+  publicKey: string;
+}

--- a/apps/backend/src/stellar/exceptions/stellar.exceptions.ts
+++ b/apps/backend/src/stellar/exceptions/stellar.exceptions.ts
@@ -50,3 +50,37 @@ export class HorizonUnavailableException extends HttpException {
     );
   }
 }
+
+/**
+ * Exception thrown when Friendbot is unavailable
+ */
+export class FriendbotUnavailableException extends HttpException {
+  constructor(friendbotUrl: string, cause?: string) {
+    super(
+      {
+        statusCode: HttpStatus.SERVICE_UNAVAILABLE,
+        message: `Friendbot is unavailable at ${friendbotUrl}${cause ? `: ${cause}` : ''}`,
+        error: 'Friendbot Unavailable',
+        friendbotUrl,
+      },
+      HttpStatus.SERVICE_UNAVAILABLE,
+    );
+  }
+}
+
+/**
+ * Exception thrown when Friendbot bootstrap fails
+ */
+export class FriendbotBootstrapFailedException extends HttpException {
+  constructor(publicKey: string, cause?: string) {
+    super(
+      {
+        statusCode: HttpStatus.BAD_REQUEST,
+        message: `Failed to bootstrap account ${publicKey}${cause ? `: ${cause}` : ''}`,
+        error: 'Friendbot Bootstrap Failed',
+        publicKey,
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+  }
+}

--- a/apps/backend/src/stellar/services/friendbot.service.ts
+++ b/apps/backend/src/stellar/services/friendbot.service.ts
@@ -1,0 +1,96 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { config } from '../../lib/config';
+import { validateStellarPublicKey } from '../utils/stellar-validator';
+import {
+  FriendbotBootstrapFailedException,
+  FriendbotUnavailableException,
+  InvalidPublicKeyException,
+} from '../exceptions/stellar.exceptions';
+import { retryWithBackoff } from '../utils/retry.util';
+import { NetworkError } from '@stellar/stellar-sdk';
+
+@Injectable()
+export class FriendbotService {
+  private readonly logger = new Logger(FriendbotService.name);
+  private readonly friendbotUrl: string;
+
+  constructor() {
+    this.friendbotUrl = config.friendbot.url;
+    this.logger.log(`FriendbotService initialized with Friendbot at ${this.friendbotUrl}`);
+  }
+
+  /**
+   * Checks if Friendbot is enabled in the configuration
+   */
+  isEnabled(): boolean {
+    return config.friendbot.enabled;
+  }
+
+  /**
+   * Fund a testnet account using Friendbot
+   * @param publicKey The testnet account public key to fund
+   * @returns Promise<void>
+   */
+  async fundAccount(publicKey: string): Promise<void> {
+    if (!this.isEnabled()) {
+      throw new FriendbotBootstrapFailedException(publicKey, 'Friendbot bootstrap is not enabled');
+    }
+
+    // Validate public key format
+    validateStellarPublicKey(publicKey);
+
+    this.logger.log(`Attempting to fund account ${publicKey} via Friendbot`);
+
+    try {
+      await retryWithBackoff(
+        async () => {
+          const response = await fetch(`${this.friendbotUrl}?addr=${encodeURIComponent(publicKey)}`, {
+            method: 'GET',
+          });
+
+          if (!response.ok) {
+            const errorText = await response.text().catch(() => 'No error message');
+            throw new Error(`Friendbot returned status ${response.status}: ${errorText}`);
+          }
+
+          return response.json();
+        },
+        3,
+        1000,
+        (error) => {
+          // Retry on network errors and 5xx server errors
+          if (error instanceof NetworkError) {
+            return true;
+          }
+          const errorObj = error as { response?: { status?: number } };
+          const status = errorObj?.response?.status;
+          return status === undefined || status >= 500;
+        },
+      );
+
+      this.logger.log(`Successfully funded account ${publicKey}`);
+    } catch (error: unknown) {
+      return this.handleError(error, publicKey);
+    }
+  }
+
+  private handleError(error: unknown, publicKey: string): never {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+
+    if (error instanceof NetworkError) {
+      this.logger.error(`Network error funding account ${publicKey}:`, errorMessage);
+      throw new FriendbotUnavailableException(this.friendbotUrl, errorMessage);
+    }
+
+    const errorObj = error as { response?: { status?: number } };
+    const status = errorObj?.response?.status;
+
+    if (status && status >= 500) {
+      this.logger.error(`Friendbot server error (${status}) for account ${publicKey}:`, errorMessage);
+      throw new FriendbotUnavailableException(this.friendbotUrl, errorMessage);
+    }
+
+    this.logger.error(`Failed to fund account ${publicKey}:`, errorMessage);
+    throw new FriendbotBootstrapFailedException(publicKey, errorMessage);
+  }
+}

--- a/apps/backend/src/stellar/stellar.controller.ts
+++ b/apps/backend/src/stellar/stellar.controller.ts
@@ -8,6 +8,7 @@ import {
   HttpCode,
   HttpStatus,
   BadRequestException,
+  ForbiddenException,
   UseInterceptors,
   UseGuards,
   ParseIntPipe,
@@ -26,7 +27,7 @@ import {
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { StellarService } from './stellar.service';
-import { getStellarReadThrottleOverride } from '../common/rate-limit/rate-limit.config';
+import { getStellarReadThrottleOverride, getFriendbotBootstrapThrottleOverride } from '../common/rate-limit/rate-limit.config';
 import { AccountBalancesDto } from './dto/balance.dto';
 import {
   AssetDiscoveryQueryDto,
@@ -49,6 +50,8 @@ import {
 } from './dto/rotate-contract-ids.dto';
 import { StellarContractRotationService } from './services/stellar-contract-rotation.service';
 import { ContractRotationService } from './services/contract-rotation.service';
+import { FriendbotService } from './services/friendbot.service';
+import { BootstrapAccountRequestDto, BootstrapAccountResponseDto } from './dto/friendbot.dto';
 
 @ApiTags('stellar')
 @Controller('stellar')
@@ -59,6 +62,7 @@ export class StellarController {
     private readonly transactionService: TransactionService,
     private readonly contractRotationService: StellarContractRotationService,
     private readonly contractValidationService: ContractRotationService,
+    private readonly friendbotService: FriendbotService,
     @Inject(stellarConfig.KEY)
     private readonly config: ConfigType<typeof stellarConfig>,
   ) {}
@@ -367,5 +371,69 @@ export class StellarController {
       ipAddress,
       request.reason,
     );
+  }
+
+  /**
+   * @summary Bootstrap a testnet account using Friendbot
+   * @description Funds a testnet account with XLM using Stellar Friendbot.
+   * Only available when STELLAR_NETWORK=testnet and FRIENDBOT_BOOTSTRAP_ENABLED=true.
+   * Requires a valid JWT. Rate-limited to prevent abuse.
+   */
+  @Post('bootstrap')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @Throttle(getFriendbotBootstrapThrottleOverride())
+  @ApiOperation({
+    summary: 'Bootstrap a testnet account (Friendbot)',
+    description:
+      'Funds a fresh testnet account with XLM using Stellar Friendbot. ' +
+      'Only available on testnet with FRIENDBOT_BOOTSTRAP_ENABLED=true. Requires authentication.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Account funded successfully',
+    type: BootstrapAccountResponseDto,
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid public key format',
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized — valid JWT required',
+  })
+  @ApiResponse({
+    status: 403,
+    description: 'Friendbot bootstrap is disabled or network is not testnet',
+  })
+  @ApiResponse({
+    status: 429,
+    description: 'Rate limit exceeded',
+  })
+  @ApiResponse({
+    status: 503,
+    description: 'Friendbot is unavailable',
+  })
+  async bootstrapAccount(
+    @Body() request: BootstrapAccountRequestDto,
+  ): Promise<BootstrapAccountResponseDto> {
+    if (this.config.network !== 'testnet') {
+      throw new ForbiddenException(
+        'Friendbot bootstrap is only available on testnet',
+      );
+    }
+
+    if (!this.friendbotService.isEnabled()) {
+      throw new ForbiddenException('Friendbot bootstrap is not enabled');
+    }
+
+    await this.friendbotService.fundAccount(request.publicKey);
+
+    return {
+      success: true,
+      message: 'Account funded successfully',
+      publicKey: request.publicKey,
+    };
   }
 }

--- a/apps/backend/src/stellar/stellar.module.ts
+++ b/apps/backend/src/stellar/stellar.module.ts
@@ -11,6 +11,7 @@ import { AppConfigModule } from '../config/config.module';
 import { SorobanRpcClientService } from './services/soroban-rpc-client.service';
 import { MatchingPoolAdminController } from './controllers/matching-pool-admin.controller';
 import { AppCacheModule } from '../cache/cache.module';
+import { FriendbotService } from './services/friendbot.service';
 
 @Module({
   imports: [
@@ -26,12 +27,14 @@ import { AppCacheModule } from '../cache/cache.module';
     SorobanRpcClientService,
     ContractRotationService,
     StellarContractRotationService,
+    FriendbotService,
   ],
   exports: [
     StellarService,
     SorobanRpcClientService,
     ContractRotationService,
     StellarContractRotationService,
+    FriendbotService,
   ],
 })
 export class StellarModule {}


### PR DESCRIPTION
PR description
The bootstrapAccount endpoint (POST /stellar/bootstrap) now fully satisfies the acceptance criteria:

@UseGuards(JwtAuthGuard) + @ApiBearerAuth — requires a valid JWT, blocking unauthenticated abuse
this.config.network !== 'testnet' check — throws 403 ForbiddenException if the running network is mainnet, making the guard environment-aware
isEnabled() check returns 403 ForbiddenException (was incorrectly 401 UnauthorizedException before)
@Throttle(getFriendbotBootstrapThrottleOverride()) — already wired to the friendbotBootstrap rate limit profile (5/hr dev, 3/hr staging, 2/hr prod)
@Matches(/^G[A-Z2-7]{55}$/) on the DTO — validates the Stellar public key format at the request validation layer before it even hits the service
.env.example comment updated to make the testnet-only constraint and the "never enable in production" intent explicit
close #843 