### PR TITLE
fix(contracts): add finalization guardrails and double-finalize prote…

### DIFF
--- a/apps/onchain/Cargo.lock
+++ b/apps/onchain/Cargo.lock
@@ -632,9 +632,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fastrand"

--- a/apps/onchain/contracts/matching_pool/src/events.rs
+++ b/apps/onchain/contracts/matching_pool/src/events.rs
@@ -53,6 +53,7 @@ pub struct RoundFinalizedEvent {
     #[topic]
     pub round_id: u64,
     pub admin: Address,
+    pub finalized_at: u64,
 }
 
 #[contractevent]

--- a/apps/onchain/contracts/matching_pool/src/lib.rs
+++ b/apps/onchain/contracts/matching_pool/src/lib.rs
@@ -310,28 +310,45 @@ impl MatchingPoolContract {
         admin: Address,
         round_id: u64,
     ) -> Result<(), MatchingPoolError> {
-        Self::require_admin(&env, &admin)?;
-        let mut round: RoundData = env
-            .storage()
-            .persistent()
-            .get(&DataKey::Round(round_id))
-            .ok_or(MatchingPoolError::RoundNotFound)?;
-        if round.is_finalized {
-            return Err(MatchingPoolError::RoundAlreadyFinalized);
-        }
-        if env.ledger().timestamp() <= round.end_time {
-            return Err(MatchingPoolError::RoundStillOpen);
-        }
-        round.is_finalized = true;
-        env.storage()
-            .persistent()
-            .set(&DataKey::Round(round_id), &round);
-        env.storage().persistent().set(
-            &DataKey::RoundStatus(round_id),
-            &Symbol::new(&env, "FINALIZED"),
-        );
-        events::RoundFinalizedEvent { round_id, admin }.publish(&env);
-        Ok(())
+        Self::with_reentrancy_guard(&env, || {
+            Self::require_admin(&env, &admin)?;
+            Self::require_not_paused(&env)?;
+
+            let mut round: RoundData = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Round(round_id))
+                .ok_or(MatchingPoolError::RoundNotFound)?;
+
+            if round.is_finalized {
+                return Err(MatchingPoolError::RoundAlreadyFinalized);
+            }
+
+            let now = env.ledger().timestamp();
+            if now <= round.end_time {
+                return Err(MatchingPoolError::RoundStillOpen);
+            }
+
+            round.is_finalized = true;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Round(round_id), &round);
+            env.storage().persistent().set(
+                &DataKey::RoundStatus(round_id),
+                &Symbol::new(&env, "FINALIZED"),
+            );
+            env.storage()
+                .persistent()
+                .set(&DataKey::FinalizedAt(round_id), &now);
+
+            events::RoundFinalizedEvent {
+                round_id,
+                admin,
+                finalized_at: now,
+            }
+            .publish(&env);
+            Ok(())
+        })
     }
 
     pub fn distribute_matching_funds(
@@ -342,6 +359,7 @@ impl MatchingPoolContract {
     ) -> Result<i128, MatchingPoolError> {
         Self::with_reentrancy_guard(&env, || {
             Self::require_admin(&env, &admin)?;
+            Self::require_not_paused(&env)?;
             let mut round: RoundData = env
                 .storage()
                 .persistent()
@@ -642,6 +660,17 @@ impl MatchingPoolContract {
             .persistent()
             .get(&DataKey::RoundStatus(round_id))
             .unwrap_or(Symbol::new(&env, "ACTIVE")))
+    }
+
+    pub fn get_finalized_at(env: Env, round_id: u64) -> Result<u64, MatchingPoolError> {
+        env.storage()
+            .persistent()
+            .get::<_, RoundData>(&DataKey::Round(round_id))
+            .ok_or(MatchingPoolError::RoundNotFound)?;
+        env.storage()
+            .persistent()
+            .get(&DataKey::FinalizedAt(round_id))
+            .ok_or(MatchingPoolError::RoundNotFound)
     }
 
     pub fn get_admin(env: Env) -> Result<Address, MatchingPoolError> {

--- a/apps/onchain/contracts/matching_pool/src/storage.rs
+++ b/apps/onchain/contracts/matching_pool/src/storage.rs
@@ -18,6 +18,7 @@ pub enum DataKey {
     ContributorAmount(u64, u64, Address), // (round_id, project_id, contributor) -> i128
     MatchDistributed(u64),                // round_id -> bool
     RoundStatus(u64),                     // round_id -> Symbol ("ACTIVE"|"FINALIZED"|"DISTRIBUTED")
+    FinalizedAt(u64),                     // round_id -> u64 (ledger timestamp when finalized)
 }
 
 /// Core data for a funding round

--- a/apps/onchain/contracts/matching_pool/src/test.rs
+++ b/apps/onchain/contracts/matching_pool/src/test.rs
@@ -484,3 +484,240 @@ fn test_fund_pool_cei_state_written_before_token_balance_assertion() {
     assert_eq!(client.get_pool_balance(&round_id), 250_000);
     assert_eq!(token.balance(&client.address), 250_000);
 }
+
+// ── Finalization guardrails ──────────────────────────────────────────────────
+
+#[test]
+fn test_double_finalize_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    env.ledger().set_timestamp(4000);
+    client.finalize_round(&admin, &round_id);
+
+    assert_eq!(
+        client.try_finalize_round(&admin, &round_id),
+        Err(Ok(MatchingPoolError::RoundAlreadyFinalized))
+    );
+
+    assert_eq!(
+        client.get_round_status(&round_id),
+        symbol_short!("FINALIZED")
+    );
+}
+
+#[test]
+fn test_finalize_unauthorized_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    let not_admin = Address::generate(&env);
+    env.ledger().set_timestamp(4000);
+    assert_eq!(
+        client.try_finalize_round(&not_admin, &round_id),
+        Err(Ok(MatchingPoolError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_finalize_nonexistent_round_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _) = setup(&env);
+    client.initialize(&admin);
+
+    assert_eq!(
+        client.try_finalize_round(&admin, &999u64),
+        Err(Ok(MatchingPoolError::RoundNotFound))
+    );
+}
+
+#[test]
+fn test_finalize_while_paused_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    client.pause(&admin);
+
+    env.ledger().set_timestamp(4000);
+    assert_eq!(
+        client.try_finalize_round(&admin, &round_id),
+        Err(Ok(MatchingPoolError::ContractPaused))
+    );
+
+    let round = client.get_round(&round_id);
+    assert!(!round.is_finalized);
+}
+
+#[test]
+fn test_finalize_records_timestamp_and_status() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    env.ledger().set_timestamp(4000);
+    client.finalize_round(&admin, &round_id);
+
+    let round = client.get_round(&round_id);
+    assert!(round.is_finalized);
+    assert_eq!(
+        client.get_round_status(&round_id),
+        symbol_short!("FINALIZED")
+    );
+    assert_eq!(client.get_finalized_at(&round_id), 4000);
+}
+
+#[test]
+fn test_reentrancy_guard_finalize_rejects_when_locked() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("RGF"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    env.as_contract(&client.address, || {
+        env.storage()
+            .instance()
+            .set(&symbol_short!("REENTRANT"), &true);
+    });
+
+    env.ledger().set_timestamp(4000);
+    let result = client.try_finalize_round(&admin, &round_id);
+    assert_eq!(result, Err(Ok(MatchingPoolError::Reentrancy)));
+
+    let round = client.get_round(&round_id);
+    assert!(!round.is_finalized);
+}
+
+#[test]
+fn test_distribute_while_paused_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    client.initialize(&admin);
+
+    let funder = Address::generate(&env);
+    let owner1 = Address::generate(&env);
+    token_admin.mint(&funder, &1_000_000);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    client.fund_pool(&funder, &round_id, &1_000_000);
+    client.approve_project(&admin, &round_id, &1u64);
+
+    env.ledger().set_timestamp(1500);
+    let c = Address::generate(&env);
+    client.record_contribution(&round_id, &1u64, &c, &100);
+
+    env.ledger().set_timestamp(4000);
+    client.finalize_round(&admin, &round_id);
+
+    client.pause(&admin);
+
+    let owners = vec![&env, owner1.clone()];
+    assert_eq!(
+        client.try_distribute_matching_funds(&admin, &round_id, &owners),
+        Err(Ok(MatchingPoolError::ContractPaused))
+    );
+
+    let round = client.get_round(&round_id);
+    assert!(!round.is_distributed);
+}
+
+#[test]
+fn test_distribute_succeeds_after_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    client.initialize(&admin);
+
+    let funder = Address::generate(&env);
+    let owner1 = Address::generate(&env);
+    token_admin.mint(&funder, &1_000_000);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    client.fund_pool(&funder, &round_id, &1_000_000);
+    client.approve_project(&admin, &round_id, &1u64);
+
+    env.ledger().set_timestamp(1500);
+    let c = Address::generate(&env);
+    client.record_contribution(&round_id, &1u64, &c, &100);
+
+    env.ledger().set_timestamp(4000);
+    client.finalize_round(&admin, &round_id);
+
+    client.pause(&admin);
+    client.unpause(&admin);
+
+    let owners = vec![&env, owner1.clone()];
+    let total = client.distribute_matching_funds(&admin, &round_id, &owners);
+
+    assert_eq!(total, 1_000_000);
+    assert_eq!(token.balance(&owner1), 1_000_000);
+}

--- a/apps/onchain/contracts/matching_pool/test_snapshots/test/test_full_distribution_flow.1.json
+++ b/apps/onchain/contracts/matching_pool/test_snapshots/test/test_full_distribution_flow.1.json
@@ -1099,6 +1099,51 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "FinalizedAt"
+                },
+                {
+                  "u64": "0"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "FinalizedAt"
+                    },
+                    {
+                      "u64": "0"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "u64": "4000"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
                   "symbol": "MatchDistributed"
                 },
                 {


### PR DESCRIPTION
## Summary
Fixes #909  the matching pool contract had no guardrails preventing a round from being finalized more than once, and lacked strict pause/reentrancy checks on finalization. This adds those guardrails, closes a related pause-check gap in `distribute_matching_funds`, and fixes an unrelated build break from an upstream crate regression.

## Changes
- `finalize_round`: added `require_not_paused` check and `with_reentrancy_guard`, matching the pattern already used by `fund_pool`
- Double-finalize attempts explicitly blocked via the existing `is_finalized` flag check (now covered by tests)
- Added `FinalizedAt` storage key + `get_finalized_at` getter to record finalization time
- `RoundFinalizedEvent` now emits `finalized_at`
- `distribute_matching_funds`: added missing `require_not_paused` check (was callable while contract paused, inconsistent with `fund_pool`/`finalize_round`)
- Bumped `ethnum` to 1.5.3 to fix a build failure against Rust 1.97 (unrelated upstream regression, needed to get CI green)

## Tests
8 new tests covering: double-finalize, unauthorized caller, nonexistent round, paused state (finalize + distribute), timestamp recording, and reentrancy-lock rejection. All 24 tests in the crate pass; `cargo clippy --all-targets --all-features -- -D warnings` is clean.

## Acceptance criteria (#909)
- [x] Round finalization is idempotent or explicitly blocked after completion
- [x] State transitions are validated strictly
- [x] Events show finalization outcomes
- [x] Tests cover duplicate finalize attempts

Closes #909