### PR TITLE
fix: resolve stellar_asset_id import error in data-processing CI

### DIFF
--- a/apps/data-processing/pytest.ini
+++ b/apps/data-processing/pytest.ini
@@ -3,6 +3,7 @@ testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
+pythonpath = .
 addopts = -v --tb=short
 markers =
     unit: Unit tests

--- a/apps/data-processing/src/ingestion/__init__.py
+++ b/apps/data-processing/src/ingestion/__init__.py
@@ -1,6 +1,16 @@
 """
 Data ingestion module for fetching external data.
 """
+from .stellar_asset_id import (
+    KNOWN_ASSETS,
+    NATIVE_KEY,
+    AssetID,
+    display_name,
+    make_asset_key,
+    normalize_asset_dict,
+    parse_asset_key,
+)
+
 from .payload_quarantine import (
     QuarantineStore,
     QuarantinedPayload,
@@ -28,9 +38,19 @@ from .social_fetcher import (
 )
 
 __all__ = [
+    # Stellar asset ID helpers
+    "KNOWN_ASSETS",
+    "NATIVE_KEY",
+    "AssetID",
+    "display_name",
+    "make_asset_key",
+    "normalize_asset_dict",
+    "parse_asset_key",
+    # News
     "NewsFetcher",
     "NewsArticle",
     "fetch_news",
+    # Stellar fetcher
     "StellarDataFetcher",
     "VolumeData",
     "TransactionRecord",

--- a/apps/data-processing/tests/conftest.py
+++ b/apps/data-processing/tests/conftest.py
@@ -12,8 +12,10 @@ import sys
 import os
 from unittest.mock import MagicMock
 
-# Add src directory to path for imports
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+# Add the data-processing root (apps/data-processing) to sys.path so that
+# "from src.ingestion.xxx import ..." resolves correctly in all environments,
+# including CI where the working directory may not be on sys.path automatically.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixes the failing `test_stellar_asset_id.py` test job in the data-processing CI workflow.

## Root Cause

`tests/conftest.py` was inserting `apps/data-processing/src` onto `sys.path` instead of the project root (`apps/data-processing`). Because all test files use `from src.ingestion.xxx import ...` style imports, Python needs the **parent** of `src` on the path — not `src` itself.

## Changes

### `tests/conftest.py`
- Fixed `sys.path.insert` to point to the data-processing root (`..`) instead of `../src`

### `pytest.ini`
- Added `pythonpath = .` — pytest 7+ native feature that ensures the working directory is always on `sys.path` in CI (already requires `pytest>=7.0.0` in `requirements.txt`)

### `src/ingestion/__init__.py`
- Exported `stellar_asset_id` symbols (`KNOWN_ASSETS`, `NATIVE_KEY`, `AssetID`, `make_asset_key`, `parse_asset_key`, `normalize_asset_dict`, `display_name`) from the package public API

## Verification

All 52 tests in `tests/test_stellar_asset_id.py` pass locally.

```
52 passed in 0.36s
```

Closes #