### PR TITLE
feat(data-processing): Source freshness SLA monitor for news, price, and on-chain feeds

### DIFF
--- a/apps/data-processing/src/ingestion/__init__.py
+++ b/apps/data-processing/src/ingestion/__init__.py
@@ -27,7 +27,25 @@ from .social_fetcher import (
     fetch_social,
 )
 
+from .freshness_monitor import (
+    FreshnessResult,
+    FreshnessThreshold,
+    StaleSourceReport,
+    probe_news_freshness,
+    probe_onchain_freshness,
+    probe_price_freshness,
+    run_freshness_check,
+)
+
 __all__ = [
+    # Freshness SLA monitor
+    "FreshnessResult",
+    "FreshnessThreshold",
+    "StaleSourceReport",
+    "probe_news_freshness",
+    "probe_onchain_freshness",
+    "probe_price_freshness",
+    "run_freshness_check",
     "NewsFetcher",
     "NewsArticle",
     "fetch_news",

--- a/apps/data-processing/src/ingestion/freshness_monitor.py
+++ b/apps/data-processing/src/ingestion/freshness_monitor.py
@@ -1,0 +1,651 @@
+"""Source Freshness SLA Monitor for the data-processing pipeline.
+
+Tracks freshness and delay budgets across news, price, and on-chain (Stellar)
+feeds so maintainers know when a feed is stale before the product surfaces drift.
+
+Design principles
+-----------------
+* One ``FreshnessThreshold`` per feed, all values configurable via environment
+  variables so SREs can tune without code changes.
+* Each probe runs inside its own try/except block — a failure in one source
+  never blocks the others or the main pipeline.
+* Results are emitted as structured log records **and** as Prometheus metrics so
+  they can be observed from any monitoring stack.
+* ``StaleSourceReport`` objects carry enough context to be actionable on their
+  own (last_seen, age, thresholds, recommended actions).
+* This module is intentionally self-contained at import time — it does not pull
+  in the database layer or heavy fetcher modules so it can be imported in
+  lightweight test environments without full dependency installation.
+
+Usage
+-----
+Run a full freshness scan from the pipeline::
+
+    from src.ingestion.freshness_monitor import run_freshness_check
+
+    report = run_freshness_check()
+    if not report["healthy"]:
+        for stale in report["stale_sources"]:
+            print(stale["recommended_action"])
+
+Environment variables (all optional, defaults shown)
+-----------------------------------------------------
+NEWS_FRESHNESS_WARNING_SECONDS   = 1800   (30 min)
+NEWS_FRESHNESS_CRITICAL_SECONDS  = 3600   (60 min)
+PRICE_FRESHNESS_WARNING_SECONDS  = 300    (5 min)
+PRICE_FRESHNESS_CRITICAL_SECONDS = 900    (15 min)
+ONCHAIN_FRESHNESS_WARNING_SECONDS  = 120  (2 min)
+ONCHAIN_FRESHNESS_CRITICAL_SECONDS = 600  (10 min)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from src.utils.logger import setup_logger
+from src.utils.metrics import INDEXER_LAG_SECONDS, SOURCE_FAILURES_TOTAL, SOURCE_HEALTH
+
+logger = setup_logger("lumenpulse.freshness_monitor")
+
+# ---------------------------------------------------------------------------
+# Severity enum — mirrors AlertSeverity in ingestion_alerting without importing
+# that module (which has heavy DB dependencies).
+# ---------------------------------------------------------------------------
+
+
+class FreshnessSeverity(str, Enum):
+    """Severity classification for a freshness measurement."""
+
+    HEALTHY = "healthy"
+    WARNING = "warning"
+    CRITICAL = "critical"
+
+
+# ---------------------------------------------------------------------------
+# Thresholds
+# ---------------------------------------------------------------------------
+
+_FRESHNESS_DEFAULTS: Dict[str, Dict[str, float]] = {
+    "news_freshness": {"warning": 1800.0, "critical": 3600.0},
+    "price_freshness": {"warning": 300.0, "critical": 900.0},
+    "onchain_freshness": {"warning": 120.0, "critical": 600.0},
+}
+
+
+def _freshness_thresholds(metric_name: str) -> Dict[str, float]:
+    """Return warning/critical thresholds for *metric_name*.
+
+    Values can be overridden via environment variables of the form
+    ``<METRIC_NAME_UPPER>_WARNING_SECONDS`` and
+    ``<METRIC_NAME_UPPER>_CRITICAL_SECONDS``.
+    """
+    base = _FRESHNESS_DEFAULTS.get(metric_name, {"warning": 600.0, "critical": 1800.0})
+    prefix = metric_name.upper()
+    warning = float(os.getenv(f"{prefix}_WARNING_SECONDS", str(base["warning"])))
+    critical = float(os.getenv(f"{prefix}_CRITICAL_SECONDS", str(base["critical"])))
+    return {"warning": warning, "critical": critical}
+
+
+def _severity_for_freshness(lag_seconds: float, metric_name: str) -> FreshnessSeverity:
+    """Classify *lag_seconds* against the metric's threshold ladder."""
+    t = _freshness_thresholds(metric_name)
+    if lag_seconds >= t["critical"]:
+        return FreshnessSeverity.CRITICAL
+    if lag_seconds >= t["warning"]:
+        return FreshnessSeverity.WARNING
+    return FreshnessSeverity.HEALTHY
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FreshnessThreshold:
+    """Configurable SLA thresholds for a single data source."""
+
+    source: str
+    metric_name: str
+    warning_seconds: float
+    critical_seconds: float
+
+    @classmethod
+    def for_source(cls, source: str, metric_name: str) -> "FreshnessThreshold":
+        t = _freshness_thresholds(metric_name)
+        return cls(
+            source=source,
+            metric_name=metric_name,
+            warning_seconds=t["warning"],
+            critical_seconds=t["critical"],
+        )
+
+
+@dataclass
+class FreshnessResult:
+    """Freshness measurement for one data source at a point in time."""
+
+    source: str
+    metric_name: str
+    last_seen_at: Optional[datetime]
+    age_seconds: float
+    severity: FreshnessSeverity
+    warning_threshold_seconds: float
+    critical_threshold_seconds: float
+    checked_at: datetime
+    details: Dict[str, Any] = field(default_factory=dict)
+    error: Optional[str] = None
+
+    def is_stale(self) -> bool:
+        return self.severity in (FreshnessSeverity.WARNING, FreshnessSeverity.CRITICAL)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source": self.source,
+            "metric_name": self.metric_name,
+            "last_seen_at": self.last_seen_at.isoformat() if self.last_seen_at else None,
+            "age_seconds": self.age_seconds,
+            "severity": self.severity.value,
+            "warning_threshold_seconds": self.warning_threshold_seconds,
+            "critical_threshold_seconds": self.critical_threshold_seconds,
+            "checked_at": self.checked_at.isoformat(),
+            "details": self.details,
+            "error": self.error,
+            "is_stale": self.is_stale(),
+        }
+
+    def to_lag_snapshot(self) -> Dict[str, Any]:
+        """Return a dict compatible with LagMetricSnapshot.to_dict().
+
+        Provides a bridge to the existing ingestion_alerting layer without
+        requiring a direct import of that module at load time.
+        """
+        return {
+            "metric_name": self.metric_name,
+            "source": self.source,
+            "lag_seconds": self.age_seconds,
+            "severity": self.severity.value,
+            "warning_threshold_seconds": self.warning_threshold_seconds,
+            "critical_threshold_seconds": self.critical_threshold_seconds,
+            "details": self.details,
+        }
+
+
+@dataclass
+class StaleSourceReport:
+    """Actionable report for a source that has exceeded its freshness SLA."""
+
+    result: FreshnessResult
+    recommended_action: str
+    runbook_hint: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            **self.result.to_dict(),
+            "recommended_action": self.recommended_action,
+            "runbook_hint": self.runbook_hint,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Prometheus helpers (thin wrappers so probes don't import metrics directly)
+# ---------------------------------------------------------------------------
+
+
+def _publish_freshness_metric(result: FreshnessResult) -> None:
+    """Set the INDEXER_LAG_SECONDS gauge for this freshness result."""
+    try:
+        INDEXER_LAG_SECONDS.labels(
+            metric_name=result.metric_name,
+            source=result.source,
+        ).set(result.age_seconds if result.age_seconds != float("inf") else -1.0)
+    except Exception:
+        pass  # Never let metrics emission crash the pipeline
+
+
+def _record_source_failure_metric(source: str, failure_type: str) -> None:
+    try:
+        SOURCE_FAILURES_TOTAL.labels(source=source, failure_type=failure_type).inc()
+        SOURCE_HEALTH.labels(source=source).set(0)
+    except Exception:
+        pass
+
+
+def _record_source_success_metric(source: str) -> None:
+    try:
+        SOURCE_HEALTH.labels(source=source).set(1)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Per-source probe functions
+# ---------------------------------------------------------------------------
+
+_RECOMMENDED_ACTIONS: Dict[str, str] = {
+    "news": (
+        "Verify CRYPTOCOMPARE_API_KEY and NEWSAPI_API_KEY env vars. "
+        "Check for upstream API outages or rate-limit exhaustion."
+    ),
+    "price": (
+        "Verify network access to CoinGecko/CoinCap. "
+        "Check PRICE_FETCHER_TIMEOUT. Trigger a manual price refresh."
+    ),
+    "onchain": (
+        "Verify STELLAR_NETWORK and Horizon RPC connectivity. "
+        "Check for ledger consensus halts on stellarchain.io."
+    ),
+}
+
+_RUNBOOK_HINTS: Dict[str, str] = {
+    "news": "See INGESTION_ALERTING_RUNBOOK.md § News Feed Outage",
+    "price": "See INGESTION_ALERTING_RUNBOOK.md § Price Feed Outage",
+    "onchain": "See INGESTION_ALERTING_RUNBOOK.md § Stellar/Horizon Outage",
+}
+
+
+def _make_stale_report(result: FreshnessResult, feed_key: str) -> StaleSourceReport:
+    return StaleSourceReport(
+        result=result,
+        recommended_action=_RECOMMENDED_ACTIONS.get(feed_key, "Investigate the source."),
+        runbook_hint=_RUNBOOK_HINTS.get(feed_key, "See ingestion runbook."),
+    )
+
+
+def _unknown_freshness(
+    source: str,
+    metric_name: str,
+    error: str,
+    checked_at: datetime,
+) -> FreshnessResult:
+    """Return a CRITICAL result when we cannot determine the last-seen timestamp."""
+    t = _freshness_thresholds(metric_name)
+    return FreshnessResult(
+        source=source,
+        metric_name=metric_name,
+        last_seen_at=None,
+        age_seconds=float("inf"),
+        severity=FreshnessSeverity.CRITICAL,
+        warning_threshold_seconds=t["warning"],
+        critical_threshold_seconds=t["critical"],
+        checked_at=checked_at,
+        error=error,
+        details={"reason": "Probe raised an exception; age unknown"},
+    )
+
+
+def probe_news_freshness(
+    *,
+    last_article_at: Optional[datetime] = None,
+    fetcher_fn: Optional[Any] = None,
+) -> FreshnessResult:
+    """Probe how fresh the latest ingested news article is.
+
+    Parameters
+    ----------
+    last_article_at:
+        Caller can supply the timestamp of the most recently ingested article
+        (e.g. read from cache/DB).  When ``None``, the probe attempts to call
+        *fetcher_fn* to retrieve the latest article timestamp.
+    fetcher_fn:
+        Callable returning the latest article timestamp as a ``datetime``.
+        Used only when *last_article_at* is ``None``.  Kept injectable for
+        easy unit-testing without network calls.
+    """
+    metric_name = "news_freshness"
+    source = "news"
+    checked_at = datetime.now(timezone.utc)
+    t = _freshness_thresholds(metric_name)
+
+    try:
+        ts: Optional[datetime] = last_article_at
+
+        if ts is None and fetcher_fn is not None:
+            ts = fetcher_fn()
+
+        if ts is None:
+            result = FreshnessResult(
+                source=source,
+                metric_name=metric_name,
+                last_seen_at=None,
+                age_seconds=float("inf"),
+                severity=FreshnessSeverity.CRITICAL,
+                warning_threshold_seconds=t["warning"],
+                critical_threshold_seconds=t["critical"],
+                checked_at=checked_at,
+                error="No article timestamp available",
+                details={"reason": "last_article_at is None and fetcher returned None"},
+            )
+            _record_source_failure_metric(source, "no_data")
+            logger.warning(
+                "news_freshness: no article timestamp available",
+                extra={"source": source, "metric_name": metric_name},
+            )
+            return result
+
+        # Normalise to UTC
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+
+        age = max(0.0, (checked_at - ts).total_seconds())
+        severity = _severity_for_freshness(age, metric_name)
+
+        result = FreshnessResult(
+            source=source,
+            metric_name=metric_name,
+            last_seen_at=ts,
+            age_seconds=age,
+            severity=severity,
+            warning_threshold_seconds=t["warning"],
+            critical_threshold_seconds=t["critical"],
+            checked_at=checked_at,
+            details={"last_article_at": ts.isoformat()},
+        )
+
+        if severity == FreshnessSeverity.HEALTHY:
+            _record_source_success_metric(source)
+        else:
+            _record_source_failure_metric(source, "stale")
+            logger.warning(
+                "news_freshness SLA breach: feed is %.0fs old",
+                age,
+                extra={"source": source, "severity": severity.value, "age_seconds": age},
+            )
+
+        return result
+
+    except Exception as exc:  # non-blocking: catch all
+        logger.warning("News freshness probe failed: %s", exc, exc_info=True)
+        _record_source_failure_metric(source, type(exc).__name__)
+        return _unknown_freshness(source, metric_name, str(exc), checked_at)
+
+
+def probe_price_freshness(
+    *,
+    last_price_at: Optional[datetime] = None,
+    fetcher_fn: Optional[Any] = None,
+) -> FreshnessResult:
+    """Probe how fresh the latest ingested price tick is.
+
+    Parameters
+    ----------
+    last_price_at:
+        Timestamp of the most recently recorded price payload.
+    fetcher_fn:
+        Callable returning the latest price timestamp as a ``datetime``.
+    """
+    metric_name = "price_freshness"
+    source = "price"
+    checked_at = datetime.now(timezone.utc)
+    t = _freshness_thresholds(metric_name)
+
+    try:
+        ts: Optional[datetime] = last_price_at
+
+        if ts is None and fetcher_fn is not None:
+            ts = fetcher_fn()
+
+        if ts is None:
+            result = FreshnessResult(
+                source=source,
+                metric_name=metric_name,
+                last_seen_at=None,
+                age_seconds=float("inf"),
+                severity=FreshnessSeverity.CRITICAL,
+                warning_threshold_seconds=t["warning"],
+                critical_threshold_seconds=t["critical"],
+                checked_at=checked_at,
+                error="No price timestamp available",
+                details={"reason": "last_price_at is None and fetcher returned None"},
+            )
+            _record_source_failure_metric(source, "no_data")
+            logger.warning(
+                "price_freshness: no price timestamp available",
+                extra={"source": source, "metric_name": metric_name},
+            )
+            return result
+
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+
+        age = max(0.0, (checked_at - ts).total_seconds())
+        severity = _severity_for_freshness(age, metric_name)
+
+        result = FreshnessResult(
+            source=source,
+            metric_name=metric_name,
+            last_seen_at=ts,
+            age_seconds=age,
+            severity=severity,
+            warning_threshold_seconds=t["warning"],
+            critical_threshold_seconds=t["critical"],
+            checked_at=checked_at,
+            details={"last_price_at": ts.isoformat()},
+        )
+
+        if severity == FreshnessSeverity.HEALTHY:
+            _record_source_success_metric(source)
+        else:
+            _record_source_failure_metric(source, "stale")
+            logger.warning(
+                "price_freshness SLA breach: feed is %.0fs old",
+                age,
+                extra={"source": source, "severity": severity.value, "age_seconds": age},
+            )
+
+        return result
+
+    except Exception as exc:
+        logger.warning("Price freshness probe failed: %s", exc, exc_info=True)
+        _record_source_failure_metric(source, type(exc).__name__)
+        return _unknown_freshness(source, metric_name, str(exc), checked_at)
+
+
+def probe_onchain_freshness(
+    *,
+    last_ledger_at: Optional[datetime] = None,
+    fetcher_fn: Optional[Any] = None,
+) -> FreshnessResult:
+    """Probe how fresh the latest on-chain (Stellar ledger) data is.
+
+    Parameters
+    ----------
+    last_ledger_at:
+        Timestamp of the most recently ingested ledger close.
+    fetcher_fn:
+        Callable returning the latest ledger close timestamp as a ``datetime``.
+    """
+    metric_name = "onchain_freshness"
+    source = "onchain"
+    checked_at = datetime.now(timezone.utc)
+    t = _freshness_thresholds(metric_name)
+
+    try:
+        ts: Optional[datetime] = last_ledger_at
+
+        if ts is None and fetcher_fn is not None:
+            ts = fetcher_fn()
+
+        if ts is None:
+            result = FreshnessResult(
+                source=source,
+                metric_name=metric_name,
+                last_seen_at=None,
+                age_seconds=float("inf"),
+                severity=FreshnessSeverity.CRITICAL,
+                warning_threshold_seconds=t["warning"],
+                critical_threshold_seconds=t["critical"],
+                checked_at=checked_at,
+                error="No ledger timestamp available",
+                details={"reason": "last_ledger_at is None and fetcher returned None"},
+            )
+            _record_source_failure_metric(source, "no_data")
+            logger.warning(
+                "onchain_freshness: no ledger timestamp available",
+                extra={"source": source, "metric_name": metric_name},
+            )
+            return result
+
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+
+        age = max(0.0, (checked_at - ts).total_seconds())
+        severity = _severity_for_freshness(age, metric_name)
+
+        result = FreshnessResult(
+            source=source,
+            metric_name=metric_name,
+            last_seen_at=ts,
+            age_seconds=age,
+            severity=severity,
+            warning_threshold_seconds=t["warning"],
+            critical_threshold_seconds=t["critical"],
+            checked_at=checked_at,
+            details={"last_ledger_close": ts.isoformat()},
+        )
+
+        if severity == FreshnessSeverity.HEALTHY:
+            _record_source_success_metric(source)
+        else:
+            _record_source_failure_metric(source, "stale")
+            logger.warning(
+                "onchain_freshness SLA breach: feed is %.0fs old",
+                age,
+                extra={"source": source, "severity": severity.value, "age_seconds": age},
+            )
+
+        return result
+
+    except Exception as exc:
+        logger.warning("On-chain freshness probe failed: %s", exc, exc_info=True)
+        _record_source_failure_metric(source, type(exc).__name__)
+        return _unknown_freshness(source, metric_name, str(exc), checked_at)
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+_FEED_KEY_MAP: Dict[str, str] = {
+    "news_freshness": "news",
+    "price_freshness": "price",
+    "onchain_freshness": "onchain",
+}
+
+
+def evaluate_freshness_results(
+    results: List[FreshnessResult],
+) -> List[StaleSourceReport]:
+    """Publish Prometheus metrics and emit log alerts; return stale-source reports."""
+    reports: List[StaleSourceReport] = []
+
+    for result in results:
+        # Update Prometheus
+        _publish_freshness_metric(result)
+
+        # Emit structured log alert for non-healthy sources
+        if result.severity != FreshnessSeverity.HEALTHY:
+            feed_key = _FEED_KEY_MAP.get(result.metric_name, result.source)
+            report = _make_stale_report(result, feed_key)
+            reports.append(report)
+
+            age_label = (
+                f"{result.age_seconds:.0f}s"
+                if result.age_seconds != float("inf")
+                else "unknown"
+            )
+            threshold = (
+                result.critical_threshold_seconds
+                if result.severity == FreshnessSeverity.CRITICAL
+                else result.warning_threshold_seconds
+            )
+            logger.error(
+                "FRESHNESS_SLA_BREACH source=%s severity=%s age=%s threshold=%.0fs | %s",
+                result.source,
+                result.severity.value,
+                age_label,
+                threshold,
+                report.recommended_action,
+                extra={
+                    "alert_type": "freshness_sla_breach",
+                    "freshness_result": result.to_dict(),
+                    "recommended_action": report.recommended_action,
+                    "runbook_hint": report.runbook_hint,
+                },
+            )
+
+    return reports
+
+
+def run_freshness_check(
+    *,
+    news_last_seen_at: Optional[datetime] = None,
+    price_last_seen_at: Optional[datetime] = None,
+    onchain_last_seen_at: Optional[datetime] = None,
+    news_fetcher_fn: Optional[Any] = None,
+    price_fetcher_fn: Optional[Any] = None,
+    onchain_fetcher_fn: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Run freshness probes for all three feeds and return a consolidated report.
+
+    Each probe is independent — an exception in one source does not block the
+    others.  The returned dict is always present and can be inspected
+    programmatically.
+
+    Parameters
+    ----------
+    *_last_seen_at:
+        Pre-computed timestamps for each feed (e.g. read from an in-process
+        cache).  Saves a network round-trip when the caller already knows the
+        latest timestamp.
+    *_fetcher_fn:
+        Callables used to retrieve the latest timestamp when the ``*_last_seen_at``
+        parameter is ``None``.
+
+    Returns
+    -------
+    dict with keys:
+        * ``checked_at``    – ISO-8601 timestamp of this run
+        * ``results``       – list of :class:`FreshnessResult` dicts
+        * ``stale_sources`` – list of :class:`StaleSourceReport` dicts
+        * ``healthy``       – ``True`` when all sources are within SLA
+    """
+    results: List[FreshnessResult] = []
+
+    # --- news (non-blocking) ---
+    results.append(
+        probe_news_freshness(
+            last_article_at=news_last_seen_at,
+            fetcher_fn=news_fetcher_fn,
+        )
+    )
+
+    # --- price (non-blocking) ---
+    results.append(
+        probe_price_freshness(
+            last_price_at=price_last_seen_at,
+            fetcher_fn=price_fetcher_fn,
+        )
+    )
+
+    # --- on-chain (non-blocking) ---
+    results.append(
+        probe_onchain_freshness(
+            last_ledger_at=onchain_last_seen_at,
+            fetcher_fn=onchain_fetcher_fn,
+        )
+    )
+
+    stale_reports = evaluate_freshness_results(results)
+
+    return {
+        "checked_at": datetime.now(timezone.utc).isoformat(),
+        "results": [r.to_dict() for r in results],
+        "stale_sources": [r.to_dict() for r in stale_reports],
+        "healthy": len(stale_reports) == 0,
+    }

--- a/apps/data-processing/tests/conftest.py
+++ b/apps/data-processing/tests/conftest.py
@@ -28,6 +28,27 @@ _HEAVY_MODULES = [
     "stellar_sdk.exceptions",
     "stellar_sdk.call_builder",
     "stellar_sdk.call_builder.call_builder_async",
+    # Translation / NLP deps not installed in the lightweight test env
+    "langdetect",
+    # Database / ORM deps not available in the lightweight test env
+    "sqlalchemy",
+    "sqlalchemy.orm",
+    "sqlalchemy.orm.session",
+    "sqlalchemy.exc",
+    "sqlalchemy.engine",
+    "sqlalchemy.engine.url",
+    "sqlalchemy.dialects",
+    "sqlalchemy.dialects.postgresql",
+    "sqlalchemy.sql",
+    "sqlalchemy.sql.expression",
+    "alembic",
+    "alembic.op",
+    "psycopg2",
+    "asyncpg",
+    # HTTP / networking deps not in lightweight env
+    "requests",
+    "requests.exceptions",
+    "redis",
 ]
 for _mod in _HEAVY_MODULES:
     if _mod not in sys.modules:

--- a/apps/data-processing/tests/test_freshness_monitor.py
+++ b/apps/data-processing/tests/test_freshness_monitor.py
@@ -1,0 +1,482 @@
+"""Tests for the Source Freshness SLA Monitor (issue #1060).
+
+Covers:
+- All three feeds: news, price, on-chain (stellar).
+- Threshold-based severity classification (healthy / warning / critical).
+- Configurable thresholds via environment variables.
+- Stale-source reports contain actionable fields.
+- Non-blocking behaviour: an exception in one probe does not stop others.
+- run_freshness_check() orchestration.
+- FreshnessResult.to_lag_snapshot() bridge dict.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.ingestion.freshness_monitor import (
+    FreshnessSeverity,
+    FreshnessResult,
+    FreshnessThreshold,
+    StaleSourceReport,
+    _freshness_thresholds,
+    _severity_for_freshness,
+    evaluate_freshness_results,
+    probe_news_freshness,
+    probe_onchain_freshness,
+    probe_price_freshness,
+    run_freshness_check,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ts_ago(seconds: float) -> datetime:
+    """Return a timezone-aware UTC datetime *seconds* in the past."""
+    return datetime.now(timezone.utc) - timedelta(seconds=seconds)
+
+
+# ---------------------------------------------------------------------------
+# _freshness_thresholds — env-var configurability
+# ---------------------------------------------------------------------------
+
+
+class TestFreshnessThresholds:
+    def test_defaults_news(self):
+        t = _freshness_thresholds("news_freshness")
+        assert t["warning"] == 1800.0
+        assert t["critical"] == 3600.0
+
+    def test_defaults_price(self):
+        t = _freshness_thresholds("price_freshness")
+        assert t["warning"] == 300.0
+        assert t["critical"] == 900.0
+
+    def test_defaults_onchain(self):
+        t = _freshness_thresholds("onchain_freshness")
+        assert t["warning"] == 120.0
+        assert t["critical"] == 600.0
+
+    def test_env_override_news_warning(self, monkeypatch):
+        monkeypatch.setenv("NEWS_FRESHNESS_WARNING_SECONDS", "999")
+        t = _freshness_thresholds("news_freshness")
+        assert t["warning"] == 999.0
+
+    def test_env_override_price_critical(self, monkeypatch):
+        monkeypatch.setenv("PRICE_FRESHNESS_CRITICAL_SECONDS", "1234")
+        t = _freshness_thresholds("price_freshness")
+        assert t["critical"] == 1234.0
+
+    def test_env_override_onchain(self, monkeypatch):
+        monkeypatch.setenv("ONCHAIN_FRESHNESS_WARNING_SECONDS", "60")
+        monkeypatch.setenv("ONCHAIN_FRESHNESS_CRITICAL_SECONDS", "300")
+        t = _freshness_thresholds("onchain_freshness")
+        assert t["warning"] == 60.0
+        assert t["critical"] == 300.0
+
+    def test_unknown_metric_uses_fallback_defaults(self):
+        t = _freshness_thresholds("nonexistent_metric")
+        assert t["warning"] == 600.0
+        assert t["critical"] == 1800.0
+
+
+class TestFreshnessThresholdClassFactory:
+    def test_for_source_returns_correct_thresholds(self):
+        ft = FreshnessThreshold.for_source("news", "news_freshness")
+        assert ft.source == "news"
+        assert ft.metric_name == "news_freshness"
+        assert ft.warning_seconds == 1800.0
+        assert ft.critical_seconds == 3600.0
+
+
+# ---------------------------------------------------------------------------
+# _severity_for_freshness
+# ---------------------------------------------------------------------------
+
+
+class TestSeverityForFreshness:
+    def test_healthy_when_below_warning(self):
+        assert _severity_for_freshness(100.0, "news_freshness") == FreshnessSeverity.HEALTHY
+
+    def test_warning_when_between_thresholds(self):
+        # Default: news warning=1800, critical=3600
+        assert _severity_for_freshness(2000.0, "news_freshness") == FreshnessSeverity.WARNING
+
+    def test_critical_when_above_critical_threshold(self):
+        assert _severity_for_freshness(5000.0, "news_freshness") == FreshnessSeverity.CRITICAL
+
+    def test_price_feed_tighter_thresholds(self):
+        # Default: price warning=300, critical=900
+        assert _severity_for_freshness(500.0, "price_freshness") == FreshnessSeverity.WARNING
+        assert _severity_for_freshness(1000.0, "price_freshness") == FreshnessSeverity.CRITICAL
+
+    def test_onchain_tightest_thresholds(self):
+        # Default: onchain warning=120, critical=600
+        assert _severity_for_freshness(60.0, "onchain_freshness") == FreshnessSeverity.HEALTHY
+        assert _severity_for_freshness(200.0, "onchain_freshness") == FreshnessSeverity.WARNING
+        assert _severity_for_freshness(700.0, "onchain_freshness") == FreshnessSeverity.CRITICAL
+
+
+# ---------------------------------------------------------------------------
+# probe_news_freshness
+# ---------------------------------------------------------------------------
+
+
+class TestProbeNewsFreshness:
+    def test_healthy_when_recent(self):
+        result = probe_news_freshness(last_article_at=_ts_ago(60))
+        assert result.severity == FreshnessSeverity.HEALTHY
+        assert result.is_stale() is False
+        assert result.source == "news"
+        assert result.metric_name == "news_freshness"
+
+    def test_warning_when_stale_within_critical(self):
+        result = probe_news_freshness(last_article_at=_ts_ago(2000))
+        assert result.severity == FreshnessSeverity.WARNING
+        assert result.is_stale() is True
+
+    def test_critical_when_very_stale(self):
+        result = probe_news_freshness(last_article_at=_ts_ago(5000))
+        assert result.severity == FreshnessSeverity.CRITICAL
+
+    def test_critical_when_no_timestamp_provided(self):
+        result = probe_news_freshness()
+        assert result.severity == FreshnessSeverity.CRITICAL
+        assert result.last_seen_at is None
+        assert result.error is not None
+
+    def test_uses_fetcher_fn_when_timestamp_absent(self):
+        ts = _ts_ago(30)
+        result = probe_news_freshness(fetcher_fn=lambda: ts)
+        assert result.severity == FreshnessSeverity.HEALTHY
+        assert result.last_seen_at == ts
+
+    def test_non_blocking_on_exception_in_fetcher_fn(self):
+        def bad_fetcher():
+            raise RuntimeError("network error")
+
+        result = probe_news_freshness(fetcher_fn=bad_fetcher)
+        # Should not propagate; returns critical result
+        assert result.severity == FreshnessSeverity.CRITICAL
+        assert "network error" in result.error
+
+    def test_naive_datetime_treated_as_utc(self):
+        naive_ts = datetime.utcnow() - timedelta(seconds=60)
+        result = probe_news_freshness(last_article_at=naive_ts)
+        assert result.severity == FreshnessSeverity.HEALTHY
+
+    def test_to_dict_shape(self):
+        result = probe_news_freshness(last_article_at=_ts_ago(60))
+        d = result.to_dict()
+        for key in (
+            "source", "metric_name", "last_seen_at", "age_seconds",
+            "severity", "warning_threshold_seconds", "critical_threshold_seconds",
+            "checked_at", "is_stale",
+        ):
+            assert key in d, f"Missing key: {key}"
+
+    def test_to_lag_snapshot_bridge(self):
+        result = probe_news_freshness(last_article_at=_ts_ago(60))
+        snap = result.to_lag_snapshot()
+        assert snap["metric_name"] == "news_freshness"
+        assert snap["source"] == "news"
+        assert snap["lag_seconds"] == pytest.approx(result.age_seconds, abs=1.0)
+        assert snap["severity"] == "healthy"
+
+    def test_severity_value_is_string(self):
+        result = probe_news_freshness(last_article_at=_ts_ago(60))
+        d = result.to_dict()
+        assert isinstance(d["severity"], str)
+        assert d["severity"] == "healthy"
+
+
+# ---------------------------------------------------------------------------
+# probe_price_freshness
+# ---------------------------------------------------------------------------
+
+
+class TestProbePriceFreshness:
+    def test_healthy_when_recent(self):
+        result = probe_price_freshness(last_price_at=_ts_ago(30))
+        assert result.severity == FreshnessSeverity.HEALTHY
+        assert result.source == "price"
+
+    def test_warning_at_stale_threshold(self):
+        result = probe_price_freshness(last_price_at=_ts_ago(400))
+        assert result.severity == FreshnessSeverity.WARNING
+
+    def test_critical_at_very_stale(self):
+        result = probe_price_freshness(last_price_at=_ts_ago(1000))
+        assert result.severity == FreshnessSeverity.CRITICAL
+
+    def test_critical_when_no_timestamp(self):
+        result = probe_price_freshness()
+        assert result.severity == FreshnessSeverity.CRITICAL
+        assert result.last_seen_at is None
+
+    def test_non_blocking_on_fetcher_exception(self):
+        def bad_fetcher():
+            raise ConnectionError("api down")
+
+        result = probe_price_freshness(fetcher_fn=bad_fetcher)
+        assert result.severity == FreshnessSeverity.CRITICAL
+        assert "api down" in result.error
+
+    def test_uses_fetcher_fn_when_no_timestamp(self):
+        ts = _ts_ago(10)
+        result = probe_price_freshness(fetcher_fn=lambda: ts)
+        assert result.severity == FreshnessSeverity.HEALTHY
+
+    def test_age_matches_elapsed(self):
+        ts = _ts_ago(50)
+        result = probe_price_freshness(last_price_at=ts)
+        assert result.age_seconds == pytest.approx(50.0, abs=2.0)
+
+
+# ---------------------------------------------------------------------------
+# probe_onchain_freshness
+# ---------------------------------------------------------------------------
+
+
+class TestProbeOnchainFreshness:
+    def test_healthy_when_recent(self):
+        result = probe_onchain_freshness(last_ledger_at=_ts_ago(10))
+        assert result.severity == FreshnessSeverity.HEALTHY
+        assert result.source == "onchain"
+
+    def test_warning_between_thresholds(self):
+        result = probe_onchain_freshness(last_ledger_at=_ts_ago(200))
+        assert result.severity == FreshnessSeverity.WARNING
+
+    def test_critical_when_very_old(self):
+        result = probe_onchain_freshness(last_ledger_at=_ts_ago(700))
+        assert result.severity == FreshnessSeverity.CRITICAL
+
+    def test_critical_when_no_timestamp(self):
+        result = probe_onchain_freshness()
+        assert result.severity == FreshnessSeverity.CRITICAL
+
+    def test_non_blocking_on_fetcher_exception(self):
+        def bad_fn():
+            raise TimeoutError("horizon timed out")
+
+        result = probe_onchain_freshness(fetcher_fn=bad_fn)
+        assert result.severity == FreshnessSeverity.CRITICAL
+        assert result.error is not None
+
+    def test_age_seconds_is_non_negative(self):
+        # Even if the timestamp is ever so slightly in the future (clock skew),
+        # age must be clamped to 0.
+        future_ts = datetime.now(timezone.utc) + timedelta(seconds=5)
+        result = probe_onchain_freshness(last_ledger_at=future_ts)
+        assert result.age_seconds >= 0.0
+
+    def test_metric_name_is_onchain_freshness(self):
+        result = probe_onchain_freshness(last_ledger_at=_ts_ago(10))
+        assert result.metric_name == "onchain_freshness"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_freshness_results
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateFreshnessResults:
+    def test_all_healthy_returns_empty_reports(self):
+        results = [
+            probe_news_freshness(last_article_at=_ts_ago(10)),
+            probe_price_freshness(last_price_at=_ts_ago(10)),
+            probe_onchain_freshness(last_ledger_at=_ts_ago(10)),
+        ]
+        reports = evaluate_freshness_results(results)
+        assert reports == []
+
+    def test_stale_source_generates_report(self):
+        results = [probe_news_freshness(last_article_at=_ts_ago(5000))]
+        reports = evaluate_freshness_results(results)
+        assert len(reports) == 1
+        r = reports[0]
+        assert isinstance(r, StaleSourceReport)
+        assert r.recommended_action
+        assert r.runbook_hint
+
+    def test_report_dict_shape(self):
+        results = [probe_price_freshness(last_price_at=_ts_ago(2000))]
+        reports = evaluate_freshness_results(results)
+        d = reports[0].to_dict()
+        assert "recommended_action" in d
+        assert "runbook_hint" in d
+        assert "severity" in d
+
+    def test_multiple_stale_sources_all_reported(self):
+        results = [
+            probe_news_freshness(last_article_at=_ts_ago(5000)),
+            probe_price_freshness(last_price_at=_ts_ago(2000)),
+        ]
+        reports = evaluate_freshness_results(results)
+        assert len(reports) == 2
+
+    def test_healthy_sources_not_included_in_reports(self):
+        results = [
+            probe_news_freshness(last_article_at=_ts_ago(10)),
+            probe_price_freshness(last_price_at=_ts_ago(5000)),
+        ]
+        reports = evaluate_freshness_results(results)
+        assert len(reports) == 1
+        assert reports[0].result.source == "price"
+
+
+# ---------------------------------------------------------------------------
+# run_freshness_check — orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestRunFreshnessCheck:
+    def test_all_healthy_returns_healthy_true(self):
+        report = run_freshness_check(
+            news_last_seen_at=_ts_ago(60),
+            price_last_seen_at=_ts_ago(30),
+            onchain_last_seen_at=_ts_ago(10),
+        )
+        assert report["healthy"] is True
+        assert report["stale_sources"] == []
+        assert len(report["results"]) == 3
+
+    def test_stale_news_sets_healthy_false(self):
+        report = run_freshness_check(
+            news_last_seen_at=_ts_ago(5000),
+            price_last_seen_at=_ts_ago(30),
+            onchain_last_seen_at=_ts_ago(10),
+        )
+        assert report["healthy"] is False
+        sources = {r["source"] for r in report["stale_sources"]}
+        assert "news" in sources
+
+    def test_all_missing_timestamps_returns_all_stale(self):
+        report = run_freshness_check()
+        assert report["healthy"] is False
+        assert len(report["stale_sources"]) == 3
+
+    def test_checked_at_is_present(self):
+        report = run_freshness_check(
+            news_last_seen_at=_ts_ago(10),
+            price_last_seen_at=_ts_ago(10),
+            onchain_last_seen_at=_ts_ago(10),
+        )
+        assert "checked_at" in report
+
+    def test_non_blocking_when_all_fetchers_raise(self):
+        """Even when every fetcher_fn raises, the orchestrator must return a dict."""
+        def boom():
+            raise RuntimeError("boom")
+
+        report = run_freshness_check(
+            news_fetcher_fn=boom,
+            price_fetcher_fn=boom,
+            onchain_fetcher_fn=boom,
+        )
+        assert isinstance(report, dict)
+        assert "results" in report
+        assert len(report["results"]) == 3
+        for r in report["results"]:
+            assert r["severity"] == "critical"
+
+    def test_price_source_stale_included_in_stale_sources(self):
+        report = run_freshness_check(
+            news_last_seen_at=_ts_ago(10),
+            price_last_seen_at=_ts_ago(2000),
+            onchain_last_seen_at=_ts_ago(10),
+        )
+        assert report["healthy"] is False
+        stale_names = [r["source"] for r in report["stale_sources"]]
+        assert "price" in stale_names
+
+    def test_onchain_stale_warning(self):
+        report = run_freshness_check(
+            news_last_seen_at=_ts_ago(10),
+            price_last_seen_at=_ts_ago(10),
+            onchain_last_seen_at=_ts_ago(200),
+        )
+        assert report["healthy"] is False
+        stale_names = [r["source"] for r in report["stale_sources"]]
+        assert "onchain" in stale_names
+
+    def test_uses_fetcher_fns_when_timestamps_absent(self):
+        news_ts = _ts_ago(10)
+        price_ts = _ts_ago(10)
+        onchain_ts = _ts_ago(10)
+        report = run_freshness_check(
+            news_fetcher_fn=lambda: news_ts,
+            price_fetcher_fn=lambda: price_ts,
+            onchain_fetcher_fn=lambda: onchain_ts,
+        )
+        assert report["healthy"] is True
+
+    def test_partial_failure_does_not_block_healthy_sources(self):
+        """One bad fetcher must not prevent healthy probes from completing."""
+        def bad_news():
+            raise RuntimeError("news API down")
+
+        report = run_freshness_check(
+            news_fetcher_fn=bad_news,
+            price_last_seen_at=_ts_ago(10),
+            onchain_last_seen_at=_ts_ago(10),
+        )
+        results_by_source = {r["source"]: r for r in report["results"]}
+        assert results_by_source["price"]["severity"] == "healthy"
+        assert results_by_source["onchain"]["severity"] == "healthy"
+        assert results_by_source["news"]["severity"] == "critical"
+
+    def test_results_list_always_has_three_entries(self):
+        report = run_freshness_check()
+        assert len(report["results"]) == 3
+
+    def test_result_sources_are_news_price_onchain(self):
+        report = run_freshness_check(
+            news_last_seen_at=_ts_ago(10),
+            price_last_seen_at=_ts_ago(10),
+            onchain_last_seen_at=_ts_ago(10),
+        )
+        sources = {r["source"] for r in report["results"]}
+        assert sources == {"news", "price", "onchain"}
+
+
+# ---------------------------------------------------------------------------
+# StaleSourceReport actionable content
+# ---------------------------------------------------------------------------
+
+
+class TestStaleSourceReport:
+    def test_recommended_action_contains_api_hint_for_news(self):
+        report = run_freshness_check(news_last_seen_at=_ts_ago(5000))
+        stale = {r["source"]: r for r in report["stale_sources"]}
+        assert "news" in stale
+        action = stale["news"]["recommended_action"]
+        assert "API" in action or "api" in action.lower()
+
+    def test_runbook_hint_contains_runbook_reference_for_price(self):
+        report = run_freshness_check(price_last_seen_at=_ts_ago(2000))
+        stale = {r["source"]: r for r in report["stale_sources"]}
+        hint = stale["price"]["runbook_hint"]
+        assert "RUNBOOK" in hint.upper() or "runbook" in hint.lower()
+
+    def test_runbook_hint_present_for_onchain(self):
+        report = run_freshness_check(onchain_last_seen_at=_ts_ago(700))
+        stale = {r["source"]: r for r in report["stale_sources"]}
+        assert stale["onchain"]["runbook_hint"]
+
+    def test_stale_report_includes_age_seconds(self):
+        report = run_freshness_check(news_last_seen_at=_ts_ago(5000))
+        stale = {r["source"]: r for r in report["stale_sources"]}
+        assert stale["news"]["age_seconds"] == pytest.approx(5000.0, abs=5.0)
+
+    def test_stale_report_includes_last_seen_at(self):
+        ts = _ts_ago(5000)
+        report = run_freshness_check(news_last_seen_at=ts)
+        stale = {r["source"]: r for r in report["stale_sources"]}
+        assert stale["news"]["last_seen_at"] is not None


### PR DESCRIPTION
## Summary

Implements the Source Freshness SLA Monitor required by issue #1060. Adds a self-contained `freshness_monitor` module to the `data-processing` pipeline that tracks freshness and delay budgets across all major data feeds so maintainers know when one feed is stale before the product surfaces drift.

---

## Changes

### New: `src/ingestion/freshness_monitor.py`
- **`FreshnessSeverity`** — `healthy` / `warning` / `critical` enum
- **`FreshnessThreshold`** — per-source SLA thresholds configurable via env vars
- **`FreshnessResult`** — dataclass capturing age, severity, timestamps, and a `to_lag_snapshot()` bridge
- **`StaleSourceReport`** — actionable stale-source report with `recommended_action` and `runbook_hint`
- **`probe_news_freshness()`** — news feed probe (non-blocking)
- **`probe_price_freshness()`** — price feed probe (non-blocking)
- **`probe_onchain_freshness()`** — Stellar/on-chain ledger probe (non-blocking)
- **`run_freshness_check()`** — orchestrates all three probes into a single consolidated report

### Updated: `src/ingestion/__init__.py`
Exports all new freshness monitor symbols.

### New: `tests/test_freshness_monitor.py`
58 tests covering all acceptance criteria.

### Updated: `tests/conftest.py`
Adds stubs for `langdetect`, `sqlalchemy`, and other deps not installed in the lightweight test environment. This also unblocks the pre-existing `test_ingestion_alerting` import failure in environments without full deps.

---

## Configurable Thresholds (env vars)

| Variable | Default | Description |
|---|---|---|
| `NEWS_FRESHNESS_WARNING_SECONDS` | 1800 (30 min) | News warning threshold |
| `NEWS_FRESHNESS_CRITICAL_SECONDS` | 3600 (60 min) | News critical threshold |
| `PRICE_FRESHNESS_WARNING_SECONDS` | 300 (5 min) | Price warning threshold |
| `PRICE_FRESHNESS_CRITICAL_SECONDS` | 900 (15 min) | Price critical threshold |
| `ONCHAIN_FRESHNESS_WARNING_SECONDS` | 120 (2 min) | On-chain warning threshold |
| `ONCHAIN_FRESHNESS_CRITICAL_SECONDS` | 600 (10 min) | On-chain critical threshold |

---

## Acceptance Criteria

- [x] News, price, and on-chain sources all have freshness signals
- [x] Thresholds are configurable via env vars and observable via Prometheus (`lumenpulse_indexer_lag_seconds`, `lumenpulse_source_health`)
- [x] Stale-source reports are actionable: each `StaleSourceReport` includes `recommended_action` and `runbook_hint`
- [x] Non-blocking: each probe uses try/except; a failure in one source does not block the others or the main pipeline

---

## Tests

```
58 passed in 0.18s
```

Covers threshold classification, env-var overrides, non-blocking behavior, partial failure isolation, and actionable stale-source report content.

Closes #1060