### PR TITLE
feat: contributor-project narrative attribution scorer (#1061)

### DIFF
--- a/apps/data-processing/alembic/versions/006_add_narrative_attribution_scores.py
+++ b/apps/data-processing/alembic/versions/006_add_narrative_attribution_scores.py
@@ -1,0 +1,142 @@
+"""Add narrative_attribution_scores table
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-07-23 00:00:00.000000
+
+Stores the output of the AttributionScorer for each (article, target) pair
+produced by the data-processing pipeline.  Results can be joined to
+contributor or project views via ``target_id`` + ``target_type``.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "006"
+down_revision: Union[str, None] = "005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "narrative_attribution_scores",
+        # --------------- primary key -----------------------------------
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        # --------------- article reference -----------------------------
+        # Soft-reference (no FK) so the table survives article pruning.
+        sa.Column("article_id", sa.String(length=255), nullable=False),
+        # --------------- target reference ------------------------------
+        # target_id  = Stellar address for contributors, project_id str for projects.
+        # target_type = "contributor" | "project"
+        sa.Column("target_id", sa.String(length=255), nullable=False),
+        sa.Column("target_type", sa.String(length=50), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        # --------------- score & confidence ----------------------------
+        # score in [0.0, 1.0]; confidence_tier in {high, medium, low, very_low}
+        sa.Column("score", sa.Float(), nullable=False),
+        sa.Column(
+            "confidence_tier",
+            sa.String(length=20),
+            nullable=False,
+            server_default="very_low",
+        ),
+        sa.Column(
+            "low_confidence",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        # --------------- explainability payload -----------------------
+        # Full JSON breakdown: list of SignalBreakdown dicts for tuning.
+        sa.Column("signals", sa.JSON(), nullable=True),
+        # --------------- provenance -----------------------------------
+        sa.Column(
+            "scorer_version",
+            sa.String(length=50),
+            nullable=False,
+            server_default="attribution_scorer_v1",
+        ),
+        # --------------- timestamps -----------------------------------
+        sa.Column(
+            "scored_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Unique constraint: one score per (article, target) pair — upsert-friendly.
+    op.create_index(
+        "ux_narrative_attribution_article_target",
+        "narrative_attribution_scores",
+        ["article_id", "target_id", "target_type"],
+        unique=True,
+    )
+
+    # Fast look-up by target (for contributor / project view joins).
+    op.create_index(
+        "idx_narrative_attribution_target",
+        "narrative_attribution_scores",
+        ["target_id", "target_type"],
+    )
+
+    # Range scan on score for top-N queries.
+    op.create_index(
+        "idx_narrative_attribution_score",
+        "narrative_attribution_scores",
+        ["score"],
+    )
+
+    # Filter by confidence tier to skip low-signal results.
+    op.create_index(
+        "idx_narrative_attribution_confidence_tier",
+        "narrative_attribution_scores",
+        ["confidence_tier"],
+    )
+
+    # Time-ordered scans for trend windows.
+    op.create_index(
+        "idx_narrative_attribution_scored_at",
+        "narrative_attribution_scores",
+        ["scored_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_narrative_attribution_scored_at",
+        table_name="narrative_attribution_scores",
+    )
+    op.drop_index(
+        "idx_narrative_attribution_confidence_tier",
+        table_name="narrative_attribution_scores",
+    )
+    op.drop_index(
+        "idx_narrative_attribution_score",
+        table_name="narrative_attribution_scores",
+    )
+    op.drop_index(
+        "idx_narrative_attribution_target",
+        table_name="narrative_attribution_scores",
+    )
+    op.drop_index(
+        "ux_narrative_attribution_article_target",
+        table_name="narrative_attribution_scores",
+    )
+    op.drop_table("narrative_attribution_scores")

--- a/apps/data-processing/src/analytics/__init__.py
+++ b/apps/data-processing/src/analytics/__init__.py
@@ -11,6 +11,11 @@ __all__ = [
     "CorrelationResult",
     "DataPoint",
     "NERService",
+    # Attribution scorer
+    "AttributionScorer",
+    "AttributionTarget",
+    "AttributionResult",
+    "SignalBreakdown",
 ]
 
 
@@ -48,5 +53,25 @@ def __getattr__(name: str):
         from .ner_service import NERService
 
         return NERService
+
+    if name in {
+        "AttributionScorer",
+        "AttributionTarget",
+        "AttributionResult",
+        "SignalBreakdown",
+    }:
+        from .attribution_scorer import (
+            AttributionResult,
+            AttributionScorer,
+            AttributionTarget,
+            SignalBreakdown,
+        )
+
+        return {
+            "AttributionScorer": AttributionScorer,
+            "AttributionTarget": AttributionTarget,
+            "AttributionResult": AttributionResult,
+            "SignalBreakdown": SignalBreakdown,
+        }[name]
 
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/apps/data-processing/src/analytics/attribution_scorer.py
+++ b/apps/data-processing/src/analytics/attribution_scorer.py
@@ -1,0 +1,657 @@
+"""
+Contributor-Project Narrative Attribution Scorer (#1061)
+
+Scores how strongly a news or discussion narrative is attributable to a
+specific contributor or project rather than broad ecosystem-level trends.
+
+Design
+------
+Attribution is computed from a small, ordered set of *signal functions*.
+Each signal returns a numeric weight in [0.0, 1.0].  The final score is a
+weighted average of all firing signals, clipped to [0.0, 1.0].  Every
+intermediate value is preserved so operators can inspect and tune without
+retraining a model.
+
+Signals
+~~~~~~~
+1. entity_link_signal  — direct onchain_entity_links in the article JSON
+2. mention_signal      — raw text / detected_entities mentions of the target
+3. keyword_signal      — target keywords / aliases in title + summary
+4. sentiment_coherence_signal — sentiment aligns with a known contributor action
+5. category_signal     — article categories match known project/contributor topics
+
+Confidence tier
+~~~~~~~~~~~~~~~
+The combined score is mapped to a human-readable tier:
+
+  >= 0.75  →  high
+  >= 0.50  →  medium
+  >= 0.25  →  low
+  <  0.25  →  very_low  (treated as "insufficient evidence" downstream)
+
+Low-confidence handling
+~~~~~~~~~~~~~~~~~~~~~~~
+When tier is "very_low" the scorer returns an AttributionResult flagged with
+``low_confidence=True`` so callers can safely skip or quarantine the result
+rather than propagate noisy attribution.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Confidence tier thresholds
+# ---------------------------------------------------------------------------
+HIGH_CONFIDENCE_THRESHOLD: float = 0.75
+MEDIUM_CONFIDENCE_THRESHOLD: float = 0.50
+LOW_CONFIDENCE_THRESHOLD: float = 0.25
+
+# Signal weights must sum to 1.0
+_SIGNAL_WEIGHTS: Dict[str, float] = {
+    "entity_link": 0.35,    # strongest — a deliberate onchain entity link
+    "mention": 0.25,        # direct name / address mention in the body
+    "keyword": 0.20,        # alias / ticker / slug hit in title or summary
+    "sentiment_coherence": 0.10,  # sentiment fits contributor context
+    "category": 0.10,       # article categories overlap with target's topics
+}
+
+assert abs(sum(_SIGNAL_WEIGHTS.values()) - 1.0) < 1e-9, "Weights must sum to 1.0"
+
+
+# ---------------------------------------------------------------------------
+# Domain types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AttributionTarget:
+    """
+    Describes the contributor or project being matched against.
+
+    Parameters
+    ----------
+    target_id:
+        Opaque identifier — a Stellar address (contributor) or integer
+        project_id.  Used as a join key for downstream views.
+    target_type:
+        ``"contributor"`` or ``"project"``.
+    display_name:
+        Human-readable label (e.g. ``"Alice"`` or ``"PulseProject 1"``).
+    aliases:
+        All known text aliases (names, handles, tickers, slugs).  The scorer
+        matches any of these against article text.
+    asset_codes:
+        Optional asset tickers associated with the target (e.g. ``["XLM"]``).
+    stable_entity_ids:
+        Optional onchain entity stable IDs (e.g. ``["project:10001"]``) used
+        to check ``onchain_entity_links``.
+    known_categories:
+        Optional set of article category strings relevant to this target.
+    """
+
+    target_id: str
+    target_type: str  # "contributor" | "project"
+    display_name: str
+    aliases: Sequence[str] = field(default_factory=list)
+    asset_codes: Sequence[str] = field(default_factory=list)
+    stable_entity_ids: Sequence[str] = field(default_factory=list)
+    known_categories: Sequence[str] = field(default_factory=list)
+
+
+@dataclass
+class SignalBreakdown:
+    """
+    Per-signal weight and firing status — the explainable part of the score.
+
+    Attributes
+    ----------
+    name:    Signal identifier (matches a key in ``_SIGNAL_WEIGHTS``).
+    weight:  Configured importance weight for this signal.
+    fired:   Whether the signal matched (True / False).
+    value:   Continuous score produced by the signal in [0.0, 1.0].
+    detail:  Human-readable explanation of why the signal fired or not.
+    """
+
+    name: str
+    weight: float
+    fired: bool
+    value: float
+    detail: str
+
+    def contribution(self) -> float:
+        """Weighted contribution to the total score."""
+        return self.weight * self.value
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "weight": round(self.weight, 4),
+            "fired": self.fired,
+            "value": round(self.value, 4),
+            "detail": self.detail,
+            "contribution": round(self.contribution(), 4),
+        }
+
+
+@dataclass
+class AttributionResult:
+    """
+    The full attribution output for one (article, target) pair.
+
+    Attributes
+    ----------
+    article_id:     Source article identifier.
+    target_id:      Matched target's opaque ID (join key).
+    target_type:    ``"contributor"`` or ``"project"``.
+    display_name:   Human-readable target label.
+    score:          Combined attribution score in [0.0, 1.0].
+    confidence_tier: ``"high"`` | ``"medium"`` | ``"low"`` | ``"very_low"``.
+    low_confidence: ``True`` when tier is ``"very_low"`` — callers should
+                    handle these results defensively.
+    signals:        Per-signal breakdown for explainability / tuning.
+    scorer_version: Monotonic scorer version string.
+    """
+
+    article_id: str
+    target_id: str
+    target_type: str
+    display_name: str
+    score: float
+    confidence_tier: str
+    low_confidence: bool
+    signals: List[SignalBreakdown] = field(default_factory=list)
+    scorer_version: str = "attribution_scorer_v1"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "article_id": self.article_id,
+            "target_id": self.target_id,
+            "target_type": self.target_type,
+            "display_name": self.display_name,
+            "score": round(self.score, 4),
+            "confidence_tier": self.confidence_tier,
+            "low_confidence": self.low_confidence,
+            "signals": [s.to_dict() for s in self.signals],
+            "scorer_version": self.scorer_version,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Scorer
+# ---------------------------------------------------------------------------
+
+
+class AttributionScorer:
+    """
+    Score narrative attribution between articles and contributor/project targets.
+
+    Usage
+    -----
+    scorer = AttributionScorer()
+
+    target = AttributionTarget(
+        target_id="10001",
+        target_type="project",
+        display_name="PulseProject 1",
+        aliases=["PulseProject 1", "pulse-project-1", "XLM"],
+        stable_entity_ids=["project:10001"],
+        known_categories=["crypto", "stellar", "defi"],
+    )
+
+    article = {
+        "article_id": "art-001",
+        "title": "PulseProject 1 ships major upgrade",
+        "summary": "The XLM-based project released v2...",
+        "content": "...",
+        "detected_entities": ["PulseProject 1", "XLM"],
+        "onchain_entity_links": [{"stable_entity_id": "project:10001", ...}],
+        "categories": ["crypto", "stellar"],
+        "sentiment_score": 0.6,
+    }
+
+    result = scorer.score(article, target)
+    print(result.confidence_tier)  # "high"
+    print(result.to_dict())        # full breakdown for tuning
+    """
+
+    SCORER_VERSION = "attribution_scorer_v1"
+
+    def score(
+        self,
+        article: Dict[str, Any],
+        target: AttributionTarget,
+    ) -> AttributionResult:
+        """
+        Compute an attribution score for one (article, target) pair.
+
+        Parameters
+        ----------
+        article:
+            Article dict with keys: article_id, title, summary, content,
+            detected_entities, onchain_entity_links, categories,
+            sentiment_score, keywords.  All keys are optional — missing
+            fields reduce available signal coverage rather than raising.
+        target:
+            The contributor or project to score against.
+
+        Returns
+        -------
+        AttributionResult
+        """
+        article_id = str(article.get("article_id") or "")
+
+        # --- Collect all signals -----------------------------------------
+        signals: List[SignalBreakdown] = [
+            self._entity_link_signal(article, target),
+            self._mention_signal(article, target),
+            self._keyword_signal(article, target),
+            self._sentiment_coherence_signal(article, target),
+            self._category_signal(article, target),
+        ]
+
+        # --- Weighted average -------------------------------------------
+        total_weight = sum(s.weight for s in signals)
+        if total_weight == 0:  # should never happen, but guard defensively
+            score = 0.0
+        else:
+            score = sum(s.contribution() for s in signals) / total_weight
+
+        score = max(0.0, min(1.0, score))  # clip to [0, 1]
+
+        # --- Confidence tier ---------------------------------------------
+        tier = _confidence_tier(score)
+        low_confidence = tier == "very_low"
+
+        if low_confidence:
+            logger.debug(
+                "Low-confidence attribution for article=%s target=%s score=%.3f",
+                article_id,
+                target.target_id,
+                score,
+            )
+
+        return AttributionResult(
+            article_id=article_id,
+            target_id=target.target_id,
+            target_type=target.target_type,
+            display_name=target.display_name,
+            score=score,
+            confidence_tier=tier,
+            low_confidence=low_confidence,
+            signals=signals,
+            scorer_version=self.SCORER_VERSION,
+        )
+
+    def score_batch(
+        self,
+        articles: Sequence[Dict[str, Any]],
+        targets: Sequence[AttributionTarget],
+    ) -> List[AttributionResult]:
+        """
+        Score all (article, target) combinations.
+
+        Returns results sorted descending by score, with low-confidence
+        entries at the end.
+        """
+        results: List[AttributionResult] = []
+        for article in articles:
+            for target in targets:
+                results.append(self.score(article, target))
+
+        results.sort(key=lambda r: (not r.low_confidence, r.score), reverse=True)
+        return results
+
+    # ------------------------------------------------------------------
+    # Signal implementations
+    # ------------------------------------------------------------------
+
+    def _entity_link_signal(
+        self,
+        article: Dict[str, Any],
+        target: AttributionTarget,
+    ) -> SignalBreakdown:
+        """
+        Signal: a deliberate onchain_entity_link in the article explicitly
+        references one of the target's stable entity IDs.
+
+        This is the strongest evidence because the link was produced by the
+        OnchainEntityLinker with its own confidence score, so we incorporate
+        that confidence directly rather than using a flat 1.0.
+        """
+        name = "entity_link"
+        weight = _SIGNAL_WEIGHTS[name]
+
+        links: List[Dict[str, Any]] = article.get("onchain_entity_links") or []
+        target_stable_ids = {sid.lower() for sid in (target.stable_entity_ids or [])}
+
+        if not target_stable_ids or not links:
+            return SignalBreakdown(
+                name=name,
+                weight=weight,
+                fired=False,
+                value=0.0,
+                detail="No onchain entity links or no stable IDs configured for target.",
+            )
+
+        best_conf: float = 0.0
+        matched_id: Optional[str] = None
+
+        for link in links:
+            # Support both key spellings used by different parts of the codebase.
+            link_id = (
+                link.get("stable_entity_id") or link.get("stable_id") or ""
+            ).lower()
+            if link_id in target_stable_ids:
+                conf = float(link.get("confidence") or 0.0)
+                if conf > best_conf:
+                    best_conf = conf
+                    matched_id = link.get("stable_entity_id") or link.get("stable_id")
+
+        if matched_id:
+            return SignalBreakdown(
+                name=name,
+                weight=weight,
+                fired=True,
+                value=best_conf,
+                detail=f"Onchain entity link matched stable_id={matched_id!r} "
+                       f"with confidence={best_conf:.2f}.",
+            )
+
+        return SignalBreakdown(
+            name=name,
+            weight=weight,
+            fired=False,
+            value=0.0,
+            detail=f"No onchain entity link matched stable IDs {sorted(target_stable_ids)}.",
+        )
+
+    def _mention_signal(
+        self,
+        article: Dict[str, Any],
+        target: AttributionTarget,
+    ) -> SignalBreakdown:
+        """
+        Signal: the target's name, address, or handle appears directly in
+        detected_entities or in the raw article text.
+
+        Score = number of distinct alias hits / total aliases, capped at 1.0.
+        Multiple matches provide stronger evidence than a single coincidence.
+        """
+        name = "mention"
+        weight = _SIGNAL_WEIGHTS[name]
+
+        aliases = list(target.aliases or [])
+        if target.target_id and target.target_id not in aliases:
+            aliases.append(target.target_id)
+
+        if not aliases:
+            return SignalBreakdown(
+                name=name,
+                weight=weight,
+                fired=False,
+                value=0.0,
+                detail="No aliases configured for target.",
+            )
+
+        detected: List[str] = [
+            str(e).lower()
+            for e in (article.get("detected_entities") or [])
+        ]
+
+        # Build a searchable corpus from all text fields.
+        corpus = _build_text_corpus(article).lower()
+
+        hits: List[str] = []
+        for alias in aliases:
+            alias_lower = alias.lower()
+            if alias_lower in detected:
+                hits.append(alias)
+                continue
+            # Whole-word / whole-token match in the full corpus.
+            pattern = r"(?<![a-z0-9_$])" + re.escape(alias_lower) + r"(?![a-z0-9_-])"
+            if re.search(pattern, corpus):
+                hits.append(alias)
+
+        unique_hits = list(dict.fromkeys(hits))  # preserve order, dedupe
+
+        if not unique_hits:
+            return SignalBreakdown(
+                name=name,
+                weight=weight,
+                fired=False,
+                value=0.0,
+                detail=f"No alias matched detected entities or article text. "
+                       f"Tried: {aliases[:5]}{'...' if len(aliases) > 5 else ''}.",
+            )
+
+        # Normalise: more distinct hits → higher value, maxing out at 1.0.
+        value = min(1.0, len(unique_hits) / max(1, len(aliases)))
+        return SignalBreakdown(
+            name=name,
+            weight=weight,
+            fired=True,
+            value=value,
+            detail=f"Matched {len(unique_hits)} alias(es): {unique_hits[:5]}"
+                   f"{'...' if len(unique_hits) > 5 else ''}.",
+        )
+
+    def _keyword_signal(
+        self,
+        article: Dict[str, Any],
+        target: AttributionTarget,
+    ) -> SignalBreakdown:
+        """
+        Signal: target aliases appear in the article's extracted keywords list
+        or in the title / summary where the signal density is higher.
+
+        Keyword lists are pre-computed by KeywordExtractor; a match here means
+        the target's term was prominent enough to be indexed.
+        """
+        name = "keyword"
+        weight = _SIGNAL_WEIGHTS[name]
+
+        aliases = {a.lower() for a in (target.aliases or [])}
+        asset_codes = {c.lower() for c in (target.asset_codes or [])}
+        searchable = aliases | asset_codes
+
+        if not searchable:
+            return SignalBreakdown(
+                name=name,
+                weight=weight,
+                fired=False,
+                value=0.0,
+                detail="No aliases or asset codes configured for keyword matching.",
+            )
+
+        article_keywords = {
+            str(k).lower() for k in (article.get("keywords") or [])
+        }
+
+        # Also scan title and summary directly (rich signal density).
+        title_summary = " ".join(
+            filter(None, [article.get("title"), article.get("summary")])
+        ).lower()
+
+        keyword_hits = searchable & article_keywords
+        inline_hits: set = set()
+        for term in searchable:
+            pattern = r"(?<![a-z0-9_$])" + re.escape(term) + r"(?![a-z0-9_-])"
+            if re.search(pattern, title_summary):
+                inline_hits.add(term)
+
+        all_hits = keyword_hits | inline_hits
+
+        if not all_hits:
+            return SignalBreakdown(
+                name=name,
+                weight=weight,
+                fired=False,
+                value=0.0,
+                detail=f"No keyword/title-summary hits for terms "
+                       f"{sorted(searchable)[:5]}{'...' if len(searchable) > 5 else ''}.",
+            )
+
+        # Keyword hits earn 0.6 base; each inline (title/summary) hit adds 0.2.
+        value = min(1.0, 0.5 * bool(keyword_hits) + 0.5 * bool(inline_hits))
+        return SignalBreakdown(
+            name=name,
+            weight=weight,
+            fired=True,
+            value=value,
+            detail=(
+                f"Keyword hits: {sorted(keyword_hits)}; "
+                f"title/summary hits: {sorted(inline_hits)}."
+            ),
+        )
+
+    def _sentiment_coherence_signal(
+        self,
+        article: Dict[str, Any],
+        target: AttributionTarget,
+    ) -> SignalBreakdown:
+        """
+        Signal: the article's sentiment score is non-neutral, which makes it
+        more likely the article discusses a specific actor rather than just
+        reporting ecosystem-wide news.
+
+        A stronger (more extreme) sentiment — positive or negative — is
+        evidence of a focused narrative.  A near-zero sentiment is typical of
+        broad market summaries with no clear protagonist.
+
+        This is a soft, supporting signal (weight 0.10) and does not fire when
+        the sentiment field is absent.
+        """
+        name = "sentiment_coherence"
+        weight = _SIGNAL_WEIGHTS[name]
+
+        raw_sentiment = article.get("sentiment_score")
+
+        if raw_sentiment is None:
+            return SignalBreakdown(
+                name=name,
+                weight=weight,
+                fired=False,
+                value=0.0,
+                detail="No sentiment_score in article; signal skipped.",
+            )
+
+        sentiment = float(raw_sentiment)
+        magnitude = abs(sentiment)  # 0.0 (neutral) → 1.0 (extreme)
+
+        # Only consider it a real signal if the sentiment crosses the VADER
+        # neutral threshold already used elsewhere in the project (|score| > 0.05).
+        if magnitude <= 0.05:
+            return SignalBreakdown(
+                name=name,
+                weight=weight,
+                fired=False,
+                value=0.0,
+                detail=f"Sentiment magnitude {magnitude:.3f} ≤ 0.05 — neutral; "
+                       "no attribution evidence.",
+            )
+
+        return SignalBreakdown(
+            name=name,
+            weight=weight,
+            fired=True,
+            value=round(magnitude, 4),
+            detail=f"Sentiment score {sentiment:.3f} (magnitude {magnitude:.3f}) "
+                   "suggests focused narrative.",
+        )
+
+    def _category_signal(
+        self,
+        article: Dict[str, Any],
+        target: AttributionTarget,
+    ) -> SignalBreakdown:
+        """
+        Signal: overlap between article categories and the target's known topic
+        categories.
+
+        Jaccard similarity is used so that a target with many categories isn't
+        unfairly advantaged over a narrow one.
+        """
+        name = "category"
+        weight = _SIGNAL_WEIGHTS[name]
+
+        target_cats = {c.lower() for c in (target.known_categories or [])}
+        article_cats = {
+            str(c).lower() for c in (article.get("categories") or [])
+        }
+
+        if not target_cats:
+            return SignalBreakdown(
+                name=name,
+                weight=weight,
+                fired=False,
+                value=0.0,
+                detail="No known_categories configured for target.",
+            )
+
+        if not article_cats:
+            return SignalBreakdown(
+                name=name,
+                weight=weight,
+                fired=False,
+                value=0.0,
+                detail="Article has no categories.",
+            )
+
+        intersection = target_cats & article_cats
+        union = target_cats | article_cats
+        jaccard = len(intersection) / len(union) if union else 0.0
+
+        if not intersection:
+            return SignalBreakdown(
+                name=name,
+                weight=weight,
+                fired=False,
+                value=0.0,
+                detail=f"No category overlap. Article: {sorted(article_cats)}; "
+                       f"Target: {sorted(target_cats)}.",
+            )
+
+        return SignalBreakdown(
+            name=name,
+            weight=weight,
+            fired=True,
+            value=round(jaccard, 4),
+            detail=(
+                f"Category overlap: {sorted(intersection)} "
+                f"(Jaccard={jaccard:.3f})."
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _confidence_tier(score: float) -> str:
+    """Map a [0, 1] score to a human-readable confidence tier string."""
+    if score >= HIGH_CONFIDENCE_THRESHOLD:
+        return "high"
+    if score >= MEDIUM_CONFIDENCE_THRESHOLD:
+        return "medium"
+    if score >= LOW_CONFIDENCE_THRESHOLD:
+        return "low"
+    return "very_low"
+
+
+def _build_text_corpus(article: Dict[str, Any]) -> str:
+    """Concatenate all text fields of an article for broad alias searching."""
+    parts = [
+        article.get("title") or "",
+        article.get("summary") or "",
+        article.get("content") or "",
+        " ".join(article.get("keywords") or []),
+        " ".join(str(e) for e in (article.get("detected_entities") or [])),
+    ]
+    return " ".join(p for p in parts if p)

--- a/apps/data-processing/tests/test_attribution_scorer.py
+++ b/apps/data-processing/tests/test_attribution_scorer.py
@@ -1,0 +1,870 @@
+"""
+Unit tests for AttributionScorer (#1061).
+
+Coverage targets
+----------------
+- All five signals independently (entity_link, mention, keyword,
+  sentiment_coherence, category)
+- Weighted score arithmetic
+- Confidence tiers (high / medium / low / very_low)
+- low_confidence flag propagation
+- score_batch ordering
+- to_dict serialisation on all three dataclasses
+- Edge cases: empty article, missing fields, no aliases
+- __init__.py lazy-import path
+"""
+
+from __future__ import annotations
+
+import math
+import unittest
+from typing import Any, Dict, List
+
+from src.analytics.attribution_scorer import (
+    HIGH_CONFIDENCE_THRESHOLD,
+    LOW_CONFIDENCE_THRESHOLD,
+    MEDIUM_CONFIDENCE_THRESHOLD,
+    AttributionResult,
+    AttributionScorer,
+    AttributionTarget,
+    SignalBreakdown,
+    _confidence_tier,
+    _build_text_corpus,
+    _SIGNAL_WEIGHTS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_UNSET = object()  # sentinel for "not provided"
+
+
+def _make_target(
+    *,
+    target_id: str = "10001",
+    target_type: str = "project",
+    display_name: str = "PulseProject 1",
+    aliases=_UNSET,
+    asset_codes=_UNSET,
+    stable_entity_ids=_UNSET,
+    known_categories=_UNSET,
+) -> AttributionTarget:
+    return AttributionTarget(
+        target_id=target_id,
+        target_type=target_type,
+        display_name=display_name,
+        aliases=["PulseProject 1", "pulse-project-1", "XLM"]
+        if aliases is _UNSET
+        else aliases,
+        asset_codes=["XLM"] if asset_codes is _UNSET else asset_codes,
+        stable_entity_ids=["project:10001"]
+        if stable_entity_ids is _UNSET
+        else stable_entity_ids,
+        known_categories=["crypto", "stellar", "defi"]
+        if known_categories is _UNSET
+        else known_categories,
+    )
+
+
+def _make_article(
+    *,
+    article_id: str = "art-001",
+    title: str = "PulseProject 1 ships major upgrade",
+    summary: str = "The XLM-based project released v2.",
+    content: str = "Details about PulseProject 1 and its contributors.",
+    detected_entities: List[str] | None = None,
+    onchain_entity_links: List[Dict[str, Any]] | None = None,
+    categories: List[str] | None = None,
+    keywords: List[str] | None = None,
+    sentiment_score: float | None = 0.6,
+) -> Dict[str, Any]:
+    return {
+        "article_id": article_id,
+        "title": title,
+        "summary": summary,
+        "content": content,
+        "detected_entities": detected_entities
+        if detected_entities is not None
+        else ["PulseProject 1", "XLM"],
+        "onchain_entity_links": onchain_entity_links
+        if onchain_entity_links is not None
+        else [
+            {
+                "stable_entity_id": "project:10001",
+                "entity_type": "project",
+                "display_name": "PulseProject 1",
+                "matched_text": "PulseProject 1",
+                "confidence": 0.95,
+                "source": "SyntheticDataGenerator",
+            }
+        ],
+        "categories": categories if categories is not None else ["crypto", "stellar"],
+        "keywords": keywords if keywords is not None else ["XLM", "synthetic"],
+        "sentiment_score": sentiment_score,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Weights sanity check
+# ---------------------------------------------------------------------------
+
+class TestSignalWeights(unittest.TestCase):
+
+    def test_weights_sum_to_one(self):
+        total = sum(_SIGNAL_WEIGHTS.values())
+        self.assertAlmostEqual(total, 1.0, places=9)
+
+    def test_all_weights_positive(self):
+        for name, w in _SIGNAL_WEIGHTS.items():
+            self.assertGreater(w, 0, msg=f"Weight for {name!r} is not positive")
+
+    def test_expected_signal_names_present(self):
+        expected = {"entity_link", "mention", "keyword", "sentiment_coherence", "category"}
+        self.assertEqual(set(_SIGNAL_WEIGHTS.keys()), expected)
+
+
+# ---------------------------------------------------------------------------
+# 2. _confidence_tier helper
+# ---------------------------------------------------------------------------
+
+class TestConfidenceTier(unittest.TestCase):
+
+    def test_high(self):
+        self.assertEqual(_confidence_tier(0.75), "high")
+        self.assertEqual(_confidence_tier(1.0), "high")
+        self.assertEqual(_confidence_tier(HIGH_CONFIDENCE_THRESHOLD), "high")
+
+    def test_medium(self):
+        self.assertEqual(_confidence_tier(0.50), "medium")
+        self.assertEqual(_confidence_tier(0.74), "medium")
+        self.assertEqual(_confidence_tier(MEDIUM_CONFIDENCE_THRESHOLD), "medium")
+
+    def test_low(self):
+        self.assertEqual(_confidence_tier(0.25), "low")
+        self.assertEqual(_confidence_tier(0.49), "low")
+        self.assertEqual(_confidence_tier(LOW_CONFIDENCE_THRESHOLD), "low")
+
+    def test_very_low(self):
+        self.assertEqual(_confidence_tier(0.0), "very_low")
+        self.assertEqual(_confidence_tier(0.24), "very_low")
+        self.assertEqual(_confidence_tier(0.001), "very_low")
+
+
+# ---------------------------------------------------------------------------
+# 3. _build_text_corpus helper
+# ---------------------------------------------------------------------------
+
+class TestBuildTextCorpus(unittest.TestCase):
+
+    def test_combines_all_fields(self):
+        article = {
+            "title": "Alpha",
+            "summary": "Beta",
+            "content": "Gamma",
+            "keywords": ["delta"],
+            "detected_entities": ["Epsilon"],
+        }
+        corpus = _build_text_corpus(article)
+        for word in ("Alpha", "Beta", "Gamma", "delta", "Epsilon"):
+            self.assertIn(word, corpus)
+
+    def test_handles_missing_fields(self):
+        corpus = _build_text_corpus({})
+        self.assertEqual(corpus.strip(), "")
+
+    def test_none_values_skipped(self):
+        article = {"title": None, "summary": "Hello"}
+        corpus = _build_text_corpus(article)
+        self.assertIn("Hello", corpus)
+
+
+
+# ---------------------------------------------------------------------------
+# 4. SignalBreakdown dataclass
+# ---------------------------------------------------------------------------
+
+class TestSignalBreakdown(unittest.TestCase):
+
+    def _make(self, weight: float = 0.35, value: float = 0.9) -> SignalBreakdown:
+        return SignalBreakdown(
+            name="entity_link",
+            weight=weight,
+            fired=True,
+            value=value,
+            detail="Test detail.",
+        )
+
+    def test_contribution_is_weight_times_value(self):
+        sb = self._make(weight=0.35, value=0.9)
+        self.assertAlmostEqual(sb.contribution(), 0.35 * 0.9)
+
+    def test_contribution_zero_when_not_fired(self):
+        sb = SignalBreakdown(
+            name="mention", weight=0.25, fired=False, value=0.0, detail="nope"
+        )
+        self.assertAlmostEqual(sb.contribution(), 0.0)
+
+    def test_to_dict_keys(self):
+        sb = self._make()
+        d = sb.to_dict()
+        for key in ("name", "weight", "fired", "value", "detail", "contribution"):
+            self.assertIn(key, d)
+
+    def test_to_dict_values_rounded(self):
+        sb = self._make(weight=0.35, value=0.9)
+        d = sb.to_dict()
+        self.assertEqual(d["contribution"], round(0.35 * 0.9, 4))
+
+
+# ---------------------------------------------------------------------------
+# 5. AttributionResult dataclass
+# ---------------------------------------------------------------------------
+
+class TestAttributionResult(unittest.TestCase):
+
+    def _make(self) -> AttributionResult:
+        return AttributionResult(
+            article_id="art-1",
+            target_id="10001",
+            target_type="project",
+            display_name="PulseProject 1",
+            score=0.8,
+            confidence_tier="high",
+            low_confidence=False,
+            signals=[],
+            scorer_version="attribution_scorer_v1",
+        )
+
+    def test_to_dict_contains_required_keys(self):
+        d = self._make().to_dict()
+        for key in (
+            "article_id", "target_id", "target_type", "display_name",
+            "score", "confidence_tier", "low_confidence", "signals",
+            "scorer_version",
+        ):
+            self.assertIn(key, d)
+
+    def test_to_dict_score_rounded(self):
+        result = AttributionResult(
+            article_id="a",
+            target_id="t",
+            target_type="project",
+            display_name="X",
+            score=0.123456789,
+            confidence_tier="low",
+            low_confidence=False,
+        )
+        d = result.to_dict()
+        self.assertEqual(d["score"], round(0.123456789, 4))
+
+    def test_signals_serialised_in_to_dict(self):
+        sb = SignalBreakdown(
+            name="entity_link", weight=0.35, fired=True, value=0.9, detail="ok"
+        )
+        result = self._make()
+        result.signals.append(sb)
+        d = result.to_dict()
+        self.assertEqual(len(d["signals"]), 1)
+        self.assertEqual(d["signals"][0]["name"], "entity_link")
+
+
+
+# ---------------------------------------------------------------------------
+# 6. Individual signal tests (via AttributionScorer private methods)
+# ---------------------------------------------------------------------------
+
+class TestEntityLinkSignal(unittest.TestCase):
+
+    def setUp(self):
+        self.scorer = AttributionScorer()
+        self.target = _make_target()
+
+    def _signal(self, article):
+        return self.scorer._entity_link_signal(article, self.target)
+
+    def test_fires_with_matching_stable_id(self):
+        article = _make_article()
+        s = self._signal(article)
+        self.assertTrue(s.fired)
+        self.assertAlmostEqual(s.value, 0.95)
+
+    def test_value_reflects_link_confidence(self):
+        article = _make_article(
+            onchain_entity_links=[
+                {"stable_entity_id": "project:10001", "confidence": 0.80}
+            ]
+        )
+        s = self._signal(article)
+        self.assertAlmostEqual(s.value, 0.80)
+
+    def test_picks_highest_confidence_among_multiple_links(self):
+        article = _make_article(
+            onchain_entity_links=[
+                {"stable_entity_id": "project:10001", "confidence": 0.70},
+                {"stable_entity_id": "project:10001", "confidence": 0.92},
+            ]
+        )
+        s = self._signal(article)
+        self.assertAlmostEqual(s.value, 0.92)
+
+    def test_does_not_fire_for_different_stable_id(self):
+        article = _make_article(
+            onchain_entity_links=[
+                {"stable_entity_id": "project:99999", "confidence": 0.95}
+            ]
+        )
+        s = self._signal(article)
+        self.assertFalse(s.fired)
+        self.assertEqual(s.value, 0.0)
+
+    def test_does_not_fire_with_empty_links(self):
+        article = _make_article(onchain_entity_links=[])
+        s = self._signal(article)
+        self.assertFalse(s.fired)
+
+    def test_does_not_fire_when_no_stable_entity_ids_on_target(self):
+        target = _make_target(stable_entity_ids=[])
+        # article has links, but target has no stable IDs to match against
+        article = _make_article()
+        s = self.scorer._entity_link_signal(article, target)
+        # The guard "if not target_stable_ids" returns early → should not fire
+        self.assertFalse(s.fired)
+
+    def test_supports_stable_id_key_alias(self):
+        # Some callers may use 'stable_id' instead of 'stable_entity_id'
+        article = _make_article(
+            onchain_entity_links=[{"stable_id": "project:10001", "confidence": 0.88}]
+        )
+        s = self._signal(article)
+        self.assertTrue(s.fired)
+        self.assertAlmostEqual(s.value, 0.88)
+
+    def test_weight_is_correct(self):
+        s = self._signal(_make_article())
+        self.assertAlmostEqual(s.weight, _SIGNAL_WEIGHTS["entity_link"])
+
+
+class TestMentionSignal(unittest.TestCase):
+
+    def setUp(self):
+        self.scorer = AttributionScorer()
+        self.target = _make_target()
+
+    def _signal(self, article):
+        return self.scorer._mention_signal(article, self.target)
+
+    def test_fires_on_detected_entity_match(self):
+        article = _make_article(detected_entities=["PulseProject 1", "XLM"])
+        s = self._signal(article)
+        self.assertTrue(s.fired)
+
+    def test_fires_on_text_match_when_not_in_entities(self):
+        article = _make_article(
+            detected_entities=[],
+            title="pulse-project-1 is growing",
+            summary="",
+            content="",
+        )
+        s = self._signal(article)
+        self.assertTrue(s.fired)
+
+    def test_value_higher_with_more_alias_hits(self):
+        # Match only one alias
+        article_one = _make_article(
+            detected_entities=["XLM"],
+            title="XLM news",
+            summary="",
+            content="",
+        )
+        # Match multiple aliases
+        article_many = _make_article(
+            detected_entities=["PulseProject 1", "XLM"],
+            title="PulseProject 1 and pulse-project-1 hit XLM milestone",
+            summary="",
+            content="",
+        )
+        s_one = self._signal(article_one)
+        s_many = self._signal(article_many)
+        self.assertGreater(s_many.value, s_one.value)
+
+    def test_does_not_fire_on_empty_article(self):
+        article = _make_article(
+            detected_entities=[],
+            title="",
+            summary="",
+            content="",
+            keywords=[],
+        )
+        s = self._signal(article)
+        self.assertFalse(s.fired)
+
+    def test_does_not_fire_when_no_aliases(self):
+        target = _make_target(aliases=[])
+        s = self.scorer._mention_signal(_make_article(), target)
+        self.assertFalse(s.fired)
+
+    def test_case_insensitive(self):
+        article = _make_article(
+            detected_entities=["pulseproject 1"],
+            title="",
+            summary="",
+            content="",
+        )
+        s = self._signal(article)
+        self.assertTrue(s.fired)
+
+    def test_weight_is_correct(self):
+        s = self._signal(_make_article())
+        self.assertAlmostEqual(s.weight, _SIGNAL_WEIGHTS["mention"])
+
+
+class TestKeywordSignal(unittest.TestCase):
+
+    def setUp(self):
+        self.scorer = AttributionScorer()
+        self.target = _make_target()
+
+    def _signal(self, article):
+        return self.scorer._keyword_signal(article, self.target)
+
+    def test_fires_when_alias_in_keywords(self):
+        article = _make_article(keywords=["XLM", "defi"])
+        s = self._signal(article)
+        self.assertTrue(s.fired)
+
+    def test_fires_when_alias_in_title(self):
+        article = _make_article(
+            title="XLM rally drives PulseProject 1 adoption",
+            keywords=[],
+        )
+        s = self._signal(article)
+        self.assertTrue(s.fired)
+
+    def test_fires_when_alias_in_summary(self):
+        article = _make_article(
+            title="Market update",
+            summary="pulse-project-1 sees record growth",
+            keywords=[],
+        )
+        s = self._signal(article)
+        self.assertTrue(s.fired)
+
+    def test_does_not_fire_when_no_match(self):
+        article = _make_article(
+            title="Bitcoin surges",
+            summary="BTC hits ATH",
+            keywords=["BTC"],
+        )
+        target = _make_target(aliases=["OnlyMe"], asset_codes=["ONLY"])
+        s = self.scorer._keyword_signal(article, target)
+        self.assertFalse(s.fired)
+
+    def test_does_not_fire_when_no_searchable_terms(self):
+        target = _make_target(aliases=[], asset_codes=[])
+        s = self.scorer._keyword_signal(_make_article(), target)
+        self.assertFalse(s.fired)
+
+    def test_both_hits_give_max_value(self):
+        article = _make_article(
+            title="XLM update",
+            keywords=["XLM"],
+        )
+        s = self._signal(article)
+        self.assertAlmostEqual(s.value, 1.0)
+
+    def test_weight_is_correct(self):
+        s = self._signal(_make_article())
+        self.assertAlmostEqual(s.weight, _SIGNAL_WEIGHTS["keyword"])
+
+
+class TestSentimentCoherenceSignal(unittest.TestCase):
+
+    def setUp(self):
+        self.scorer = AttributionScorer()
+        self.target = _make_target()
+
+    def _signal(self, article):
+        return self.scorer._sentiment_coherence_signal(article, self.target)
+
+    def test_fires_on_positive_sentiment(self):
+        s = self._signal(_make_article(sentiment_score=0.7))
+        self.assertTrue(s.fired)
+        self.assertAlmostEqual(s.value, 0.7)
+
+    def test_fires_on_negative_sentiment(self):
+        s = self._signal(_make_article(sentiment_score=-0.6))
+        self.assertTrue(s.fired)
+        self.assertAlmostEqual(s.value, 0.6)
+
+    def test_does_not_fire_on_neutral_sentiment(self):
+        s = self._signal(_make_article(sentiment_score=0.03))
+        self.assertFalse(s.fired)
+        self.assertEqual(s.value, 0.0)
+
+    def test_does_not_fire_when_sentiment_absent(self):
+        s = self._signal(_make_article(sentiment_score=None))
+        self.assertFalse(s.fired)
+
+    def test_does_not_fire_at_exact_threshold(self):
+        s = self._signal(_make_article(sentiment_score=0.05))
+        self.assertFalse(s.fired)
+
+    def test_fires_just_above_threshold(self):
+        s = self._signal(_make_article(sentiment_score=0.051))
+        self.assertTrue(s.fired)
+
+    def test_weight_is_correct(self):
+        s = self._signal(_make_article())
+        self.assertAlmostEqual(s.weight, _SIGNAL_WEIGHTS["sentiment_coherence"])
+
+
+class TestCategorySignal(unittest.TestCase):
+
+    def setUp(self):
+        self.scorer = AttributionScorer()
+        self.target = _make_target(known_categories=["crypto", "stellar", "defi"])
+
+    def _signal(self, article):
+        return self.scorer._category_signal(article, self.target)
+
+    def test_fires_with_overlapping_categories(self):
+        article = _make_article(categories=["crypto", "news"])
+        s = self._signal(article)
+        self.assertTrue(s.fired)
+
+    def test_value_is_jaccard_similarity(self):
+        # target: {crypto, stellar, defi}  article: {crypto, stellar}
+        # intersection=2, union=3  → jaccard=2/3
+        article = _make_article(categories=["crypto", "stellar"])
+        s = self._signal(article)
+        self.assertAlmostEqual(s.value, 2 / 3, places=3)
+
+    def test_perfect_overlap_gives_1(self):
+        article = _make_article(categories=["crypto", "stellar", "defi"])
+        s = self._signal(article)
+        self.assertAlmostEqual(s.value, 1.0)
+
+    def test_does_not_fire_with_no_overlap(self):
+        article = _make_article(categories=["finance", "stocks"])
+        s = self._signal(article)
+        self.assertFalse(s.fired)
+
+    def test_does_not_fire_when_target_has_no_categories(self):
+        target = _make_target(known_categories=[])
+        s = self.scorer._category_signal(_make_article(), target)
+        self.assertFalse(s.fired)
+
+    def test_does_not_fire_when_article_has_no_categories(self):
+        article = _make_article(categories=[])
+        s = self._signal(article)
+        self.assertFalse(s.fired)
+
+    def test_case_insensitive_matching(self):
+        article = _make_article(categories=["Crypto", "STELLAR"])
+        s = self._signal(article)
+        self.assertTrue(s.fired)
+
+    def test_weight_is_correct(self):
+        s = self._signal(_make_article())
+        self.assertAlmostEqual(s.weight, _SIGNAL_WEIGHTS["category"])
+
+
+
+# ---------------------------------------------------------------------------
+# 7. AttributionScorer.score() — integration tests
+# ---------------------------------------------------------------------------
+
+class TestAttributionScorerScore(unittest.TestCase):
+
+    def setUp(self):
+        self.scorer = AttributionScorer()
+        self.target = _make_target()
+
+    def test_returns_attribution_result(self):
+        result = self.scorer.score(_make_article(), self.target)
+        self.assertIsInstance(result, AttributionResult)
+
+    def test_score_is_between_zero_and_one(self):
+        result = self.scorer.score(_make_article(), self.target)
+        self.assertGreaterEqual(result.score, 0.0)
+        self.assertLessEqual(result.score, 1.0)
+
+    def test_high_confidence_for_strong_article(self):
+        # Full entity link, alias mentions, keyword hits, non-neutral sentiment,
+        # and matching categories — should produce a high-confidence score.
+        result = self.scorer.score(_make_article(), self.target)
+        self.assertEqual(result.confidence_tier, "high")
+        self.assertFalse(result.low_confidence)
+
+    def test_very_low_confidence_on_blank_article(self):
+        blank = {
+            "article_id": "blank-001",
+            "title": "",
+            "summary": "",
+            "content": "",
+            "detected_entities": [],
+            "onchain_entity_links": [],
+            "categories": [],
+            "keywords": [],
+            "sentiment_score": 0.0,
+        }
+        result = self.scorer.score(blank, self.target)
+        self.assertEqual(result.confidence_tier, "very_low")
+        self.assertTrue(result.low_confidence)
+
+    def test_result_article_id_propagated(self):
+        article = _make_article(article_id="test-999")
+        result = self.scorer.score(article, self.target)
+        self.assertEqual(result.article_id, "test-999")
+
+    def test_result_target_fields_propagated(self):
+        result = self.scorer.score(_make_article(), self.target)
+        self.assertEqual(result.target_id, self.target.target_id)
+        self.assertEqual(result.target_type, self.target.target_type)
+        self.assertEqual(result.display_name, self.target.display_name)
+
+    def test_result_has_five_signals(self):
+        result = self.scorer.score(_make_article(), self.target)
+        self.assertEqual(len(result.signals), 5)
+
+    def test_signal_names_all_present(self):
+        result = self.scorer.score(_make_article(), self.target)
+        names = {s.name for s in result.signals}
+        self.assertEqual(
+            names,
+            {"entity_link", "mention", "keyword", "sentiment_coherence", "category"},
+        )
+
+    def test_scorer_version_set(self):
+        result = self.scorer.score(_make_article(), self.target)
+        self.assertEqual(result.scorer_version, "attribution_scorer_v1")
+
+    def test_score_weighted_sum_matches_manual_calc(self):
+        """Score must equal sum(weight * value) for each signal."""
+        result = self.scorer.score(_make_article(), self.target)
+        expected = sum(s.contribution() for s in result.signals)
+        self.assertAlmostEqual(result.score, expected, places=6)
+
+    def test_score_clipped_to_zero_on_all_no_fire(self):
+        blank = {
+            "article_id": "z",
+            "title": "Random market news",
+            "detected_entities": [],
+            "onchain_entity_links": [],
+            "categories": [],
+            "keywords": [],
+            "sentiment_score": 0.0,
+        }
+        target = _make_target(
+            aliases=["UniqueTokenXYZ"],
+            asset_codes=["UNQ"],
+            stable_entity_ids=["project:99999"],
+            known_categories=["special-niche"],
+        )
+        result = self.scorer.score(blank, target)
+        self.assertGreaterEqual(result.score, 0.0)
+
+    def test_contributor_target_type(self):
+        target = _make_target(
+            target_id="GCONTRIB123",
+            target_type="contributor",
+            display_name="Alice",
+            aliases=["Alice", "contributor_alice"],
+            stable_entity_ids=[],
+            known_categories=["community"],
+        )
+        article = _make_article(
+            title="Alice contributes to Stellar project",
+            detected_entities=["Alice"],
+            categories=["community", "stellar"],
+            onchain_entity_links=[],
+        )
+        result = self.scorer.score(article, target)
+        self.assertEqual(result.target_type, "contributor")
+        self.assertGreater(result.score, 0.0)
+
+    def test_missing_article_id_becomes_empty_string(self):
+        article = _make_article()
+        del article["article_id"]
+        result = self.scorer.score(article, self.target)
+        self.assertEqual(result.article_id, "")
+
+    def test_to_dict_is_json_serialisable(self):
+        import json
+        result = self.scorer.score(_make_article(), self.target)
+        # Should not raise
+        serialised = json.dumps(result.to_dict())
+        self.assertIn("score", serialised)
+
+
+# ---------------------------------------------------------------------------
+# 8. score_batch()
+# ---------------------------------------------------------------------------
+
+class TestAttributionScorerBatch(unittest.TestCase):
+
+    def setUp(self):
+        self.scorer = AttributionScorer()
+
+    def test_returns_correct_count(self):
+        articles = [_make_article(article_id=f"a-{i}") for i in range(3)]
+        targets = [
+            _make_target(target_id="10001"),
+            _make_target(target_id="10002", display_name="PulseProject 2"),
+        ]
+        results = self.scorer.score_batch(articles, targets)
+        self.assertEqual(len(results), 6)  # 3 articles × 2 targets
+
+    def test_results_sorted_descending_by_score(self):
+        articles = [_make_article()]
+        target_strong = _make_target(target_id="10001")
+        target_weak = _make_target(
+            target_id="99999",
+            display_name="Unknown",
+            aliases=["UnknownZZZ"],
+            stable_entity_ids=["project:99999"],
+            known_categories=["niche"],
+        )
+        results = self.scorer.score_batch(articles, [target_strong, target_weak])
+        scores = [r.score for r in results]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    def test_low_confidence_results_appear_last(self):
+        blank = {
+            "article_id": "blank",
+            "title": "",
+            "detected_entities": [],
+            "onchain_entity_links": [],
+            "categories": [],
+            "keywords": [],
+            "sentiment_score": 0.0,
+        }
+        good = _make_article()
+        target = _make_target()
+        results = self.scorer.score_batch([blank, good], [target])
+
+        low_conf_indices = [i for i, r in enumerate(results) if r.low_confidence]
+        high_conf_indices = [i for i, r in enumerate(results) if not r.low_confidence]
+
+        if low_conf_indices and high_conf_indices:
+            self.assertGreater(min(low_conf_indices), max(high_conf_indices))
+
+    def test_empty_inputs_returns_empty_list(self):
+        self.assertEqual(self.scorer.score_batch([], []), [])
+        self.assertEqual(self.scorer.score_batch([_make_article()], []), [])
+
+
+# ---------------------------------------------------------------------------
+# 9. Confidence tier boundary behaviour in full score
+# ---------------------------------------------------------------------------
+
+class TestConfidenceBoundaries(unittest.TestCase):
+
+    def setUp(self):
+        self.scorer = AttributionScorer()
+
+    def test_low_confidence_flag_matches_tier(self):
+        for article in [_make_article(), {"article_id": "x"}]:
+            target = _make_target()
+            result = self.scorer.score(article, target)
+            self.assertEqual(result.low_confidence, result.confidence_tier == "very_low")
+
+    def test_high_tier_implies_not_low_confidence(self):
+        result = self.scorer.score(_make_article(), _make_target())
+        if result.confidence_tier == "high":
+            self.assertFalse(result.low_confidence)
+
+
+# ---------------------------------------------------------------------------
+# 10. Lazy import via analytics __init__
+# ---------------------------------------------------------------------------
+
+class TestAnalyticsInitImport(unittest.TestCase):
+
+    def test_import_attribution_scorer(self):
+        from src.analytics import AttributionScorer as AS
+        self.assertIs(AS, AttributionScorer)
+
+    def test_import_attribution_target(self):
+        from src.analytics import AttributionTarget as AT
+        self.assertIs(AT, AttributionTarget)
+
+    def test_import_attribution_result(self):
+        from src.analytics import AttributionResult as AR
+        self.assertIs(AR, AttributionResult)
+
+    def test_import_signal_breakdown(self):
+        from src.analytics import SignalBreakdown as SB
+        self.assertIs(SB, SignalBreakdown)
+
+    def test_unknown_attribute_raises(self):
+        import src.analytics as analytics
+        with self.assertRaises(AttributeError):
+            _ = analytics.ThisDoesNotExist
+
+
+# ---------------------------------------------------------------------------
+# 11. Miscellaneous edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases(unittest.TestCase):
+
+    def setUp(self):
+        self.scorer = AttributionScorer()
+
+    def test_score_with_all_none_fields(self):
+        article = {
+            "article_id": None,
+            "title": None,
+            "summary": None,
+            "content": None,
+            "detected_entities": None,
+            "onchain_entity_links": None,
+            "categories": None,
+            "keywords": None,
+            "sentiment_score": None,
+        }
+        result = self.scorer.score(article, _make_target())
+        self.assertGreaterEqual(result.score, 0.0)
+        self.assertLessEqual(result.score, 1.0)
+
+    def test_score_with_extra_unknown_fields(self):
+        article = _make_article()
+        article["unknown_field"] = "should be ignored"
+        # Must not raise
+        result = self.scorer.score(article, _make_target())
+        self.assertIsInstance(result, AttributionResult)
+
+    def test_target_id_appears_as_alias(self):
+        # If the target_id is a Stellar address that appears in article text,
+        # the mention signal should still fire.
+        addr = "GCONTRIB_ADDR_XYZ"
+        target = _make_target(
+            target_id=addr,
+            aliases=[],  # no explicit aliases — target_id appended internally
+            stable_entity_ids=[],
+            known_categories=[],
+        )
+        article = _make_article(
+            title=f"Contributor {addr} just joined",
+            detected_entities=[addr],
+        )
+        result = self.scorer.score(article, target)
+        mention_signal = next(s for s in result.signals if s.name == "mention")
+        self.assertTrue(mention_signal.fired)
+
+    def test_score_does_not_exceed_one(self):
+        # Craft an article that maxes every signal
+        article = _make_article(sentiment_score=1.0)
+        result = self.scorer.score(article, _make_target())
+        self.assertLessEqual(result.score, 1.0)
+
+    def test_score_not_nan(self):
+        result = self.scorer.score(_make_article(), _make_target())
+        self.assertFalse(math.isnan(result.score))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the contributor-project narrative attribution scorer described in issue #1061.

Scores how strongly a news or discussion narrative relates to a specific contributor or project, rather than broad ecosystem trends.

## Changes

### `src/analytics/attribution_scorer.py` (new)
Core scorer with five weighted signals:

| Signal | Weight | Description |
|---|---|---|
| `entity_link` | 0.35 | Matches `onchain_entity_links` stable IDs; uses the linker's own confidence as value |
| `mention` | 0.25 | Alias / address hits in `detected_entities` or raw article text |
| `keyword` | 0.20 | Alias / ticker in pre-extracted keywords or title / summary |
| `sentiment_coherence` | 0.10 | Non-neutral sentiment (|score| > 0.05) suggests a focused narrative |
| `category` | 0.10 | Jaccard similarity between article categories and target's known topics |

Every result carries a `signals` breakdown list (`name / weight / fired / value / detail / contribution`) for full explainability and operator tuning without touching model logic.

Confidence tiers: `high` (≥ 0.75) / `medium` (≥ 0.50) / `low` (≥ 0.25) / `very_low` (< 0.25). Low-confidence results get `low_confidence=True` and sort to the end of `score_batch()` output.

### `alembic/versions/006_add_narrative_attribution_scores.py` (new)
Persists scored results in `narrative_attribution_scores` table. Join-friendly indexes on `(target_id, target_type)`, unique constraint on `(article_id, target_id, target_type)`, and a `signals` JSON column for the full breakdown.

### `src/analytics/__init__.py` (modified)
Lazy-exports `AttributionScorer`, `AttributionTarget`, `AttributionResult`, `SignalBreakdown`.

### `tests/test_attribution_scorer.py` (new)
84 unit tests covering all signals individually, weighted score arithmetic, confidence tiers, `score_batch()` ordering, serialisation, edge cases (missing fields, empty article, all-None fields), and the `__init__` lazy-import path.

## Acceptance criteria

- [x] Pipeline produces an attribution score / confidence value
- [x] Attribution logic is explainable enough for tuning
- [x] Output can be joined to contributor or project views later
- [x] Low-confidence cases are handled safely

## Testing

```
pytest tests/test_attribution_scorer.py -v
# 84 passed in 0.09s
```

closes #1061