### PR TITLE
feat: add replay validator and tests for historical record transforma…

### DIFF
--- a/apps/data-processing/scripts/replay_validator.py
+++ b/apps/data-processing/scripts/replay_validator.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Replay historical JSON/JSONL records through two transforms."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.replay_validator import import_transform, identity, load_records, replay, select_records
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Replay historical records and compare transforms")
+    parser.add_argument("--input", required=True, help="JSON array or JSONL historical records")
+    parser.add_argument("--limit", type=int, help="Maximum records to replay")
+    parser.add_argument("--start-ledger", type=int, help="First ledger, inclusive")
+    parser.add_argument("--end-ledger", type=int, help="Last ledger, inclusive")
+    parser.add_argument("--old-transform", help="Old transform as module:function")
+    parser.add_argument("--new-transform", help="New transform as module:function")
+    parser.add_argument("--output", help="Optional report path; stdout is always written")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.limit is not None and args.limit < 1:
+        raise SystemExit("--limit must be greater than zero")
+    if args.start_ledger is not None and args.end_ledger is not None and args.start_ledger > args.end_ledger:
+        raise SystemExit("--start-ledger must be <= --end-ledger")
+
+    records = select_records(
+        load_records(args.input), args.limit, args.start_ledger, args.end_ledger
+    )
+    old_transform = import_transform(args.old_transform) if args.old_transform else identity
+    new_transform = import_transform(args.new_transform) if args.new_transform else identity
+    report = replay(records, old_transform, new_transform)
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    print(rendered)
+    if args.output:
+        Path(args.output).write_text(rendered + "\n", encoding="utf-8")
+    return 1 if report["status"] != "match" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/data-processing/src/replay_validator.py
+++ b/apps/data-processing/src/replay_validator.py
@@ -1,0 +1,135 @@
+"""Replay historical records through two transforms and report regressions."""
+
+import importlib
+from dataclasses import dataclass
+import json
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+Transform = Callable[[Dict[str, Any]], Any]
+
+
+@dataclass(frozen=True)
+class Difference:
+    """A single output difference for one historical record."""
+
+    record_key: str
+    path: str
+    old_value: Any
+    new_value: Any
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "record_key": self.record_key,
+            "path": self.path,
+            "old": self.old_value,
+            "new": self.new_value,
+        }
+
+
+def load_records(path: str) -> List[Dict[str, Any]]:
+    """Load a JSON array or JSONL file of historical object records."""
+    with open(path, "r", encoding="utf-8-sig") as handle:
+        content = handle.read().strip()
+
+    if not content:
+        return []
+    parsed = json.loads(content) if content.startswith("[") else [
+        json.loads(line) for line in content.splitlines() if line.strip()
+    ]
+    if not isinstance(parsed, list) or not all(isinstance(item, dict) for item in parsed):
+        raise ValueError("Replay input must contain a JSON array or JSONL objects")
+    return parsed
+
+
+def select_records(
+    records: Iterable[Dict[str, Any]],
+    limit: Optional[int] = None,
+    start_ledger: Optional[int] = None,
+    end_ledger: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Select a bounded, stable sample, optionally constrained by ledger."""
+    selected = []
+    for record in records:
+        ledger = record.get("ledger")
+        if start_ledger is not None or end_ledger is not None:
+            if not isinstance(ledger, int):
+                continue
+            if start_ledger is not None and ledger < start_ledger:
+                continue
+            if end_ledger is not None and ledger > end_ledger:
+                continue
+        selected.append(record)
+        if limit is not None and len(selected) >= limit:
+            break
+    return selected
+
+
+def _diff_values(old: Any, new: Any, path: str = "$") -> List[Tuple[str, Any, Any]]:
+    if isinstance(old, dict) and isinstance(new, dict):
+        differences = []
+        for key in sorted(set(old) | set(new)):
+            differences.extend(_diff_values(old.get(key), new.get(key), f"{path}.{key}"))
+        return differences
+    if isinstance(old, list) and isinstance(new, list):
+        differences = []
+        for index in range(max(len(old), len(new))):
+            differences.extend(
+                _diff_values(
+                    old[index] if index < len(old) else None,
+                    new[index] if index < len(new) else None,
+                    f"{path}[{index}]",
+                )
+            )
+        return differences
+    return [] if old == new else [(path, old, new)]
+
+
+def replay(
+    records: Sequence[Dict[str, Any]],
+    old_transform: Transform,
+    new_transform: Transform,
+) -> Dict[str, Any]:
+    """Run both transforms and return a JSON-serializable validation report."""
+    differences: List[Difference] = []
+    failures: List[Dict[str, str]] = []
+    compared = 0
+
+    for index, record in enumerate(records):
+        record_key = str(record.get("id", record.get("ledger", index)))
+        try:
+            old_output = old_transform(record)
+            new_output = new_transform(record)
+            compared += 1
+            differences.extend(
+                Difference(record_key, path, old, new)
+                for path, old, new in _diff_values(old_output, new_output)
+            )
+        except Exception as exc:
+            failures.append({"record_key": record_key, "error": str(exc)})
+
+    return {
+        "status": "failed" if failures else ("differences" if differences else "match"),
+        "records": len(records),
+        "compared": compared,
+        "difference_count": len(differences),
+        "failure_count": len(failures),
+        "differences": [difference.to_dict() for difference in differences],
+        "failures": failures,
+    }
+
+
+def import_transform(spec: str) -> Transform:
+    """Load a transform using ``package.module:function`` notation."""
+    module_name, separator, function_name = spec.partition(":")
+    if not separator or not module_name or not function_name:
+        raise ValueError(f"Transform must use module:function notation: {spec}")
+    transform = getattr(importlib.import_module(module_name), function_name)
+    if not callable(transform):
+        raise TypeError(f"Transform is not callable: {spec}")
+    return transform
+
+
+def identity(record: Dict[str, Any]) -> Dict[str, Any]:
+    """Default transform for smoke-checking a replay dataset."""
+    return record

--- a/apps/data-processing/tests/test_replay_validator.py
+++ b/apps/data-processing/tests/test_replay_validator.py
@@ -1,0 +1,33 @@
+import json
+
+from src.replay_validator import identity, load_records, replay, select_records
+
+
+def test_replays_bounded_ledger_slice_and_reports_nested_difference(tmp_path):
+    input_path = tmp_path / "history.jsonl"
+    input_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"id": "a", "ledger": 10, "value": 1}),
+                json.dumps({"id": "b", "ledger": 20, "value": 2}),
+                json.dumps({"id": "c", "ledger": 30, "value": 3}),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    records = select_records(load_records(str(input_path)), start_ledger=20, end_ledger=30)
+    report = replay(records, identity, lambda record: {**record, "value": record["value"] + 1})
+
+    assert report["status"] == "differences"
+    assert report["compared"] == 2
+    assert report["difference_count"] == 2
+    assert report["differences"][0]["path"] == "$.value"
+
+
+def test_identical_replay_matches():
+    report = replay([{"id": "a", "ledger": 1}], identity, identity)
+
+    assert report["status"] == "match"
+    assert report["difference_count"] == 0
+    assert report["failure_count"] == 0


### PR DESCRIPTION
closed #1068 

Summary

Adds an offline historical replay validator for the data-processing application. Contributors can replay a bounded sample or Stellar ledger range through an old and new parser/transform implementation and receive a deterministic JSON report of output differences