### PR TITLE
feat(analytics): implement low-confidence entity linking review queue…

### DIFF
--- a/apps/data-processing/alembic/versions/006_add_entity_linking_review_queue.py
+++ b/apps/data-processing/alembic/versions/006_add_entity_linking_review_queue.py
@@ -1,0 +1,98 @@
+"""Add entity linking review queue table
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-07-23 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "006"
+down_revision: Union[str, None] = "005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "entity_linking_review_queue",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("article_id", sa.String(length=255), nullable=False),
+        sa.Column("stable_entity_id", sa.String(length=255), nullable=False),
+        sa.Column("entity_type", sa.String(length=50), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("matched_text", sa.String(length=255), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("supporting_evidence", sa.JSON(), nullable=True),
+        sa.Column("status", sa.String(length=50), server_default="pending", nullable=False),
+        sa.Column("corrected_entity_id", sa.String(length=255), nullable=True),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_entity_linking_review_queue_article_id",
+        "entity_linking_review_queue",
+        ["article_id"],
+    )
+    op.create_index(
+        "ix_entity_linking_review_queue_stable_entity_id",
+        "entity_linking_review_queue",
+        ["stable_entity_id"],
+    )
+    op.create_index(
+        "ix_entity_linking_review_queue_entity_type",
+        "entity_linking_review_queue",
+        ["entity_type"],
+    )
+    op.create_index(
+        "ix_entity_linking_review_queue_status",
+        "entity_linking_review_queue",
+        ["status"],
+    )
+    op.create_index(
+        "ux_entity_review_queue_article_entity",
+        "entity_linking_review_queue",
+        ["article_id", "stable_entity_id"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ux_entity_review_queue_article_entity",
+        table_name="entity_linking_review_queue",
+    )
+    op.drop_index(
+        "ix_entity_linking_review_queue_status",
+        table_name="entity_linking_review_queue",
+    )
+    op.drop_index(
+        "ix_entity_linking_review_queue_entity_type",
+        table_name="entity_linking_review_queue",
+    )
+    op.drop_index(
+        "ix_entity_linking_review_queue_stable_entity_id",
+        table_name="entity_linking_review_queue",
+    )
+    op.drop_index(
+        "ix_entity_linking_review_queue_article_id",
+        table_name="entity_linking_review_queue",
+    )
+    op.drop_table("entity_linking_review_queue")

--- a/apps/data-processing/src/analytics/onchain_entity_linker.py
+++ b/apps/data-processing/src/analytics/onchain_entity_linker.py
@@ -68,10 +68,12 @@ class OnchainEntityLinker:
     def __init__(
         self,
         candidates: Optional[Sequence[OnchainEntityCandidate]] = None,
+        overrides: Optional[Dict[str, str]] = None,
     ) -> None:
         self.candidates = self._dedupe_candidates(
             list(candidates or []) + list(self.DEFAULT_ASSETS)
         )
+        self.overrides = overrides or {}
 
     def link_text(
         self,
@@ -88,6 +90,10 @@ class OnchainEntityLinker:
         links: Dict[str, OnchainEntityLink] = {}
 
         for candidate in self.candidates:
+            override_val = self.overrides.get(candidate.stable_id)
+            if override_val == "__REJECTED__":
+                continue
+
             match = self._first_alias_match(haystack, candidate.aliases)
             if not match:
                 continue
@@ -96,16 +102,26 @@ class OnchainEntityLinker:
             if candidate.entity_type == "asset" and match.upper() == candidate.asset_code:
                 confidence = 0.9
 
-            links[candidate.stable_id] = OnchainEntityLink(
-                stable_id=candidate.stable_id,
-                entity_type=candidate.entity_type,
-                display_name=candidate.display_name,
+            target_stable_id = candidate.stable_id
+            target_candidate = candidate
+            if override_val:
+                if override_val != candidate.stable_id:
+                    corrected_cand = next((c for c in self.candidates if c.stable_id == override_val), None)
+                    if corrected_cand:
+                        target_stable_id = override_val
+                        target_candidate = corrected_cand
+                confidence = 1.0
+
+            links[target_stable_id] = OnchainEntityLink(
+                stable_id=target_stable_id,
+                entity_type=target_candidate.entity_type,
+                display_name=target_candidate.display_name,
                 matched_text=match,
                 confidence=confidence,
                 source="onchain_entity_linker_v1",
-                asset_code=candidate.asset_code,
-                project_id=candidate.project_id,
-                contract_id=candidate.contract_id,
+                asset_code=target_candidate.asset_code,
+                project_id=target_candidate.project_id,
+                contract_id=target_candidate.contract_id,
             )
 
         return sorted(links.values(), key=lambda link: link.stable_id)

--- a/apps/data-processing/src/api/review_queue_routes.py
+++ b/apps/data-processing/src/api/review_queue_routes.py
@@ -1,0 +1,134 @@
+"""FastAPI routes for entity linking review queue."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+from src.db.postgres_service import PostgresService
+
+router = APIRouter(prefix="/api/review-queue", tags=["Review Queue"])
+
+
+class ReviewQueueItemResponse(BaseModel):
+    id: int
+    article_id: str
+    stable_entity_id: str
+    entity_type: str
+    display_name: str
+    matched_text: str
+    confidence: float
+    supporting_evidence: Optional[Dict[str, Any]] = None
+    status: str
+    corrected_entity_id: Optional[str] = None
+    reviewed_at: Optional[str] = None
+    created_at: str
+
+
+class UpdateReviewStatusRequest(BaseModel):
+    status: str = Field(..., description="Must be approved, rejected, corrected, or pending")
+    corrected_entity_id: Optional[str] = Field(None, description="Optional stable entity ID if status is 'corrected'")
+
+
+class ActionResponse(BaseModel):
+    success: bool
+    message: str
+
+
+try:
+    postgres_service = PostgresService()
+except Exception:
+    postgres_service = None
+
+
+def get_db():
+    if not postgres_service:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Database service unavailable",
+        )
+    return postgres_service
+
+
+@router.get("", response_model=List[ReviewQueueItemResponse])
+async def get_review_queue(
+    status: Optional[str] = Query(None, description="Filter queue by status (pending, approved, rejected, corrected)"),
+    limit: int = Query(100, ge=1, le=1000),
+    db: PostgresService = Query(default=None, include_in_schema=False),
+) -> List[ReviewQueueItemResponse]:
+    """Retrieve items from the review queue with optional filters."""
+    db_service = get_db()
+    items = db_service.get_review_queue(status=status, limit=limit)
+    return [
+        ReviewQueueItemResponse(
+            id=item.id,
+            article_id=item.article_id,
+            stable_entity_id=item.stable_entity_id,
+            entity_type=item.entity_type,
+            display_name=item.display_name,
+            matched_text=item.matched_text,
+            confidence=item.confidence,
+            supporting_evidence=item.supporting_evidence,
+            status=item.status,
+            corrected_entity_id=item.corrected_entity_id,
+            reviewed_at=item.reviewed_at.isoformat() if item.reviewed_at else None,
+            created_at=item.created_at.isoformat(),
+        )
+        for item in items
+    ]
+
+
+@router.post("/{review_id}", response_model=ActionResponse)
+async def update_item_status(
+    review_id: int,
+    req: UpdateReviewStatusRequest,
+) -> ActionResponse:
+    """Update status of a queue item (approve, reject, correct)."""
+    db_service = get_db()
+    success = db_service.update_review_status(
+        review_id=review_id,
+        status=req.status,
+        corrected_entity_id=req.corrected_entity_id,
+    )
+    if not success:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Failed to update item. Ensure review_id exists and status is valid.",
+        )
+    return ActionResponse(success=True, message=f"Item {review_id} updated to {req.status}")
+
+
+@router.get("/export", response_model=List[ReviewQueueItemResponse])
+async def export_review_queue(
+    status: Optional[str] = Query(None, description="Filter by status before exporting"),
+) -> List[ReviewQueueItemResponse]:
+    """Export the review queue as a structured response."""
+    db_service = get_db()
+    items = db_service.get_review_queue(status=status, limit=1000)
+    return [
+        ReviewQueueItemResponse(
+            id=item.id,
+            article_id=item.article_id,
+            stable_entity_id=item.stable_entity_id,
+            entity_type=item.entity_type,
+            display_name=item.display_name,
+            matched_text=item.matched_text,
+            confidence=item.confidence,
+            supporting_evidence=item.supporting_evidence,
+            status=item.status,
+            corrected_entity_id=item.corrected_entity_id,
+            reviewed_at=item.reviewed_at.isoformat() if item.reviewed_at else None,
+            created_at=item.created_at.isoformat(),
+        )
+        for item in items
+    ]
+
+
+@router.get("/outcomes", response_model=List[Dict[str, Any]])
+async def get_reviewed_outcomes() -> List[Dict[str, Any]]:
+    """Retrieve all reviewed outcomes (approved/corrected/rejected) for feedback tuning."""
+    db_service = get_db()
+    return db_service.get_reviewed_outcomes()

--- a/apps/data-processing/src/api/review_queue_routes.py
+++ b/apps/data-processing/src/api/review_queue_routes.py
@@ -57,7 +57,6 @@ def get_db():
 async def get_review_queue(
     status: Optional[str] = Query(None, description="Filter queue by status (pending, approved, rejected, corrected)"),
     limit: int = Query(100, ge=1, le=1000),
-    db: PostgresService = Query(default=None, include_in_schema=False),
 ) -> List[ReviewQueueItemResponse]:
     """Retrieve items from the review queue with optional filters."""
     db_service = get_db()

--- a/apps/data-processing/src/api/server.py
+++ b/apps/data-processing/src/api/server.py
@@ -90,6 +90,10 @@ sentiment_analyzer = SentimentAnalyzer()
 from src.api.ingestion_quality_routes import router as ingestion_quality_router
 app.include_router(ingestion_quality_router)
 
+# Entity linking review queue routes
+from src.api.review_queue_routes import router as review_queue_router
+app.include_router(review_queue_router)
+
 
 try:
     postgres_service = PostgresService()

--- a/apps/data-processing/src/db/__init__.py
+++ b/apps/data-processing/src/db/__init__.py
@@ -15,6 +15,7 @@ from .models import (
     ProjectMilestone,
     NewsInsight,
     AssetTrend,
+    EntityLinkingReview,
 )
 from .postgres_service import PostgresService
 
@@ -31,5 +32,6 @@ __all__ = [
     "ProjectMilestone",
     "NewsInsight",
     "AssetTrend",
+    "EntityLinkingReview",
     "PostgresService",
 ]

--- a/apps/data-processing/src/db/models.py
+++ b/apps/data-processing/src/db/models.py
@@ -589,3 +589,45 @@ class RoundAnomalySignal(Base):
             f"type={self.anomaly_type}, severity={self.severity_score:.2f}, "
             f"reviewed={self.reviewed})>"
         )
+
+
+class EntityLinkingReview(Base):
+    """
+    Human-in-the-loop review queue for low-confidence entity linking and attribution.
+    """
+
+    __tablename__ = "entity_linking_review_queue"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    article_id = Column(String(255), nullable=False, index=True)
+    stable_entity_id = Column(String(255), nullable=False, index=True)
+    entity_type = Column(String(50), nullable=False, index=True)
+    display_name = Column(String(255), nullable=False)
+    matched_text = Column(String(255), nullable=False)
+    confidence = Column(Float, nullable=False)
+    supporting_evidence = Column(JSON, nullable=True)  # Context snippet, reason, candidates
+    status = Column(String(50), default="pending", nullable=False, index=True)  # pending, approved, rejected, corrected
+    corrected_entity_id = Column(String(255), nullable=True)
+    reviewed_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        Index(
+            "ux_entity_review_queue_article_entity",
+            "article_id",
+            "stable_entity_id",
+            unique=True,
+        ),
+    )
+
+    def __repr__(self):
+        return (
+            f"<EntityLinkingReview(id={self.id}, article_id='{self.article_id}', "
+            f"stable_entity_id='{self.stable_entity_id}', status='{self.status}')>"
+        )
+

--- a/apps/data-processing/src/db/postgres_service.py
+++ b/apps/data-processing/src/db/postgres_service.py
@@ -30,6 +30,7 @@ from .models import (
     AssetTrend,
     RoundAnomalySignal,
     MetadataDriftFinding,
+    EntityLinkingReview,
 )
 from src.analytics.ner_service import NERService
 from src.analytics.onchain_entity_linker import (
@@ -155,7 +156,32 @@ class PostgresService:
         article_data: Dict[str, Any],
     ) -> List[OnchainEntityLink]:
         """Link article content to default assets and current project views."""
-        linker = OnchainEntityLinker(self._project_candidates_from_session(session))
+        overrides = {}
+        article_id = article_data.get("id")
+        if article_id:
+            try:
+                reviewed_items = session.execute(
+                    select(EntityLinkingReview).where(
+                        and_(
+                            EntityLinkingReview.article_id == article_id,
+                            EntityLinkingReview.status.in_(["approved", "rejected", "corrected"])
+                        )
+                    )
+                ).scalars().all()
+                for item in reviewed_items:
+                    if item.status == "rejected":
+                        overrides[item.stable_entity_id] = "__REJECTED__"
+                    elif item.status == "corrected":
+                        overrides[item.stable_entity_id] = item.corrected_entity_id or "__REJECTED__"
+                    elif item.status == "approved":
+                        overrides[item.stable_entity_id] = item.stable_entity_id
+            except Exception as e:
+                logger.warning(f"Failed to fetch reviewed overrides: {e}")
+
+        linker = OnchainEntityLinker(
+            self._project_candidates_from_session(session),
+            overrides=overrides,
+        )
         return linker.link_article(article_data)
 
     def _sync_article_onchain_links(
@@ -187,6 +213,72 @@ class PostgresService:
                     contract_id=link.contract_id,
                 )
             )
+
+        self._upsert_review_queue_items(session, article, links)
+
+    def _upsert_review_queue_items(
+        self,
+        session: Session,
+        article: Article,
+        links: List[OnchainEntityLink],
+        confidence_threshold: float = 0.90,
+    ) -> None:
+        """
+        Upsert low-confidence entity linking cases into the review queue.
+        Guaranteed to be non-blocking.
+        """
+        try:
+            for link in links:
+                if link.confidence >= confidence_threshold:
+                    continue
+
+                evidence = {
+                    "title": article.title,
+                    "summary": article.summary,
+                    "matched_text": link.matched_text,
+                    "reason": f"Confidence {link.confidence:.2f} below threshold {confidence_threshold:.2f}",
+                }
+
+                content = article.content or ""
+                summary = article.summary or ""
+                text_to_search = content if content else summary
+                if link.matched_text and text_to_search:
+                    idx = text_to_search.lower().find(link.matched_text.lower())
+                    if idx != -1:
+                        start = max(0, idx - 100)
+                        end = min(len(text_to_search), idx + len(link.matched_text) + 100)
+                        evidence["context_snippet"] = text_to_search[start:end]
+
+                existing = session.execute(
+                    select(EntityLinkingReview).where(
+                        and_(
+                            EntityLinkingReview.article_id == article.article_id,
+                            EntityLinkingReview.stable_entity_id == link.stable_id,
+                        )
+                    )
+                ).scalar_one_or_none()
+
+                if existing:
+                    if existing.status == "pending":
+                        existing.confidence = link.confidence
+                        existing.display_name = link.display_name
+                        existing.matched_text = link.matched_text
+                        existing.supporting_evidence = evidence
+                else:
+                    session.add(
+                        EntityLinkingReview(
+                            article_id=article.article_id,
+                            stable_entity_id=link.stable_id,
+                            entity_type=link.entity_type,
+                            display_name=link.display_name,
+                            matched_text=link.matched_text,
+                            confidence=link.confidence,
+                            supporting_evidence=evidence,
+                            status="pending",
+                        )
+                    )
+        except Exception as e:
+            logger.error(f"Non-blocking review queue logging failure: {e}", exc_info=True)
 
     @contextmanager
     def get_session(self):
@@ -2305,3 +2397,98 @@ class PostgresService:
         except SQLAlchemyError as e:
             logger.error(f"Failed to mark metadata drift finding as reviewed: {e}")
             return False
+
+    def get_review_queue(self, status: Optional[str] = None, limit: int = 100) -> List[EntityLinkingReview]:
+        """
+        Retrieve items from the entity linking review queue.
+        """
+        try:
+            with self.get_session() as session:
+                query = select(EntityLinkingReview)
+                if status is not None:
+                    query = query.where(EntityLinkingReview.status == status)
+                query = query.order_by(desc(EntityLinkingReview.created_at)).limit(limit)
+                return session.execute(query).scalars().all()
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to retrieve review queue: {e}")
+            return []
+
+    def update_review_status(self, review_id: int, status: str, corrected_entity_id: Optional[str] = None) -> bool:
+        """
+        Update the review status of a queue item.
+        """
+        if status not in ["approved", "rejected", "corrected", "pending"]:
+            logger.warning(f"Invalid review status: {status}")
+            return False
+
+        try:
+            with self.get_session() as session:
+                item = session.execute(
+                    select(EntityLinkingReview).where(EntityLinkingReview.id == review_id)
+                ).scalar_one_or_none()
+
+                if not item:
+                    logger.warning(f"Review queue item {review_id} not found")
+                    return False
+
+                item.status = status
+                item.corrected_entity_id = corrected_entity_id
+                item.reviewed_at = datetime.utcnow()
+                
+                session.flush()
+                
+                # Re-run entity linking on the associated article to immediately reflect changes
+                article = session.execute(
+                    select(Article).where(Article.article_id == item.article_id)
+                ).scalar_one_or_none()
+                if article:
+                    # Construct article_data dictionary
+                    article_data = {
+                        "id": article.article_id,
+                        "title": article.title,
+                        "summary": article.summary,
+                        "content": article.content,
+                        "detected_entities": article.detected_entities,
+                        "keywords": article.keywords,
+                        "categories": article.categories,
+                    }
+                    # This will re-link using updated overrides
+                    links = self._link_article_onchain_entities(session, article_data)
+                    self._sync_article_onchain_links(session, article, links)
+
+                logger.info(f"Updated review queue item {review_id} status to {status}")
+                return True
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to update review queue item: {e}")
+            return False
+
+    def get_reviewed_outcomes(self) -> List[Dict[str, Any]]:
+        """
+        Get all reviewed outcomes to feed future tuning/model workflows.
+        """
+        try:
+            with self.get_session() as session:
+                query = select(EntityLinkingReview).where(
+                    EntityLinkingReview.status.in_(["approved", "corrected", "rejected"])
+                )
+                rows = session.execute(query).scalars().all()
+                return [
+                    {
+                        "id": r.id,
+                        "article_id": r.article_id,
+                        "stable_entity_id": r.stable_entity_id,
+                        "entity_type": r.entity_type,
+                        "display_name": r.display_name,
+                        "matched_text": r.matched_text,
+                        "confidence": r.confidence,
+                        "status": r.status,
+                        "corrected_entity_id": r.corrected_entity_id,
+                        "supporting_evidence": r.supporting_evidence,
+                        "reviewed_at": r.reviewed_at.isoformat() if r.reviewed_at else None,
+                    }
+                    for r in rows
+                ]
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to retrieve reviewed outcomes: {e}")
+            return []
+

--- a/apps/data-processing/src/qa_exporter.py
+++ b/apps/data-processing/src/qa_exporter.py
@@ -31,7 +31,7 @@ from typing import Any, Dict, List, Optional
 from sqlalchemy import create_engine, select, and_
 from sqlalchemy.orm import sessionmaker
 
-from src.db.models import AnalyticsRecord, Article, AssetTrend, SocialPost
+from src.db.models import AnalyticsRecord, Article, AssetTrend, SocialPost, EntityLinkingReview
 
 logger = logging.getLogger(__name__)
 
@@ -246,11 +246,39 @@ class QAExporter:
         logger.info("Exported %d KPIs → %s", len(records), path)
         return ExportResult("kpis", str(path), len(records), "completed")
 
+    def export_review_queue(self) -> ExportResult:
+        """Export the entity linking review queue."""
+        with self.Session() as session:
+            rows = session.execute(select(EntityLinkingReview)).scalars().all()
+            records = [
+                {
+                    "id": r.id,
+                    "article_id": r.article_id,
+                    "stable_entity_id": r.stable_entity_id,
+                    "entity_type": r.entity_type,
+                    "display_name": r.display_name,
+                    "matched_text": r.matched_text,
+                    "confidence": r.confidence,
+                    "supporting_evidence": r.supporting_evidence,
+                    "status": r.status,
+                    "corrected_entity_id": r.corrected_entity_id,
+                    "reviewed_at": r.reviewed_at.isoformat() if r.reviewed_at else None,
+                    "created_at": r.created_at.isoformat() if r.created_at else None,
+                }
+                for r in rows
+            ]
+
+        data = self._envelope(records, "review_queue")
+        path = self._write(data, "review_queue")
+        logger.info("Exported %d review queue items → %s", len(records), path)
+        return ExportResult("review_queue", str(path), len(records), "completed")
+
     def run(self) -> List[ExportResult]:
-        """Run all three exports and return results."""
+        """Run all exports and return results."""
         results = [
             self.export_events(),
             self.export_views(),
             self.export_kpis(),
+            self.export_review_queue(),
         ]
         return results

--- a/apps/data-processing/tests/test_qa_exporter.py
+++ b/apps/data-processing/tests/test_qa_exporter.py
@@ -10,37 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-# ---------------------------------------------------------------------------
-# Stub out heavy dependencies before importing our module
-# ---------------------------------------------------------------------------
-for _mod in [
-    "sqlalchemy",
-    "sqlalchemy.orm",
-    "sqlalchemy.dialects",
-    "sqlalchemy.dialects.postgresql",
-    "src.db",
-    "src.db.models",
-]:
-    if _mod not in sys.modules:
-        sys.modules[_mod] = MagicMock()
-
-# Provide the specific names qa_exporter imports from sqlalchemy
-import sqlalchemy as _sa
-_sa.create_engine = MagicMock()
-_sa.select = MagicMock(return_value=MagicMock())
-_sa.and_ = MagicMock()
-
-import sqlalchemy.orm as _orm
-_orm.sessionmaker = MagicMock()
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
-
-# Stub the db models
-_models_mock = sys.modules["src.db.models"]
-_models_mock.AnalyticsRecord = MagicMock()
-_models_mock.Article = MagicMock()
-_models_mock.AssetTrend = MagicMock()
-_models_mock.SocialPost = MagicMock()
 
 from src.qa_exporter import QAExporter, ExportResult  # noqa: E402
 

--- a/apps/data-processing/tests/test_qa_exporter.py
+++ b/apps/data-processing/tests/test_qa_exporter.py
@@ -225,16 +225,43 @@ class TestExportViews:
 
 
 class TestRunAll:
-    def test_run_returns_three_results(self, tmp_path):
+    def test_run_returns_four_results(self, tmp_path):
         exporter = _make_exporter(tmp_path)
         mock_session = MagicMock()
         mock_session.__enter__ = MagicMock(return_value=mock_session)
         mock_session.__exit__ = MagicMock(return_value=False)
-        # run() calls export_events, export_views (3 queries), export_kpis
+        # run() calls export_events, export_views (3 queries), export_kpis, export_review_queue
         mock_session.execute.return_value.scalars.return_value.all.return_value = []
         exporter.Session = MagicMock(return_value=mock_session)
 
         results = exporter.run()
 
-        assert len(results) == 3
-        assert {r.dataset for r in results} == {"events", "views", "kpis"}
+        assert len(results) == 4
+        assert {r.dataset for r in results} == {"events", "views", "kpis", "review_queue"}
+
+    def test_export_review_queue(self, tmp_path):
+        exporter = _make_exporter(tmp_path)
+        item = MagicMock()
+        item.id = 42
+        item.article_id = "art-1"
+        item.stable_entity_id = "project:7"
+        item.entity_type = "project"
+        item.display_name = "Lumen Devs"
+        item.matched_text = "LumenDevs"
+        item.confidence = 0.85
+        item.supporting_evidence = {"reason": "test"}
+        item.status = "pending"
+        item.corrected_entity_id = None
+        item.reviewed_at = None
+        item.created_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+        _mock_session(exporter, return_value=[item])
+        result = exporter.export_review_queue()
+
+        data = json.loads((tmp_path / "review_queue_1000_2000.json").read_text())
+        assert data["dataset"] == "review_queue"
+        assert len(data["records"]) == 1
+        assert data["records"][0]["id"] == 42
+        assert data["records"][0]["matched_text"] == "LumenDevs"
+        assert result.status == "completed"
+

--- a/apps/data-processing/tests/test_review_queue.py
+++ b/apps/data-processing/tests/test_review_queue.py
@@ -1,0 +1,169 @@
+"""Tests for the human-in-the-loop review queue for low-confidence entity linking."""
+
+from datetime import datetime
+from unittest.mock import patch
+import pytest
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.analytics.ner_service import NERService
+from src.db.models import Base, EntityLinkingReview
+from src.db.postgres_service import PostgresService
+
+
+def build_sqlite_service() -> PostgresService:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+
+    service = PostgresService.__new__(PostgresService)
+    service.database_url = "sqlite:///:memory:"
+    service.engine = engine
+    service.SessionLocal = sessionmaker(
+        autocommit=False,
+        autoflush=False,
+        expire_on_commit=False,
+        bind=engine,
+    )
+    service.ner_service = NERService()
+    return service
+
+
+def test_review_queue_routing_and_non_blocking() -> None:
+    service = build_sqlite_service()
+
+    # Save a project view so we have candidate display name and aliases
+    service.save_project_view(
+        project_id=400,
+        contract_id="CBQPROJECT400",
+        status="active",
+        extra_data={
+            "name": "Soroban Devs",
+            "aliases": ["SorobanDevsAlias"],  # Alias match will yield 0.85 (low confidence)
+            "asset_code": "SRB",
+        },
+    )
+
+    # 1. Routing to review queue when alias is matched (low confidence < 0.90)
+    article = service.save_article(
+        {
+            "id": "art-100",
+            "title": "Article mentioning SorobanDevsAlias here",
+            "content": "This is a detailed content explaining SorobanDevsAlias contributions.",
+            "source": "test-source",
+            "published_at": datetime.utcnow(),
+        }
+    )
+
+    assert article is not None
+
+    # Retrieve queue items
+    queue_items = service.get_review_queue()
+    assert len(queue_items) == 1
+    item = queue_items[0]
+    assert item.article_id == "art-100"
+    assert item.stable_entity_id == "project:400"
+    assert item.confidence == 0.85
+    assert item.status == "pending"
+    assert item.supporting_evidence is not None
+    assert "SorobanDevsAlias" in item.supporting_evidence["matched_text"]
+    assert "context_snippet" in item.supporting_evidence
+
+    # 2. Pipeline remains non-blocking on database failure in review queue logging
+    # We patch _sync_article_onchain_links to mock database execute failure inside it
+    original_sync = service._sync_article_onchain_links
+    def failing_sync(session, article, links):
+        original_execute = session.execute
+        def failing_execute(statement, *args, **kwargs):
+            if "entity_linking_review_queue" in str(statement):
+                raise Exception("Database Connection Loss")
+            return original_execute(statement, *args, **kwargs)
+        session.execute = failing_execute
+        original_sync(session, article, links)
+
+    with patch.object(service, "_sync_article_onchain_links", side_effect=failing_sync):
+        article_non_blocking = service.save_article(
+            {
+                "id": "art-101",
+                "title": "Another article mentioning SorobanDevsAlias",
+                "content": "Content.",
+                "source": "test-source",
+                "published_at": datetime.utcnow(),
+            }
+        )
+        # Ingestion should still succeed despite the review queue logging exception
+        assert article_non_blocking is not None
+        assert article_non_blocking.article_id == "art-101"
+
+
+def test_reviewed_outcomes_overrides() -> None:
+    service = build_sqlite_service()
+
+    # Save multiple candidates to allow correction testing
+    service.save_project_view(
+        project_id=400,
+        contract_id="CBQPROJECT400",
+        status="active",
+        extra_data={
+            "name": "Soroban Devs",
+            "aliases": ["SorobanDevsAlias"],
+            "asset_code": "SRB",
+        },
+    )
+    service.save_project_view(
+        project_id=500,
+        contract_id="CBQPROJECT500",
+        status="active",
+        extra_data={
+            "name": "Other Project",
+            "aliases": ["OtherProjectAlias"],
+            "asset_code": "OTH",
+        },
+    )
+
+    # Ingest an article to trigger the low confidence queue item
+    service.save_article(
+        {
+            "id": "art-200",
+            "title": "Article mentioning SorobanDevsAlias here",
+            "content": "Content.",
+            "source": "test-source",
+            "published_at": datetime.utcnow(),
+        }
+    )
+
+    queue = service.get_review_queue()
+    assert len(queue) == 1
+    item = queue[0]
+
+    # A. Test Approve Outcome
+    success = service.update_review_status(review_id=item.id, status="approved")
+    assert success is True
+
+    # Re-fetch article links to verify the override was applied
+    links = service.get_article_onchain_links(article_id="art-200")
+    assert len(links) == 1
+    assert links[0].stable_entity_id == "project:400"
+    assert links[0].confidence == 1.0  # Boosted to 1.0 because it's human approved
+
+    # B. Test Correct Outcome
+    success = service.update_review_status(review_id=item.id, status="corrected", corrected_entity_id="project:500")
+    assert success is True
+
+    links = service.get_article_onchain_links(article_id="art-200")
+    assert len(links) == 1
+    assert links[0].stable_entity_id == "project:500"  # Corrected to project 500
+    assert links[0].confidence == 1.0  # Boosted to 1.0
+
+    # C. Test Reject Outcome
+    success = service.update_review_status(review_id=item.id, status="rejected")
+    assert success is True
+
+    links = service.get_article_onchain_links(article_id="art-200")
+    assert len(links) == 0  # Link was rejected, so it is suppressed
+
+    # Retrieve all reviewed outcomes for feedback loop/downstream tuning
+    outcomes = service.get_reviewed_outcomes()
+    assert len(outcomes) == 1
+    assert outcomes[0]["status"] == "rejected"
+    assert outcomes[0]["article_id"] == "art-200"


### PR DESCRIPTION
Closes #1064 

# Pull Request: Implement Human-in-the-Loop Review Queue for Low-Confidence Entity Linking

## Issue
Closes the issue: Export low-confidence entity linking and attribution cases into a reviewable queue.

## Description
This PR implements a robust, non-blocking, human-in-the-loop review queue for low-confidence entity linking and attribution. It enables operators to review, approve, reject, or correct low-confidence matches, feeding the resolved outcomes back into the deterministic linking pipeline as overrides.

## Changes Made

### 1. Database Schema & Models (`src/db/models.py`, `src/db/__init__.py`)
- Added `EntityLinkingReview` model (`entity_linking_review_queue` table) to persist low-confidence items with supporting evidence (such as context snippets and the rationale behind the classification).
- Added unique indexes on `(article_id, stable_entity_id)` to prevent duplicate reviews for the same entity match on an article.
- Exported the new model from the `src/db` package.

### 2. Schema Migrations (`alembic/versions/006_add_entity_linking_review_queue.py`)
- Created migration version `006` to create the `entity_linking_review_queue` table, setting up indexes for `article_id`, `stable_entity_id`, `entity_type`, and `status`.

### 3. Pipeline Logging & Feedback Overrides (`src/db/postgres_service.py`, `src/analytics/onchain_entity_linker.py`)
- Added `_upsert_review_queue_items` in `postgres_service.py` to identify low-confidence links (`confidence < 0.90`) and insert them into the review queue. All review queue database actions are wrapped in catch-all error handling blocks to guarantee the live ingestion pipeline remains non-blocking on database errors.
- Enhanced `OnchainEntityLinker` to load and respect review status overrides (`approved`, `rejected`, `corrected`) to dynamically update linking behavior. Suppressed rejected matches, redirected corrected matches, and boosted approved matches to `1.0` confidence.
- Added public methods: `get_review_queue`, `update_review_status` (which immediately re-links the article with updated overrides), and `get_reviewed_outcomes`.

### 4. FastAPI Routes & API Exporter (`src/api/review_queue_routes.py`, `src/api/server.py`, `src/qa_exporter.py`)
- Created FastAPI endpoints to list the queue, update the status of review items, and fetch reviewed outcomes for pipeline tuning.
- Registered the new router prefix `/api/review-queue` in `src/api/server.py`.
- Integrated review queue exports into `QAExporter` so QA engineers can dump the review queue to structured JSON logs.

---

## Acceptance Criteria Met

* **Low-confidence cases exported with supporting evidence**: Matches under `0.90` confidence are logged to the queue along with article context snippets and match reason.
* **Queue output structured for manual review**: Exposed via the API (`GET /api/review-queue` and `GET /api/review-queue/export`) in a clean JSON format.
* **Reviewed outcomes feed future workflows**: Resolved outcomes act as override rules, automatically loaded by the linker to adjust downstream linking logic, and exposed via `GET /api/review-queue/outcomes`.
* **Pipeline remains non-blocking for noncritical uncertainty**: Ingestion runs seamlessly even if review queue logging encounters database issues.

---

## Verification & Testing

Created a dedicated test suite `tests/test_review_queue.py` to assert correct behavior of all criteria. All unit and integration tests passed:

```bash
python -m pytest tests/test_review_queue.py tests/test_onchain_entity_linker.py tests/test_onchain_entity_persistence.py tests/test_qa_exporter.py -v