### PR TITLE
Add cohort analysis datasets, models, and migration

### DIFF
--- a/apps/data-processing/COHORT_ANALYSIS_DATASETS.md
+++ b/apps/data-processing/COHORT_ANALYSIS_DATASETS.md
@@ -1,0 +1,492 @@
+# Cohort Analysis Datasets Documentation
+
+This document describes the cohort analysis datasets for grant round contributor tracking, repeat participation patterns, and round-to-round retention analysis.
+
+## Overview
+
+The cohort analysis system provides datasets that enable:
+- **Repeat contributor identification** across grant rounds
+- **Time-windowed cohort summaries** for temporal analysis
+- **Round-to-round retention patterns** for understanding contributor loyalty
+- **Contributor classification** (one-time, repeat, super contributors)
+
+## Dataset Schema
+
+### 1. GrantRound (`grant_rounds`)
+
+Stores metadata for quadratic funding grant rounds.
+
+**Columns:**
+- `id` (BigInteger, PK): Round ID from chain
+- `name` (String): Round name
+- `description` (String): Round description
+- `start_time` (DateTime): Round start timestamp
+- `end_time` (DateTime): Round end timestamp
+- `total_pool` (Float): Total funding pool
+- `total_contributions` (Float): Total contributions received
+- `unique_contributors` (Integer): Number of unique contributors
+- `unique_projects` (Integer): Number of unique projects
+- `status` (String): Round status (active, completed, cancelled)
+- `extra_data` (JSON): Additional metadata
+- `created_at` (DateTime): Record creation timestamp
+- `updated_at` (DateTime): Record update timestamp
+
+**Indexes:**
+- `idx_grant_rounds_start_time`
+- `idx_grant_rounds_end_time`
+- `idx_grant_rounds_status`
+
+**Usage:**
+```python
+# Query active rounds
+SELECT * FROM grant_rounds WHERE status = 'active';
+
+# Get rounds in a time range
+SELECT * FROM grant_rounds 
+WHERE start_time >= '2026-01-01' AND end_time <= '2026-12-31';
+```
+
+---
+
+### 2. ContributorRoundParticipation (`contributor_round_participation`)
+
+Tracks individual contributor participation in each round.
+
+**Columns:**
+- `id` (Integer, PK): Auto-increment ID
+- `round_id` (BigInteger, FK): Grant round ID
+- `contributor` (String): Contributor wallet address
+- `total_contributed` (Float): Total amount contributed by this contributor in the round
+- `projects_supported` (Integer): Number of projects supported
+- `contribution_count` (Integer): Number of contribution transactions
+- `first_contribution_at` (DateTime): First contribution timestamp in round
+- `last_contribution_at` (DateTime): Last contribution timestamp in round
+- `project_ids` (JSON): Array of project IDs supported
+- `created_at` (DateTime): Record creation timestamp
+- `updated_at` (DateTime): Record update timestamp
+
+**Indexes:**
+- `ux_contributor_round_participation_round_contributor` (unique on round_id, contributor)
+- `idx_contributor_round_participation_contributor`
+- `idx_contributor_round_participation_round_id`
+
+**Usage:**
+```python
+# Get all contributors for a round
+SELECT contributor, total_contributed, projects_supported 
+FROM contributor_round_participation 
+WHERE round_id = 123;
+
+# Get contributor's participation history
+SELECT * FROM contributor_round_participation 
+WHERE contributor = '0x123...' 
+ORDER BY round_id;
+```
+
+---
+
+### 3. ContributorCohort (`contributor_cohorts`)
+
+Stores cohort definitions and summaries for time-windowed analysis.
+
+**Columns:**
+- `id` (Integer, PK): Auto-increment ID
+- `cohort_id` (String, unique): Cohort identifier
+- `cohort_type` (String): Cohort type (first_round, time_window, repeat, super_contributor)
+- `definition_window_start` (DateTime): Cohort definition window start
+- `definition_window_end` (DateTime): Cohort definition window end
+- `member_count` (Integer): Number of cohort members
+- `members` (JSON): Array of contributor addresses
+- `total_contributed` (Float): Total contributions by cohort members
+- `avg_contributed_per_member` (Float): Average contribution per member
+- `created_at` (DateTime): Record creation timestamp
+- `updated_at` (DateTime): Record update timestamp
+
+**Indexes:**
+- `idx_contributor_cohorts_type`
+- `idx_contributor_cohorts_cohort_id`
+- `idx_contributor_cohorts_window`
+
+**Usage:**
+```python
+# Get all first-round cohorts
+SELECT * FROM contributor_cohorts 
+WHERE cohort_type = 'first_round';
+
+# Get cohorts defined in a time window
+SELECT * FROM contributor_cohorts 
+WHERE definition_window_start >= '2026-01-01' 
+AND definition_window_end <= '2026-03-31';
+```
+
+---
+
+### 4. CohortRetentionSummary (`cohort_retention_summaries`)
+
+Stores retention metrics for cohorts across subsequent rounds.
+
+**Columns:**
+- `id` (Integer, PK): Auto-increment ID
+- `cohort_id` (String, FK): Cohort identifier
+- `round_id` (BigInteger, FK): Grant round ID
+- `cohort_size` (Integer): Original cohort size
+- `retained_contributors` (Integer): Number of cohort members who participated
+- `retention_rate` (Float): Retention rate (0.0 - 1.0)
+- `retained_total_contributed` (Float): Total contributions by retained contributors
+- `avg_retained_contribution` (Float): Average contribution by retained contributors
+- `new_contributors` (Integer): Number of new contributors (not in cohort)
+- `calculated_at` (DateTime): When retention was calculated
+- `created_at` (DateTime): Record creation timestamp
+
+**Indexes:**
+- `ux_cohort_retention_cohort_round` (unique on cohort_id, round_id)
+- `idx_cohort_retention_cohort_id`
+- `idx_cohort_retention_round_id`
+- `idx_cohort_retention_calculated_at`
+
+**Usage:**
+```python
+# Get retention timeline for a cohort
+SELECT round_id, cohort_size, retained_contributors, retention_rate 
+FROM cohort_retention_summaries 
+WHERE cohort_id = 'first_round_123' 
+ORDER BY round_id;
+
+# Get retention rates for a specific round across all cohorts
+SELECT cohort_id, retention_rate 
+FROM cohort_retention_summaries 
+WHERE round_id = 456;
+```
+
+---
+
+### 5. RepeatContributorSummary (`repeat_contributor_summaries`)
+
+Stores aggregated metrics for repeat contributors across rounds.
+
+**Columns:**
+- `id` (Integer, PK): Auto-increment ID
+- `contributor` (String, unique): Contributor wallet address
+- `rounds_participated` (Integer): Number of rounds participated
+- `first_round_id` (BigInteger): First round participated
+- `last_round_id` (BigInteger): Last round participated
+- `total_contributed_all_rounds` (Float): Total contributions across all rounds
+- `avg_contributed_per_round` (Float): Average contribution per round
+- `total_projects_supported` (Integer): Total projects supported (counting duplicates)
+- `unique_projects_supported` (Integer): Unique projects supported
+- `contributor_type` (String): Classification (one_time, repeat, super_contributor)
+- `round_ids` (JSON): Array of round IDs participated
+- `first_contribution_at` (DateTime): First contribution timestamp
+- `last_contribution_at` (DateTime): Last contribution timestamp
+- `calculated_at` (DateTime): When metrics were calculated
+- `created_at` (DateTime): Record creation timestamp
+- `updated_at` (DateTime): Record update timestamp
+
+**Indexes:**
+- `idx_repeat_contributor_contributor` (unique)
+- `idx_repeat_contributor_type`
+- `idx_repeat_contributor_rounds`
+- `idx_repeat_contributor_calculated_at`
+
+**Usage:**
+```python
+# Get all super contributors
+SELECT * FROM repeat_contributor_summaries 
+WHERE contributor_type = 'super_contributor';
+
+# Get contributors who participated in 5+ rounds
+SELECT * FROM repeat_contributor_summaries 
+WHERE rounds_participated >= 5 
+ORDER BY total_contributed_all_rounds DESC;
+
+# Get contributor classification breakdown
+SELECT contributor_type, COUNT(*) as count, 
+AVG(total_contributed_all_rounds) as avg_total
+FROM repeat_contributor_summaries 
+GROUP BY contributor_type;
+```
+
+---
+
+## API Usage
+
+### Initialization
+
+```python
+from src.analytics.cohort_analyzer import CohortAnalyzer, create_cohort_analyzer
+from src.db.postgres_service import PostgresService
+
+# Initialize with default database service
+analyzer = create_cohort_analyzer()
+
+# Or with custom database service
+db_service = PostgresService(database_url="postgresql://...")
+analyzer = CohortAnalyzer(db_service=db_service)
+```
+
+### Track Round Participation
+
+```python
+# Track contributions for a round
+contributions = [
+    {
+        "contributor": "0x123...",
+        "amount": 100.0,
+        "project_id": 1,
+        "timestamp": datetime(2026, 1, 15, 10, 30)
+    },
+    # ... more contributions
+]
+
+saved_count = analyzer.track_round_participation(
+    round_id=123,
+    contributions=contributions
+)
+print(f"Saved {saved_count} participation records")
+```
+
+### Create First-Round Cohort
+
+```python
+# Create cohort of contributors who first participated in round 123
+cohort_metrics = analyzer.create_first_round_cohort(round_id=123)
+
+print(f"Cohort {cohort_metrics.chort_id} has {cohort_metrics.member_count} members")
+print(f"Total contributed: ${cohort_metrics.total_contributed}")
+```
+
+### Calculate Retention
+
+```python
+# Calculate retention for a cohort in a subsequent round
+retention_metrics = analyzer.calculate_retention(
+    cohort_id="first_round_123",
+    round_id=124
+)
+
+print(f"Retention rate: {retention_metrics.retention_rate:.1%}")
+print(f"Retained contributors: {retention_metrics.retained_contributors}/{retention_metrics.cohort_size}")
+```
+
+### Analyze Repeat Contributors
+
+```python
+# Analyze all repeat contributors (2+ rounds)
+repeat_contributors = analyzer.analyze_repeat_contributors(min_rounds=2)
+
+for contributor in repeat_contributors:
+    print(f"{contributor.contributor}: {contributor.rounds_participated} rounds, "
+          f"${contributor.total_contributed_all_rounds:.2f} total, "
+          f"type={contributor.contributor_type.value}")
+```
+
+### Create Time-Window Cohort
+
+```python
+# Create cohort for Q1 2026
+from datetime import datetime
+
+cohort_metrics = analyzer.create_time_window_cohort(
+    window_start=datetime(2026, 1, 1),
+    window_end=datetime(2026, 3, 31)
+)
+
+print(f"Q1 2026 cohort has {cohort_metrics.member_count} members")
+```
+
+### Get Retention Timeline
+
+```python
+# Get full retention timeline for a cohort
+timeline = analyzer.get_cohort_retention_timeline(cohort_id="first_round_123")
+
+for data in timeline:
+    print(f"Round {data['round_id']}: {data['retention_rate']:.1%} retention")
+```
+
+---
+
+## Dataset Definitions for Contributors
+
+### Cohort Types
+
+- **first_round**: Contributors who made their first contribution in a specific round
+- **time_window**: Contributors who participated within a defined time window
+- **repeat**: Contributors who participated in multiple rounds (2-5 rounds)
+- **super_contributor**: High-value contributors (6+ rounds or >$10,000 total)
+
+### Contributor Types
+
+- **one_time**: Participated in only one round
+- **repeat**: Participated in 2-5 rounds
+- **super_contributor**: Participated in 6+ rounds or contributed >$10,000 total
+
+### Retention Rate Calculation
+
+```
+retention_rate = retained_contributors / cohort_size
+```
+
+Where:
+- `retained_contributors`: Number of cohort members who participated in the target round
+- `cohort_size`: Original cohort size at definition time
+
+### Classification Thresholds
+
+Current thresholds (configurable in code):
+- **Super contributor**: 6+ rounds OR >$10,000 total contributions
+- **Repeat contributor**: 2-5 rounds
+- **One-time contributor**: 1 round
+
+---
+
+## Output Format for Backend/Dashboard Consumption
+
+### Cohort Metrics Response
+
+```json
+{
+  "cohort_id": "first_round_123",
+  "member_count": 150,
+  "members": ["0x123...", "0x456..."],
+  "total_contributed": 50000.0,
+  "avg_contributed_per_member": 333.33
+}
+```
+
+### Retention Metrics Response
+
+```json
+{
+  "cohort_id": "first_round_123",
+  "round_id": 124,
+  "cohort_size": 150,
+  "retained_contributors": 90,
+  "retention_rate": 0.6,
+  "retained_total_contributed": 30000.0,
+  "avg_retained_contribution": 333.33,
+  "new_contributors": 50
+}
+```
+
+### Repeat Contributor Metrics Response
+
+```json
+{
+  "contributor": "0x123...",
+  "rounds_participated": 5,
+  "first_round_id": 120,
+  "last_round_id": 124,
+  "total_contributed_all_rounds": 2500.0,
+  "avg_contributed_per_round": 500.0,
+  "total_projects_supported": 15,
+  "unique_projects_supported": 12,
+  "contributor_type": "repeat",
+  "round_ids": [120, 121, 122, 123, 124],
+  "first_contribution_at": "2026-01-15T10:30:00Z",
+  "last_contribution_at": "2026-06-20T14:45:00Z"
+}
+```
+
+### Retention Timeline Response
+
+```json
+[
+  {
+    "round_id": 124,
+    "cohort_size": 150,
+    "retained_contributors": 90,
+    "retention_rate": 0.6,
+    "retained_total_contributed": 30000.0,
+    "avg_retained_contribution": 333.33,
+    "new_contributors": 50,
+    "calculated_at": "2026-07-23T12:00:00Z"
+  },
+  {
+    "round_id": 125,
+    "cohort_size": 150,
+    "retained_contributors": 75,
+    "retention_rate": 0.5,
+    "retained_total_contributed": 25000.0,
+    "avg_retained_contribution": 333.33,
+    "new_contributors": 60,
+    "calculated_at": "2026-07-23T12:00:00Z"
+  }
+]
+```
+
+---
+
+## Database Migration
+
+To create the cohort analysis tables, run the migration:
+
+```bash
+cd apps/data-processing
+alembic upgrade head
+```
+
+Or to upgrade to a specific revision:
+
+```bash
+alembic upgrade 006_add_cohort_analysis_tables
+```
+
+---
+
+## Integration with Existing Data
+
+The cohort analysis system integrates with existing tables:
+
+- **ProjectContributor**: Used to extract contribution data for round participation tracking
+- **ProjectView**: Used to get project information for cohort analysis
+- **ContractEvent**: Can be used as source data for contribution tracking
+
+---
+
+## Performance Considerations
+
+1. **Indexes**: All tables have appropriate indexes for common query patterns
+2. **Batch operations**: Use batch operations when tracking large numbers of contributions
+3. **Caching**: Consider caching cohort metrics for frequently accessed cohorts
+4. **Partitioning**: For large deployments, consider partitioning by round_id or time ranges
+
+---
+
+## Maintenance
+
+### Recalculating Metrics
+
+To force recalculation of repeat contributor metrics:
+
+```python
+analyzer.analyze_repeat_contributors(min_rounds=2, recalculate=True)
+```
+
+### Cleaning Old Data
+
+To remove old cohort data (use with caution):
+
+```sql
+DELETE FROM cohort_retention_summaries WHERE calculated_at < '2025-01-01';
+DELETE FROM contributor_cohorts WHERE created_at < '2025-01-01';
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Cohort not found**: Ensure the cohort was created before calculating retention
+2. **No rounds in time window**: Verify that grant rounds exist in the specified time range
+3. **Empty participation data**: Check that contribution data is being tracked properly
+
+### Logging
+
+The cohort analyzer uses Python logging. Enable debug logging for detailed operation traces:
+
+```python
+import logging
+logging.getLogger('src.analytics.cohort_analyzer').setLevel(logging.DEBUG)
+```

--- a/apps/data-processing/alembic/versions/006_add_cohort_analysis_tables.py
+++ b/apps/data-processing/alembic/versions/006_add_cohort_analysis_tables.py
@@ -1,0 +1,137 @@
+"""Add cohort analysis tables for grant round contributor tracking
+
+Revision ID: 006_add_cohort_analysis_tables
+Revises: 005_add_project_contributor_reputation_snapshot
+Create Date: 2026-07-23
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '006_add_cohort_analysis_tables'
+down_revision = '005_add_project_contributor_reputation_snapshot'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Create grant_rounds table
+    op.create_table(
+        'grant_rounds',
+        sa.Column('id', sa.BigInteger(), autoincrement=False, nullable=False),
+        sa.Column('name', sa.String(length=255), nullable=True),
+        sa.Column('description', sa.String(length=1000), nullable=True),
+        sa.Column('start_time', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('end_time', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('total_pool', sa.Float(), nullable=True),
+        sa.Column('total_contributions', sa.Float(), nullable=True),
+        sa.Column('unique_contributors', sa.Integer(), nullable=True),
+        sa.Column('unique_projects', sa.Integer(), nullable=True),
+        sa.Column('status', sa.String(length=50), nullable=False, server_default='active'),
+        sa.Column('extra_data', postgresql.JSON(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index('idx_grant_rounds_start_time', 'grant_rounds', ['start_time'])
+    op.create_index('idx_grant_rounds_end_time', 'grant_rounds', ['end_time'])
+    op.create_index('idx_grant_rounds_status', 'grant_rounds', ['status'])
+
+    # Create contributor_round_participation table
+    op.create_table(
+        'contributor_round_participation',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('round_id', sa.BigInteger(), nullable=False),
+        sa.Column('contributor', sa.String(length=255), nullable=False),
+        sa.Column('total_contributed', sa.Float(), nullable=False, server_default='0'),
+        sa.Column('projects_supported', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('contribution_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('first_contribution_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('last_contribution_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('project_ids', postgresql.JSON(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('round_id', 'contributor', name='ux_contributor_round_participation_round_contributor')
+    )
+    op.create_index('idx_contributor_round_participation_contributor', 'contributor_round_participation', ['contributor'])
+    op.create_index('idx_contributor_round_participation_round_id', 'contributor_round_participation', ['round_id'])
+
+    # Create contributor_cohorts table
+    op.create_table(
+        'contributor_cohorts',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('cohort_id', sa.String(length=255), nullable=False),
+        sa.Column('cohort_type', sa.String(length=50), nullable=False),
+        sa.Column('definition_window_start', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('definition_window_end', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('member_count', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('members', postgresql.JSON(), nullable=True),
+        sa.Column('total_contributed', sa.Float(), nullable=True),
+        sa.Column('avg_contributed_per_member', sa.Float(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('cohort_id')
+    )
+    op.create_index('idx_contributor_cohorts_type', 'contributor_cohorts', ['cohort_type'])
+    op.create_index('idx_contributor_cohorts_cohort_id', 'contributor_cohorts', ['cohort_id'])
+    op.create_index('idx_contributor_cohorts_window', 'contributor_cohorts', ['definition_window_start', 'definition_window_end'])
+
+    # Create cohort_retention_summaries table
+    op.create_table(
+        'cohort_retention_summaries',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('cohort_id', sa.String(length=255), nullable=False),
+        sa.Column('round_id', sa.BigInteger(), nullable=False),
+        sa.Column('cohort_size', sa.Integer(), nullable=False),
+        sa.Column('retained_contributors', sa.Integer(), nullable=False),
+        sa.Column('retention_rate', sa.Float(), nullable=False),
+        sa.Column('retained_total_contributed', sa.Float(), nullable=True),
+        sa.Column('avg_retained_contribution', sa.Float(), nullable=True),
+        sa.Column('new_contributors', sa.Integer(), nullable=True),
+        sa.Column('calculated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('cohort_id', 'round_id', name='ux_cohort_retention_cohort_round')
+    )
+    op.create_index('idx_cohort_retention_cohort_id', 'cohort_retention_summaries', ['cohort_id'])
+    op.create_index('idx_cohort_retention_round_id', 'cohort_retention_summaries', ['round_id'])
+    op.create_index('idx_cohort_retention_calculated_at', 'cohort_retention_summaries', ['calculated_at'])
+
+    # Create repeat_contributor_summaries table
+    op.create_table(
+        'repeat_contributor_summaries',
+        sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column('contributor', sa.String(length=255), nullable=False),
+        sa.Column('rounds_participated', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('first_round_id', sa.BigInteger(), nullable=True),
+        sa.Column('last_round_id', sa.BigInteger(), nullable=True),
+        sa.Column('total_contributed_all_rounds', sa.Float(), nullable=False, server_default='0'),
+        sa.Column('avg_contributed_per_round', sa.Float(), nullable=True),
+        sa.Column('total_projects_supported', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('unique_projects_supported', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('contributor_type', sa.String(length=50), nullable=True),
+        sa.Column('round_ids', postgresql.JSON(), nullable=True),
+        sa.Column('first_contribution_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('last_contribution_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('calculated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('contributor')
+    )
+    op.create_index('idx_repeat_contributor_contributor', 'repeat_contributor_summaries', ['contributor'])
+    op.create_index('idx_repeat_contributor_type', 'repeat_contributor_summaries', ['contributor_type'])
+    op.create_index('idx_repeat_contributor_rounds', 'repeat_contributor_summaries', ['rounds_participated'])
+    op.create_index('idx_repeat_contributor_calculated_at', 'repeat_contributor_summaries', ['calculated_at'])
+
+
+def downgrade():
+    op.drop_table('repeat_contributor_summaries')
+    op.drop_table('cohort_retention_summaries')
+    op.drop_table('contributor_cohorts')
+    op.drop_table('contributor_round_participation')
+    op.drop_table('grant_rounds')

--- a/apps/data-processing/examples/cohort_analysis_example.py
+++ b/apps/data-processing/examples/cohort_analysis_example.py
@@ -1,0 +1,233 @@
+"""
+Example: Cohort Analysis Dataset Generation and Validation
+
+This script demonstrates how to use the cohort analysis system to:
+1. Track contributor participation across grant rounds
+2. Create cohorts based on first participation or time windows
+3. Calculate retention metrics for cohorts
+4. Analyze repeat contributors
+5. Validate output formats for backend/dashboard consumption
+"""
+
+import sys
+import os
+from pathlib import Path
+
+# Add parent directory to path to enable imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from datetime import datetime, timedelta
+from src.analytics.cohort_analyzer import (
+    CohortAnalyzer,
+    create_cohort_analyzer,
+    CohortType,
+    ContributorType,
+)
+from src.db.postgres_service import PostgresService
+import json
+
+
+def print_section(title: str):
+    """Print a formatted section header"""
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print(f"{'=' * 60}\n")
+
+
+def validate_output_format(data: dict, required_fields: list, context: str) -> bool:
+    """
+    Validate that output data contains required fields for backend/dashboard consumption.
+    
+    Args:
+        data: Dictionary to validate
+        required_fields: List of required field names
+        context: Description of what is being validated
+        
+    Returns:
+        True if validation passes, False otherwise
+    """
+    missing_fields = [field for field in required_fields if field not in data]
+    
+    if missing_fields:
+        print(f"❌ Validation failed for {context}")
+        print(f"   Missing fields: {missing_fields}")
+        return False
+    
+    print(f"✅ Validation passed for {context}")
+    return True
+
+
+def main():
+    """Main example execution"""
+    print_section("Cohort Analysis Dataset Example")
+    
+    # Initialize analyzer
+    print("Initializing cohort analyzer...")
+    analyzer = create_cohort_analyzer()
+    print("✅ Analyzer initialized\n")
+    
+    # Sample contribution data
+    print("Creating sample contribution data...")
+    sample_contributions = {
+        1: [  # Round 1
+            {"contributor": "0xAAA1111111111111111111111111111111111111", "amount": 100.0, "project_id": 1, "timestamp": datetime(2026, 1, 5, 10, 30)},
+            {"contributor": "0xAAA1111111111111111111111111111111111111", "amount": 50.0, "project_id": 2, "timestamp": datetime(2026, 1, 10, 14, 20)},
+            {"contributor": "0xBBB2222222222222222222222222222222222222", "amount": 200.0, "project_id": 1, "timestamp": datetime(2026, 1, 7, 9, 15)},
+            {"contributor": "0xCCC3333333333333333333333333333333333333", "amount": 150.0, "project_id": 3, "timestamp": datetime(2026, 1, 15, 16, 45)},
+            {"contributor": "0xDDD4444444444444444444444444444444444444", "amount": 75.0, "project_id": 2, "timestamp": datetime(2026, 1, 20, 11, 0)},
+        ],
+        2: [  # Round 2
+            {"contributor": "0xAAA1111111111111111111111111111111111111", "amount": 120.0, "project_id": 1, "timestamp": datetime(2026, 2, 5, 10, 30)},
+            {"contributor": "0xBBB2222222222222222222222222222222222222", "amount": 180.0, "project_id": 4, "timestamp": datetime(2026, 2, 8, 9, 15)},
+            {"contributor": "0xEEE5555555555555555555555555555555555555", "amount": 250.0, "project_id": 1, "timestamp": datetime(2026, 2, 12, 14, 20)},
+            {"contributor": "0xFFF6666666666666666666666666666666666666", "amount": 100.0, "project_id": 5, "timestamp": datetime(2026, 2, 18, 16, 45)},
+        ],
+        3: [  # Round 3
+            {"contributor": "0xAAA1111111111111111111111111111111111111", "amount": 80.0, "project_id": 2, "timestamp": datetime(2026, 3, 5, 10, 30)},
+            {"contributor": "0xCCC3333333333333333333333333333333333333", "amount": 200.0, "project_id": 3, "timestamp": datetime(2026, 3, 10, 9, 15)},
+            {"contributor": "0xEEE5555555555555555555555555555555555555", "amount": 150.0, "project_id": 4, "timestamp": datetime(2026, 3, 15, 14, 20)},
+        ],
+    }
+    print(f"✅ Created sample data for {len(sample_contributions)} rounds\n")
+    
+    # Track round participation
+    print_section("1. Tracking Round Participation")
+    
+    for round_id, contributions in sample_contributions.items():
+        saved_count = analyzer.track_round_participation(round_id=round_id, contributions=contributions)
+        print(f"Round {round_id}: Saved {saved_count} participation records")
+    
+    # Create first-round cohort
+    print_section("2. Creating First-Round Cohort")
+    
+    cohort_metrics = analyzer.create_first_round_cohort(round_id=1)
+    cohort_dict = cohort_metrics.to_dict()
+    
+    print(f"Cohort ID: {cohort_dict['cohort_id']}")
+    print(f"Member Count: {cohort_dict['member_count']}")
+    print(f"Total Contributed: ${cohort_dict['total_contributed']:.2f}")
+    print(f"Average per Member: ${cohort_dict['avg_contributed_per_member']:.2f}")
+    
+    # Validate output format
+    required_cohort_fields = [
+        "cohort_id", "member_count", "members", 
+        "total_contributed", "avg_contributed_per_member"
+    ]
+    validate_output_format(cohort_dict, required_cohort_fields, "Cohort Metrics")
+    
+    print(f"\nFull JSON output:")
+    print(json.dumps(cohort_dict, indent=2, default=str))
+    
+    # Calculate retention
+    print_section("3. Calculating Retention Metrics")
+    
+    retention_metrics = analyzer.calculate_retention(
+        cohort_id="first_round_1",
+        round_id=2
+    )
+    retention_dict = retention_metrics.to_dict()
+    
+    print(f"Cohort ID: {retention_dict['cohort_id']}")
+    print(f"Round ID: {retention_dict['round_id']}")
+    print(f"Cohort Size: {retention_dict['cohort_size']}")
+    print(f"Retained Contributors: {retention_dict['retained_contributors']}")
+    print(f"Retention Rate: {retention_dict['retention_rate']:.1%}")
+    print(f"New Contributors: {retention_dict['new_contributors']}")
+    
+    # Validate output format
+    required_retention_fields = [
+        "cohort_id", "round_id", "cohort_size", "retained_contributors",
+        "retention_rate", "retained_total_contributed", 
+        "avg_retained_contribution", "new_contributors"
+    ]
+    validate_output_format(retention_dict, required_retention_fields, "Retention Metrics")
+    
+    print(f"\nFull JSON output:")
+    print(json.dumps(retention_dict, indent=2, default=str))
+    
+    # Analyze repeat contributors
+    print_section("4. Analyzing Repeat Contributors")
+    
+    repeat_contributors = analyzer.analyze_repeat_contributors(min_rounds=2)
+    
+    print(f"Found {len(repeat_contributors)} repeat contributors\n")
+    
+    for i, contributor in enumerate(repeat_contributors[:3], 1):  # Show first 3
+        contributor_dict = contributor.to_dict()
+        print(f"{i}. {contributor_dict['contributor'][:10]}...")
+        print(f"   Rounds Participated: {contributor_dict['rounds_participated']}")
+        print(f"   Total Contributed: ${contributor_dict['total_contributed_all_rounds']:.2f}")
+        print(f"   Type: {contributor_dict['contributor_type']}")
+        
+        # Validate output format
+        required_contributor_fields = [
+            "contributor", "rounds_participated", "first_round_id", "last_round_id",
+            "total_contributed_all_rounds", "avg_contributed_per_round",
+            "total_projects_supported", "unique_projects_supported",
+            "contributor_type", "round_ids"
+        ]
+        validate_output_format(contributor_dict, required_contributor_fields, f"Contributor {i}")
+    
+    if repeat_contributors:
+        print(f"\nFull JSON output for first contributor:")
+        print(json.dumps(repeat_contributors[0].to_dict(), indent=2, default=str))
+    
+    # Create time-window cohort
+    print_section("5. Creating Time-Window Cohort")
+    
+    time_window_cohort = analyzer.create_time_window_cohort(
+        window_start=datetime(2026, 1, 1),
+        window_end=datetime(2026, 3, 31)
+    )
+    
+    print(f"Cohort ID: {time_window_cohort.cohort_id}")
+    print(f"Member Count: {time_window_cohort.member_count}")
+    print(f"Total Contributed: ${time_window_cohort.total_contributed:.2f}")
+    
+    # Get retention timeline
+    print_section("6. Getting Retention Timeline")
+    
+    # Calculate retention for all rounds
+    for round_id in [2, 3]:
+        try:
+            analyzer.calculate_retention(cohort_id="first_round_1", round_id=round_id)
+        except Exception as e:
+            print(f"Note: Could not calculate retention for round {round_id}: {e}")
+    
+    timeline = analyzer.get_cohort_retention_timeline(cohort_id="first_round_1")
+    
+    print(f"Retention timeline for cohort 'first_round_1':\n")
+    
+    for data in timeline:
+        print(f"Round {data['round_id']}:")
+        print(f"  Retention Rate: {data['retention_rate']:.1%}")
+        print(f"  Retained: {data['retained_contributors']}/{data['cohort_size']}")
+        print(f"  New Contributors: {data['new_contributors']}")
+    
+    if timeline:
+        print(f"\nFull JSON timeline:")
+        print(json.dumps(timeline, indent=2, default=str))
+    
+    # Summary
+    print_section("Summary")
+    
+    print("✅ All cohort analysis datasets generated successfully")
+    print("✅ Output formats validated for backend/dashboard consumption")
+    print("\nDataset capabilities demonstrated:")
+    print("  • Round participation tracking")
+    print("  • First-round cohort creation")
+    print("  • Retention rate calculation")
+    print("  • Repeat contributor analysis")
+    print("  • Time-window cohort creation")
+    print("  • Retention timeline generation")
+    print("\nAll outputs are structured as JSON-serializable dictionaries")
+    print("with required fields for backend API and dashboard consumption.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        import traceback
+        traceback.print_exc()

--- a/apps/data-processing/src/analytics/cohort_analyzer.py
+++ b/apps/data-processing/src/analytics/cohort_analyzer.py
@@ -1,0 +1,727 @@
+"""
+Cohort Analyzer - Builds datasets for contributor cohorts, repeat participation, and retention patterns
+"""
+
+from src.utils.logger import setup_logger
+from src.db.postgres_service import PostgresService
+from typing import Dict, Any, List, Optional, Set
+from datetime import datetime, timedelta
+from collections import defaultdict
+from dataclasses import dataclass, field
+from enum import Enum
+import json
+
+logger = setup_logger(__name__)
+
+
+class CohortType(Enum):
+    """Types of cohort definitions"""
+    FIRST_ROUND = "first_round"  # Contributors who first participated in a specific round
+    TIME_WINDOW = "time_window"  # Contributors who participated within a time window
+    REPEAT = "repeat"  # Contributors who participated in multiple rounds
+    SUPER_CONTRIBUTOR = "super_contributor"  # High-value repeat contributors
+
+
+class ContributorType(Enum):
+    """Classification of contributors based on participation patterns"""
+    ONE_TIME = "one_time"  # Participated in only one round
+    REPEAT = "repeat"  # Participated in 2-5 rounds
+    SUPER_CONTRIBUTOR = "super_contributor"  # Participated in 6+ rounds or high total contribution
+
+
+@dataclass
+class CohortDefinition:
+    """Definition of a contributor cohort"""
+    cohort_id: str
+    cohort_type: CohortType
+    window_start: datetime
+    window_end: datetime
+    description: str = ""
+    
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "cohort_id": self.cohort_id,
+            "cohort_type": self.cohort_type.value,
+            "window_start": self.window_start.isoformat(),
+            "window_end": self.window_end.isoformat(),
+            "description": self.description,
+        }
+
+
+@dataclass
+class CohortMetrics:
+    """Aggregated metrics for a cohort"""
+    cohort_id: str
+    member_count: int
+    members: List[str] = field(default_factory=list)
+    total_contributed: float = 0.0
+    avg_contributed_per_member: float = 0.0
+    
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "cohort_id": self.cohort_id,
+            "member_count": self.member_count,
+            "members": self.members,
+            "total_contributed": self.total_contributed,
+            "avg_contributed_per_member": self.avg_contributed_per_member,
+        }
+
+
+@dataclass
+class RetentionMetrics:
+    """Retention metrics for a cohort in a specific round"""
+    cohort_id: str
+    round_id: int
+    cohort_size: int
+    retained_contributors: int
+    retention_rate: float
+    retained_total_contributed: float = 0.0
+    avg_retained_contribution: float = 0.0
+    new_contributors: int = 0
+    
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "cohort_id": self.cohort_id,
+            "round_id": self.round_id,
+            "cohort_size": self.cohort_size,
+            "retained_contributors": self.retained_contributors,
+            "retention_rate": self.retention_rate,
+            "retained_total_contributed": self.retained_total_contributed,
+            "avg_retained_contribution": self.avg_retained_contribution,
+            "new_contributors": self.new_contributors,
+        }
+
+
+@dataclass
+class RepeatContributorMetrics:
+    """Metrics for a repeat contributor"""
+    contributor: str
+    rounds_participated: int
+    first_round_id: Optional[int]
+    last_round_id: Optional[int]
+    total_contributed_all_rounds: float
+    avg_contributed_per_round: float
+    total_projects_supported: int
+    unique_projects_supported: int
+    contributor_type: ContributorType
+    round_ids: List[int] = field(default_factory=list)
+    first_contribution_at: Optional[datetime] = None
+    last_contribution_at: Optional[datetime] = None
+    
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "contributor": self.contributor,
+            "rounds_participated": self.rounds_participated,
+            "first_round_id": self.first_round_id,
+            "last_round_id": self.last_round_id,
+            "total_contributed_all_rounds": self.total_contributed_all_rounds,
+            "avg_contributed_per_round": self.avg_contributed_per_round,
+            "total_projects_supported": self.total_projects_supported,
+            "unique_projects_supported": self.unique_projects_supported,
+            "contributor_type": self.contributor_type.value,
+            "round_ids": self.round_ids,
+            "first_contribution_at": self.first_contribution_at.isoformat() if self.first_contribution_at else None,
+            "last_contribution_at": self.last_contribution_at.isoformat() if self.last_contribution_at else None,
+        }
+
+
+class CohortAnalyzer:
+    """
+    Analyzes contributor cohorts, repeat participation, and retention patterns.
+    
+    Capabilities:
+    - Track contributor participation across grant rounds
+    - Define cohorts based on first participation or time windows
+    - Calculate round-to-round retention rates
+    - Identify and classify repeat contributors
+    - Generate time-windowed cohort summaries
+    """
+    
+    def __init__(self, db_service: Optional[PostgresService] = None):
+        """
+        Initialize the cohort analyzer.
+        
+        Args:
+            db_service: Optional database service instance
+        """
+        self.db_service = db_service or PostgresService()
+        logger.info("CohortAnalyzer initialized")
+    
+    def _classify_contributor(
+        self, 
+        rounds_participated: int, 
+        total_contributed: float
+    ) -> ContributorType:
+        """
+        Classify a contributor based on participation patterns.
+        
+        Args:
+            rounds_participated: Number of rounds participated
+            total_contributed: Total amount contributed across all rounds
+            
+        Returns:
+            ContributorType classification
+        """
+        if rounds_participated == 1:
+            return ContributorType.ONE_TIME
+        elif rounds_participated >= 6 or total_contributed > 10000:  # Threshold configurable
+            return ContributorType.SUPER_CONTRIBUTOR
+        else:
+            return ContributorType.REPEAT
+    
+    def track_round_participation(
+        self, 
+        round_id: int, 
+        contributions: List[Dict[str, Any]]
+    ) -> int:
+        """
+        Track contributor participation for a specific round.
+        
+        Args:
+            round_id: Grant round ID
+            contributions: List of contribution records with:
+                - contributor: contributor address
+                - amount: contribution amount
+                - project_id: project ID
+                - timestamp: contribution timestamp
+                
+        Returns:
+            Number of participation records created/updated
+        """
+        logger.info(f"Tracking participation for round {round_id} with {len(contributions)} contributions")
+        
+        try:
+            from src.db.cohort_models import ContributorRoundParticipation
+            
+            # Aggregate contributions by contributor
+            contributor_data = defaultdict(lambda: {
+                "total_contributed": 0.0,
+                "projects_supported": set(),
+                "contribution_count": 0,
+                "timestamps": []
+            })
+            
+            for contrib in contributions:
+                contributor = contrib.get("contributor")
+                amount = contrib.get("amount", 0.0)
+                project_id = contrib.get("project_id")
+                timestamp = contrib.get("timestamp")
+                
+                if contributor:
+                    contributor_data[contributor]["total_contributed"] += amount
+                    contributor_data[contributor]["contribution_count"] += 1
+                    if project_id:
+                        contributor_data[contributor]["projects_supported"].add(project_id)
+                    if timestamp:
+                        contributor_data[contributor]["timestamps"].append(timestamp)
+            
+            # Save to database
+            saved_count = 0
+            with self.db_service.get_session() as session:
+                for contributor, data in contributor_data.items():
+                    timestamps = sorted(data["timestamps"]) if data["timestamps"] else None
+                    
+                    # Check if record exists
+                    existing = session.execute(
+                        session.query(ContributorRoundParticipation).filter(
+                            ContributorRoundParticipation.round_id == round_id,
+                            ContributorRoundParticipation.contributor == contributor
+                        )
+                    ).scalar_one_or_none()
+                    
+                    if existing:
+                        # Update existing record
+                        existing.total_contributed = data["total_contributed"]
+                        existing.projects_supported = len(data["projects_supported"])
+                        existing.contribution_count = data["contribution_count"]
+                        existing.project_ids = list(data["projects_supported"])
+                        if timestamps:
+                            existing.first_contribution_at = timestamps[0]
+                            existing.last_contribution_at = timestamps[-1]
+                        saved_count += 1
+                    else:
+                        # Create new record
+                        participation = ContributorRoundParticipation(
+                            round_id=round_id,
+                            contributor=contributor,
+                            total_contributed=data["total_contributed"],
+                            projects_supported=len(data["projects_supported"]),
+                            contribution_count=data["contribution_count"],
+                            project_ids=list(data["projects_supported"]),
+                            first_contribution_at=timestamps[0] if timestamps else None,
+                            last_contribution_at=timestamps[-1] if timestamps else None,
+                        )
+                        session.add(participation)
+                        saved_count += 1
+                
+                session.flush()
+            
+            logger.info(f"Saved {saved_count} participation records for round {round_id}")
+            return saved_count
+            
+        except Exception as e:
+            logger.error(f"Failed to track round participation: {e}")
+            return 0
+    
+    def create_first_round_cohort(
+        self, 
+        round_id: int, 
+        cohort_id: Optional[str] = None
+    ) -> CohortMetrics:
+        """
+        Create a cohort of contributors who first participated in a specific round.
+        
+        Args:
+            round_id: Grant round ID
+            cohort_id: Optional custom cohort ID (auto-generated if not provided)
+            
+        Returns:
+            CohortMetrics with cohort information
+        """
+        if cohort_id is None:
+            cohort_id = f"first_round_{round_id}"
+        
+        logger.info(f"Creating first-round cohort for round {round_id}")
+        
+        try:
+            from src.db.cohort_models import ContributorRoundParticipation, ContributorCohort
+            
+            # Get all contributors who participated in this round
+            with self.db_service.get_session() as session:
+                participants = session.execute(
+                    session.query(ContributorRoundParticipation).filter(
+                        ContributorRoundParticipation.round_id == round_id
+                    )
+                ).scalars().all()
+                
+                # Filter for first-time contributors (not in previous rounds)
+                all_previous_rounds = session.execute(
+                    session.query(ContributorRoundParticipation.round_id).filter(
+                        ContributorRoundParticipation.round_id < round_id
+                    ).distinct()
+                ).scalars().all()
+                
+                previous_contributors = set()
+                for prev_round in all_previous_rounds:
+                    prev_participants = session.execute(
+                        session.query(ContributorRoundParticipation.contributor).filter(
+                            ContributorRoundParticipation.round_id == prev_round
+                        )
+                    ).scalars().all()
+                    previous_contributors.update(prev_participants)
+                
+                # Identify first-time contributors
+                first_time_contributors = [
+                    p.contributor for p in participants 
+                    if p.contributor not in previous_contributors
+                ]
+                
+                # Calculate metrics
+                total_contributed = sum(p.total_contributed for p in participants if p.contributor in first_time_contributors)
+                avg_contributed = total_contributed / len(first_time_contributors) if first_time_contributors else 0.0
+                
+                # Save cohort
+                cohort = ContributorCohort(
+                    cohort_id=cohort_id,
+                    cohort_type=CohortType.FIRST_ROUND.value,
+                    definition_window_start=datetime.utcnow() - timedelta(days=30),
+                    definition_window_end=datetime.utcnow(),
+                    member_count=len(first_time_contributors),
+                    members=first_time_contributors,
+                    total_contributed=total_contributed,
+                    avg_contributed_per_member=avg_contributed,
+                )
+                session.add(cohort)
+                session.flush()
+                
+                logger.info(f"Created cohort {cohort_id} with {len(first_time_contributors)} members")
+                
+                return CohortMetrics(
+                    cohort_id=cohort_id,
+                    member_count=len(first_time_contributors),
+                    members=first_time_contributors,
+                    total_contributed=total_contributed,
+                    avg_contributed_per_member=avg_contributed,
+                )
+                
+        except Exception as e:
+            logger.error(f"Failed to create first-round cohort: {e}")
+            raise
+    
+    def calculate_retention(
+        self, 
+        cohort_id: str, 
+        round_id: int
+    ) -> RetentionMetrics:
+        """
+        Calculate retention metrics for a cohort in a specific round.
+        
+        Args:
+            cohort_id: Cohort identifier
+            round_id: Round ID to calculate retention for
+            
+        Returns:
+            RetentionMetrics with retention information
+        """
+        logger.info(f"Calculating retention for cohort {cohort_id} in round {round_id}")
+        
+        try:
+            from src.db.cohort_models import ContributorCohort, ContributorRoundParticipation, CohortRetentionSummary
+            
+            with self.db_service.get_session() as session:
+                # Get cohort members
+                cohort = session.execute(
+                    session.query(ContributorCohort).filter(
+                        ContributorCohort.cohort_id == cohort_id
+                    )
+                ).scalar_one_or_none()
+                
+                if not cohort:
+                    raise ValueError(f"Cohort {cohort_id} not found")
+                
+                cohort_members = set(cohort.members or [])
+                cohort_size = len(cohort_members)
+                
+                # Get contributors in the target round
+                round_participants = session.execute(
+                    session.query(ContributorRoundParticipation).filter(
+                        ContributorRoundParticipation.round_id == round_id
+                    )
+                ).scalars().all()
+                
+                round_contributors = {p.contributor: p for p in round_participants}
+                
+                # Calculate retention
+                retained = cohort_members.intersection(set(round_contributors.keys()))
+                retained_count = len(retained)
+                retention_rate = retained_count / cohort_size if cohort_size > 0 else 0.0
+                
+                # Calculate contribution metrics for retained contributors
+                retained_total = sum(round_contributors[c].total_contributed for c in retained)
+                avg_retained = retained_total / retained_count if retained_count > 0 else 0.0
+                
+                # Count new contributors (not in cohort)
+                new_contributors = len(set(round_contributors.keys()) - cohort_members)
+                
+                # Save retention summary
+                summary = CohortRetentionSummary(
+                    cohort_id=cohort_id,
+                    round_id=round_id,
+                    cohort_size=cohort_size,
+                    retained_contributors=retained_count,
+                    retention_rate=retention_rate,
+                    retained_total_contributed=retained_total,
+                    avg_retained_contribution=avg_retained,
+                    new_contributors=new_contributors,
+                    calculated_at=datetime.utcnow(),
+                )
+                session.add(summary)
+                session.flush()
+                
+                logger.info(
+                    f"Cohort {cohort_id} retention in round {round_id}: "
+                    f"{retained_count}/{cohort_size} ({retention_rate:.1%})"
+                )
+                
+                return RetentionMetrics(
+                    cohort_id=cohort_id,
+                    round_id=round_id,
+                    cohort_size=cohort_size,
+                    retained_contributors=retained_count,
+                    retention_rate=retention_rate,
+                    retained_total_contributed=retained_total,
+                    avg_retained_contribution=avg_retained,
+                    new_contributors=new_contributors,
+                )
+                
+        except Exception as e:
+            logger.error(f"Failed to calculate retention: {e}")
+            raise
+    
+    def analyze_repeat_contributors(
+        self, 
+        min_rounds: int = 2,
+        recalculate: bool = False
+    ) -> List[RepeatContributorMetrics]:
+        """
+        Analyze and classify repeat contributors across all rounds.
+        
+        Args:
+            min_rounds: Minimum number of rounds to be considered a repeat contributor
+            recalculate: Force recalculation of existing summaries
+            
+        Returns:
+            List of RepeatContributorMetrics for all repeat contributors
+        """
+        logger.info(f"Analyzing repeat contributors (min_rounds={min_rounds})")
+        
+        try:
+            from src.db.cohort_models import ContributorRoundParticipation, RepeatContributorSummary
+            
+            with self.db_service.get_session() as session:
+                # Get all participation records
+                all_participation = session.execute(
+                    session.query(ContributorRoundParticipation)
+                ).scalars().all()
+                
+                # Aggregate by contributor
+                contributor_data = defaultdict(lambda: {
+                    "rounds": set(),
+                    "total_contributed": 0.0,
+                    "projects": set(),
+                    "total_projects": 0,
+                    "timestamps": []
+                })
+                
+                for participation in all_participation:
+                    contributor = participation.contributor
+                    contributor_data[contributor]["rounds"].add(participation.round_id)
+                    contributor_data[contributor]["total_contributed"] += participation.total_contributed
+                    contributor_data[contributor]["total_projects"] += participation.projects_supported
+                    if participation.project_ids:
+                        contributor_data[contributor]["projects"].update(participation.project_ids)
+                    if participation.first_contribution_at:
+                        contributor_data[contributor]["timestamps"].append(participation.first_contribution_at)
+                    if participation.last_contribution_at:
+                        contributor_data[contributor]["timestamps"].append(participation.last_contribution_at)
+                
+                # Calculate metrics for each contributor
+                results = []
+                for contributor, data in contributor_data.items():
+                    rounds_participated = len(data["rounds"])
+                    
+                    if rounds_participated < min_rounds:
+                        continue
+                    
+                    round_ids = sorted(list(data["rounds"]))
+                    total_contributed = data["total_contributed"]
+                    avg_per_round = total_contributed / rounds_participated
+                    unique_projects = len(data["projects"])
+                    timestamps = sorted(data["timestamps"]) if data["timestamps"] else []
+                    
+                    contributor_type = self._classify_contributor(rounds_participated, total_contributed)
+                    
+                    # Check if summary exists
+                    existing = session.execute(
+                        session.query(RepeatContributorSummary).filter(
+                            RepeatContributorSummary.contributor == contributor
+                        )
+                    ).scalar_one_or_none()
+                    
+                    if existing and not recalculate:
+                        # Return existing data
+                        results.append(RepeatContributorMetrics(
+                            contributor=contributor,
+                            rounds_participated=existing.rounds_participated,
+                            first_round_id=existing.first_round_id,
+                            last_round_id=existing.last_round_id,
+                            total_contributed_all_rounds=existing.total_contributed_all_rounds,
+                            avg_contributed_per_round=existing.avg_contributed_per_round,
+                            total_projects_supported=existing.total_projects_supported,
+                            unique_projects_supported=existing.unique_projects_supported,
+                            contributor_type=ContributorType(existing.contributor_type),
+                            round_ids=existing.round_ids or [],
+                            first_contribution_at=existing.first_contribution_at,
+                            last_contribution_at=existing.last_contribution_at,
+                        ))
+                    else:
+                        # Create or update summary
+                        metrics = RepeatContributorMetrics(
+                            contributor=contributor,
+                            rounds_participated=rounds_participated,
+                            first_round_id=round_ids[0] if round_ids else None,
+                            last_round_id=round_ids[-1] if round_ids else None,
+                            total_contributed_all_rounds=total_contributed,
+                            avg_contributed_per_round=avg_per_round,
+                            total_projects_supported=data["total_projects"],
+                            unique_projects_supported=unique_projects,
+                            contributor_type=contributor_type,
+                            round_ids=round_ids,
+                            first_contribution_at=timestamps[0] if timestamps else None,
+                            last_contribution_at=timestamps[-1] if timestamps else None,
+                        )
+                        
+                        if existing:
+                            existing.rounds_participated = rounds_participated
+                            existing.first_round_id = metrics.first_round_id
+                            existing.last_round_id = metrics.last_round_id
+                            existing.total_contributed_all_rounds = total_contributed
+                            existing.avg_contributed_per_round = avg_per_round
+                            existing.total_projects_supported = data["total_projects"]
+                            existing.unique_projects_supported = unique_projects
+                            existing.contributor_type = contributor_type.value
+                            existing.round_ids = round_ids
+                            existing.first_contribution_at = metrics.first_contribution_at
+                            existing.last_contribution_at = metrics.last_contribution_at
+                            existing.calculated_at = datetime.utcnow()
+                        else:
+                            summary = RepeatContributorSummary(
+                                contributor=contributor,
+                                rounds_participated=rounds_participated,
+                                first_round_id=metrics.first_round_id,
+                                last_round_id=metrics.last_round_id,
+                                total_contributed_all_rounds=total_contributed,
+                                avg_contributed_per_round=avg_per_round,
+                                total_projects_supported=data["total_projects"],
+                                unique_projects_supported=unique_projects,
+                                contributor_type=contributor_type.value,
+                                round_ids=round_ids,
+                                first_contribution_at=metrics.first_contribution_at,
+                                last_contribution_at=metrics.last_contribution_at,
+                                calculated_at=datetime.utcnow(),
+                            )
+                            session.add(summary)
+                        
+                        results.append(metrics)
+                
+                session.flush()
+                logger.info(f"Analyzed {len(results)} repeat contributors")
+                return results
+                
+        except Exception as e:
+            logger.error(f"Failed to analyze repeat contributors: {e}")
+            raise
+    
+    def create_time_window_cohort(
+        self, 
+        window_start: datetime, 
+        window_end: datetime,
+        cohort_id: Optional[str] = None
+    ) -> CohortMetrics:
+        """
+        Create a cohort of contributors who participated within a time window.
+        
+        Args:
+            window_start: Start of the time window
+            window_end: End of the time window
+            cohort_id: Optional custom cohort ID (auto-generated if not provided)
+            
+        Returns:
+            CohortMetrics with cohort information
+        """
+        if cohort_id is None:
+            cohort_id = f"time_window_{window_start.strftime('%Y%m%d')}_{window_end.strftime('%Y%m%d')}"
+        
+        logger.info(f"Creating time-window cohort: {window_start} to {window_end}")
+        
+        try:
+            from src.db.cohort_models import ContributorRoundParticipation, ContributorCohort, GrantRound
+            
+            with self.db_service.get_session() as session:
+                # Get rounds within the time window
+                rounds_in_window = session.execute(
+                    session.query(GrantRound.id).filter(
+                        GrantRound.start_time >= window_start,
+                        GrantRound.end_time <= window_end
+                    )
+                ).scalars().all()
+                
+                if not rounds_in_window:
+                    logger.warning(f"No rounds found in time window {window_start} to {window_end}")
+                    return CohortMetrics(cohort_id=cohort_id, member_count=0)
+                
+                # Get all contributors in these rounds
+                contributors_in_window = set()
+                contributor_totals = defaultdict(float)
+                
+                for round_id in rounds_in_window:
+                    participants = session.execute(
+                        session.query(ContributorRoundParticipation).filter(
+                            ContributorRoundParticipation.round_id == round_id
+                        )
+                    ).scalars().all()
+                    
+                    for p in participants:
+                        contributors_in_window.add(p.contributor)
+                        contributor_totals[p.contributor] += p.total_contributed
+                
+                # Calculate metrics
+                total_contributed = sum(contributor_totals.values())
+                avg_contributed = total_contributed / len(contributors_in_window) if contributors_in_window else 0.0
+                
+                # Save cohort
+                cohort = ContributorCohort(
+                    cohort_id=cohort_id,
+                    cohort_type=CohortType.TIME_WINDOW.value,
+                    definition_window_start=window_start,
+                    definition_window_end=window_end,
+                    member_count=len(contributors_in_window),
+                    members=list(contributors_in_window),
+                    total_contributed=total_contributed,
+                    avg_contributed_per_member=avg_contributed,
+                )
+                session.add(cohort)
+                session.flush()
+                
+                logger.info(f"Created time-window cohort {cohort_id} with {len(contributors_in_window)} members")
+                
+                return CohortMetrics(
+                    cohort_id=cohort_id,
+                    member_count=len(contributors_in_window),
+                    members=list(contributors_in_window),
+                    total_contributed=total_contributed,
+                    avg_contributed_per_member=avg_contributed,
+                )
+                
+        except Exception as e:
+            logger.error(f"Failed to create time-window cohort: {e}")
+            raise
+    
+    def get_cohort_retention_timeline(
+        self, 
+        cohort_id: str
+    ) -> List[Dict[str, Any]]:
+        """
+        Get retention timeline for a cohort across all rounds.
+        
+        Args:
+            cohort_id: Cohort identifier
+            
+        Returns:
+            List of retention metrics for each round
+        """
+        logger.info(f"Getting retention timeline for cohort {cohort_id}")
+        
+        try:
+            from src.db.cohort_models import CohortRetentionSummary
+            
+            with self.db_service.get_session() as session:
+                summaries = session.execute(
+                    session.query(CohortRetentionSummary).filter(
+                        CohortRetentionSummary.cohort_id == cohort_id
+                    ).order_by(CohortRetentionSummary.round_id)
+                ).scalars().all()
+                
+                timeline = [
+                    {
+                        "round_id": s.round_id,
+                        "cohort_size": s.cohort_size,
+                        "retained_contributors": s.retained_contributors,
+                        "retention_rate": s.retention_rate,
+                        "retained_total_contributed": s.retained_total_contributed,
+                        "avg_retained_contribution": s.avg_retained_contribution,
+                        "new_contributors": s.new_contributors,
+                        "calculated_at": s.calculated_at.isoformat(),
+                    }
+                    for s in summaries
+                ]
+                
+                logger.info(f"Retrieved {len(timeline)} retention data points for cohort {cohort_id}")
+                return timeline
+                
+        except Exception as e:
+            logger.error(f"Failed to get retention timeline: {e}")
+            return []
+
+
+def create_cohort_analyzer(db_service: Optional[PostgresService] = None) -> CohortAnalyzer:
+    """
+    Factory function to create a CohortAnalyzer instance.
+    
+    Args:
+        db_service: Optional database service instance
+        
+    Returns:
+        Configured CohortAnalyzer instance
+    """
+    return CohortAnalyzer(db_service=db_service)

--- a/apps/data-processing/src/db/__init__.py
+++ b/apps/data-processing/src/db/__init__.py
@@ -16,6 +16,13 @@ from .models import (
     NewsInsight,
     AssetTrend,
 )
+from .cohort_models import (
+    GrantRound,
+    ContributorRoundParticipation,
+    ContributorCohort,
+    CohortRetentionSummary,
+    RepeatContributorSummary,
+)
 from .postgres_service import PostgresService
 
 __all__ = [
@@ -31,5 +38,10 @@ __all__ = [
     "ProjectMilestone",
     "NewsInsight",
     "AssetTrend",
+    "GrantRound",
+    "ContributorRoundParticipation",
+    "ContributorCohort",
+    "CohortRetentionSummary",
+    "RepeatContributorSummary",
     "PostgresService",
 ]

--- a/apps/data-processing/src/db/cohort_models.py
+++ b/apps/data-processing/src/db/cohort_models.py
@@ -1,0 +1,245 @@
+"""
+Cohort analysis models for grant round contributor tracking
+"""
+
+from datetime import datetime
+from typing import Optional
+from sqlalchemy import Column, Integer, String, Float, DateTime, JSON, BigInteger, Index
+from sqlalchemy.orm import declarative_base
+from sqlalchemy.sql import func
+
+Base = declarative_base()
+
+
+class GrantRound(Base):
+    """
+    Stores metadata for quadratic funding grant rounds
+    """
+
+    __tablename__ = "grant_rounds"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=False)  # Round ID from chain
+    name = Column(String(255), nullable=True)
+    description = Column(String(1000), nullable=True)
+    
+    # Round timing
+    start_time = Column(DateTime(timezone=True), nullable=False, index=True)
+    end_time = Column(DateTime(timezone=True), nullable=False, index=True)
+    
+    # Round metrics
+    total_pool = Column(Float, nullable=True)
+    total_contributions = Column(Float, nullable=True)
+    unique_contributors = Column(Integer, nullable=True)
+    unique_projects = Column(Integer, nullable=True)
+    
+    # Round status
+    status = Column(String(50), nullable=False, default="active", index=True)  # active, completed, cancelled
+    
+    # Additional metadata
+    extra_data = Column(JSON, nullable=True)
+    
+    # Timestamps
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        Index("idx_grant_rounds_start_time", "start_time"),
+        Index("idx_grant_rounds_end_time", "end_time"),
+        Index("idx_grant_rounds_status", "status"),
+    )
+
+    def __repr__(self):
+        return f"<GrantRound(id={self.id}, name={self.name}, status={self.status})>"
+
+
+class ContributorRoundParticipation(Base):
+    """
+    Tracks individual contributor participation in each round
+    """
+
+    __tablename__ = "contributor_round_participation"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    round_id = Column(BigInteger, nullable=False, index=True)
+    contributor = Column(String(255), nullable=False, index=True)
+    
+    # Participation metrics
+    total_contributed = Column(Float, nullable=False, default=0.0)
+    projects_supported = Column(Integer, nullable=False, default=0)
+    contribution_count = Column(Integer, nullable=False, default=0)
+    
+    # First and last contribution in round
+    first_contribution_at = Column(DateTime(timezone=True), nullable=True)
+    last_contribution_at = Column(DateTime(timezone=True), nullable=True)
+    
+    # Project IDs supported (for analysis)
+    project_ids = Column(JSON, nullable=True)  # Array of project IDs
+    
+    # Timestamps
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        Index(
+            "ux_contributor_round_participation_round_contributor",
+            "round_id",
+            "contributor",
+            unique=True,
+        ),
+        Index("idx_contributor_round_participation_contributor", "contributor"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<ContributorRoundParticipation(round_id={self.round_id}, "
+            f"contributor={self.contributor}, total={self.total_contributed})>"
+        )
+
+
+class ContributorCohort(Base):
+    """
+    Stores cohort definitions and summaries for time-windowed analysis
+    """
+
+    __tablename__ = "contributor_cohorts"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    cohort_id = Column(String(255), nullable=False, unique=True, index=True)
+    
+    # Cohort definition
+    cohort_type = Column(String(50), nullable=False, index=True)  # first_round, time_window, etc.
+    definition_window_start = Column(DateTime(timezone=True), nullable=False)
+    definition_window_end = Column(DateTime(timezone=True), nullable=False)
+    
+    # Cohort members
+    member_count = Column(Integer, nullable=False, default=0)
+    members = Column(JSON, nullable=True)  # Array of contributor addresses
+    
+    # Cohort metrics
+    total_contributed = Column(Float, nullable=True)
+    avg_contributed_per_member = Column(Float, nullable=True)
+    
+    # Timestamps
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        Index("idx_contributor_cohorts_type", "cohort_type"),
+        Index("idx_contributor_cohorts_window", "definition_window_start", "definition_window_end"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<ContributorCohort(cohort_id={self.cohort_id}, type={self.cohort_type}, "
+            f"members={self.member_count})>"
+        )
+
+
+class CohortRetentionSummary(Base):
+    """
+    Stores retention metrics for cohorts across subsequent rounds
+    """
+
+    __tablename__ = "cohort_retention_summaries"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    cohort_id = Column(String(255), nullable=False, index=True)
+    round_id = Column(BigInteger, nullable=False, index=True)
+    
+    # Retention metrics
+    cohort_size = Column(Integer, nullable=False)
+    retained_contributors = Column(Integer, nullable=False)
+    retention_rate = Column(Float, nullable=False)
+    
+    # Contribution metrics for retained contributors
+    retained_total_contributed = Column(Float, nullable=True)
+    avg_retained_contribution = Column(Float, nullable=True)
+    
+    # New contributors in this round (not in cohort)
+    new_contributors = Column(Integer, nullable=True)
+    
+    # Timestamps
+    calculated_at = Column(DateTime(timezone=True), nullable=False, index=True)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        Index(
+            "ux_cohort_retention_cohort_round",
+            "cohort_id",
+            "round_id",
+            unique=True,
+        ),
+        Index("idx_cohort_retention_calculated_at", "calculated_at"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<CohortRetentionSummary(cohort_id={self.cohort_id}, round_id={self.round_id}, "
+            f"retention_rate={self.retention_rate:.2%})>"
+        )
+
+
+class RepeatContributorSummary(Base):
+    """
+    Stores aggregated metrics for repeat contributors across rounds
+    """
+
+    __tablename__ = "repeat_contributor_summaries"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    contributor = Column(String(255), nullable=False, unique=True, index=True)
+    
+    # Participation metrics
+    rounds_participated = Column(Integer, nullable=False, default=0)
+    first_round_id = Column(BigInteger, nullable=True)
+    last_round_id = Column(BigInteger, nullable=True)
+    
+    # Contribution metrics
+    total_contributed_all_rounds = Column(Float, nullable=False, default=0.0)
+    avg_contributed_per_round = Column(Float, nullable=True)
+    
+    # Project diversity
+    total_projects_supported = Column(Integer, nullable=False, default=0)
+    unique_projects_supported = Column(Integer, nullable=False, default=0)
+    
+    # Classification
+    contributor_type = Column(String(50), nullable=True, index=True)  # one_time, repeat, super_contributor
+    
+    # Round participation history
+    round_ids = Column(JSON, nullable=True)  # Array of round IDs participated
+    
+    # Timestamps
+    first_contribution_at = Column(DateTime(timezone=True), nullable=True)
+    last_contribution_at = Column(DateTime(timezone=True), nullable=True)
+    calculated_at = Column(DateTime(timezone=True), nullable=False, index=True)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        Index("idx_repeat_contributor_type", "contributor_type"),
+        Index("idx_repeat_contributor_rounds", "rounds_participated"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<RepeatContributorSummary(contributor={self.contributor}, "
+            f"rounds={self.rounds_participated}, type={self.contributor_type})>"
+        )

--- a/apps/data-processing/src/db/cohort_models.py
+++ b/apps/data-processing/src/db/cohort_models.py
@@ -5,10 +5,9 @@ Cohort analysis models for grant round contributor tracking
 from datetime import datetime
 from typing import Optional
 from sqlalchemy import Column, Integer, String, Float, DateTime, JSON, BigInteger, Index
-from sqlalchemy.orm import declarative_base
 from sqlalchemy.sql import func
 
-Base = declarative_base()
+from .models import Base
 
 
 class GrantRound(Base):

--- a/apps/data-processing/src/db/postgres_service.py
+++ b/apps/data-processing/src/db/postgres_service.py
@@ -31,6 +31,13 @@ from .models import (
     RoundAnomalySignal,
     MetadataDriftFinding,
 )
+from .cohort_models import (
+    GrantRound,
+    ContributorRoundParticipation,
+    ContributorCohort,
+    CohortRetentionSummary,
+    RepeatContributorSummary,
+)
 from src.analytics.ner_service import NERService
 from src.analytics.onchain_entity_linker import (
     OnchainEntityCandidate,
@@ -58,13 +65,22 @@ class PostgresService:
         )
 
         try:
-            self.engine = create_engine(
-                self.database_url,
-                pool_pre_ping=True,  # Verify connections before using
-                pool_size=5,
-                max_overflow=10,
-                echo=False,  # Set to True for SQL query logging
-            )
+            if self.database_url.startswith("sqlite"):
+                from sqlalchemy.pool import StaticPool
+                self.engine = create_engine(
+                    self.database_url,
+                    connect_args={"check_same_thread": False},
+                    poolclass=StaticPool,
+                    echo=False,
+                )
+            else:
+                self.engine = create_engine(
+                    self.database_url,
+                    pool_pre_ping=True,  # Verify connections before using
+                    pool_size=5,
+                    max_overflow=10,
+                    echo=False,  # Set to True for SQL query logging
+                )
             self.SessionLocal = sessionmaker(
                 autocommit=False,
                 autoflush=False,

--- a/apps/data-processing/tests/test_cohort_analyzer.py
+++ b/apps/data-processing/tests/test_cohort_analyzer.py
@@ -1,0 +1,453 @@
+"""
+Tests for Cohort Analyzer - Validates cohort analysis datasets and output formats
+"""
+
+import sys
+from pathlib import Path
+
+# Add parent directory to path to enable imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pytest
+from datetime import datetime, timedelta
+from src.analytics.cohort_analyzer import (
+    CohortAnalyzer,
+    CohortType,
+    ContributorType,
+    CohortDefinition,
+    CohortMetrics,
+    RetentionMetrics,
+    RepeatContributorMetrics,
+    create_cohort_analyzer,
+)
+from src.db.postgres_service import PostgresService
+from src.db.cohort_models import (
+    GrantRound,
+    ContributorRoundParticipation,
+    ContributorCohort,
+    CohortRetentionSummary,
+    RepeatContributorSummary,
+)
+
+
+class TestCohortAnalyzer:
+    """Test suite for CohortAnalyzer functionality"""
+    
+    @pytest.fixture
+    def db_service(self):
+        """Create a test database service"""
+        # Use test database URL from environment or default
+        db = PostgresService()
+        db.create_tables()
+        yield db
+        # Cleanup if needed
+    
+    @pytest.fixture
+    def analyzer(self, db_service):
+        """Create a cohort analyzer instance"""
+        return CohortAnalyzer(db_service=db_service)
+    
+    @pytest.fixture
+    def sample_rounds(self, db_service):
+        """Create sample grant rounds for testing"""
+        rounds = [
+            GrantRound(
+                id=1,
+                name="Round 1",
+                start_time=datetime(2026, 1, 1),
+                end_time=datetime(2026, 1, 31),
+                status="completed",
+                total_pool=100000.0,
+                total_contributions=50000.0,
+                unique_contributors=50,
+                unique_projects=10,
+            ),
+            GrantRound(
+                id=2,
+                name="Round 2",
+                start_time=datetime(2026, 2, 1),
+                end_time=datetime(2026, 2, 28),
+                status="completed",
+                total_pool=100000.0,
+                total_contributions=60000.0,
+                unique_contributors=60,
+                unique_projects=12,
+            ),
+            GrantRound(
+                id=3,
+                name="Round 3",
+                start_time=datetime(2026, 3, 1),
+                end_time=datetime(2026, 3, 31),
+                status="active",
+                total_pool=100000.0,
+                total_contributions=40000.0,
+                unique_contributors=40,
+                unique_projects=8,
+            ),
+        ]
+        
+        with db_service.get_session() as session:
+            for round_data in rounds:
+                session.add(round_data)
+            session.flush()
+        
+        return rounds
+    
+    @pytest.fixture
+    def sample_contributions(self):
+        """Create sample contribution data"""
+        return [
+            # Round 1 contributions
+            {"contributor": "0xAAA1", "amount": 100.0, "project_id": 1, "timestamp": datetime(2026, 1, 5)},
+            {"contributor": "0xAAA1", "amount": 50.0, "project_id": 2, "timestamp": datetime(2026, 1, 10)},
+            {"contributor": "0xBBB2", "amount": 200.0, "project_id": 1, "timestamp": datetime(2026, 1, 7)},
+            {"contributor": "0xCCC3", "amount": 150.0, "project_id": 3, "timestamp": datetime(2026, 1, 15)},
+            {"contributor": "0xDDD4", "amount": 75.0, "project_id": 2, "timestamp": datetime(2026, 1, 20)},
+            # Round 2 contributions (some repeat, some new)
+            {"contributor": "0xAAA1", "amount": 120.0, "project_id": 1, "timestamp": datetime(2026, 2, 5)},
+            {"contributor": "0xBBB2", "amount": 180.0, "project_id": 4, "timestamp": datetime(2026, 2, 8)},
+            {"contributor": "0xEEE5", "amount": 250.0, "project_id": 1, "timestamp": datetime(2026, 2, 12)},
+            {"contributor": "0xFFF6", "amount": 100.0, "project_id": 5, "timestamp": datetime(2026, 2, 18)},
+            # Round 3 contributions
+            {"contributor": "0xAAA1", "amount": 80.0, "project_id": 2, "timestamp": datetime(2026, 3, 5)},
+            {"contributor": "0xCCC3", "amount": 200.0, "project_id": 3, "timestamp": datetime(2026, 3, 10)},
+            {"contributor": "0xEEE5", "amount": 150.0, "project_id": 4, "timestamp": datetime(2026, 3, 15)},
+        ]
+    
+    def test_track_round_participation(self, analyzer, sample_contributions):
+        """Test tracking contributor participation for a round"""
+        # Track round 1 contributions
+        round1_contributions = [c for c in sample_contributions if c["timestamp"].month == 1]
+        saved_count = analyzer.track_round_participation(round_id=1, contributions=round1_contributions)
+        
+        assert saved_count == 4  # 4 unique contributors in round 1
+        
+        # Verify data was saved
+        with analyzer.db_service.get_session() as session:
+            participations = session.execute(
+                session.query(ContributorRoundParticipation).filter(
+                    ContributorRoundParticipation.round_id == 1
+                )
+            ).scalars().all()
+            
+            assert len(participations) == 4
+            
+            # Check specific contributor
+            aaa1 = next(p for p in participations if p.contributor == "0xAAA1")
+            assert aaa1.total_contributed == 150.0  # 100 + 50
+            assert aaa1.projects_supported == 2
+            assert aaa1.contribution_count == 2
+    
+    def test_create_first_round_cohort(self, analyzer, sample_contributions, sample_rounds):
+        """Test creating a first-round cohort"""
+        # Track participation for round 1
+        round1_contributions = [c for c in sample_contributions if c["timestamp"].month == 1]
+        analyzer.track_round_participation(round_id=1, contributions=round1_contributions)
+        
+        # Create first-round cohort
+        cohort_metrics = analyzer.create_first_round_cohort(round_id=1)
+        
+        assert cohort_metrics.cohort_id == "first_round_1"
+        assert cohort_metrics.member_count == 4
+        assert cohort_metrics.total_contributed == 575.0  # 100+50+200+150+75
+        assert len(cohort_metrics.members) == 4
+        
+        # Verify cohort was saved
+        with analyzer.db_service.get_session() as session:
+            cohort = session.execute(
+                session.query(ContributorCohort).filter(
+                    ContributorCohort.cohort_id == "first_round_1"
+                )
+            ).scalar_one_or_none()
+            
+            assert cohort is not None
+            assert cohort.cohort_type == CohortType.FIRST_ROUND.value
+            assert cohort.member_count == 4
+    
+    def test_calculate_retention(self, analyzer, sample_contributions, sample_rounds):
+        """Test calculating retention metrics"""
+        # Track participation for rounds 1 and 2
+        round1_contributions = [c for c in sample_contributions if c["timestamp"].month == 1]
+        round2_contributions = [c for c in sample_contributions if c["timestamp"].month == 2]
+        
+        analyzer.track_round_participation(round_id=1, contributions=round1_contributions)
+        analyzer.track_round_participation(round_id=2, contributions=round2_contributions)
+        
+        # Create first-round cohort
+        analyzer.create_first_round_cohort(round_id=1)
+        
+        # Calculate retention for round 2
+        retention_metrics = analyzer.calculate_retention(
+            cohort_id="first_round_1",
+            round_id=2
+        )
+        
+        assert retention_metrics.cohort_id == "first_round_1"
+        assert retention_metrics.round_id == 2
+        assert retention_metrics.cohort_size == 4
+        # 0xAAA1 and 0xBBB2 participated in both rounds
+        assert retention_metrics.retained_contributors == 2
+        assert retention_metrics.retention_rate == 0.5  # 2/4
+        
+        # Verify retention summary was saved
+        with analyzer.db_service.get_session() as session:
+            summary = session.execute(
+                session.query(CohortRetentionSummary).filter(
+                    CohortRetentionSummary.cohort_id == "first_round_1",
+                    CohortRetentionSummary.round_id == 2
+                )
+            ).scalar_one_or_none()
+            
+            assert summary is not None
+            assert summary.retention_rate == 0.5
+    
+    def test_analyze_repeat_contributors(self, analyzer, sample_contributions, sample_rounds):
+        """Test analyzing repeat contributors"""
+        # Track participation for all rounds
+        for round_id in [1, 2, 3]:
+            round_contributions = [c for c in sample_contributions if c["timestamp"].month == round_id]
+            analyzer.track_round_participation(round_id=round_id, contributions=round_contributions)
+        
+        # Analyze repeat contributors
+        repeat_contributors = analyzer.analyze_repeat_contributors(min_rounds=2)
+        
+        # 0xAAA1 participated in all 3 rounds, 0xBBB2 in 2 rounds, 0xCCC3 in 2 rounds, 0xEEE5 in 2 rounds
+        assert len(repeat_contributors) == 4
+        
+        # Check 0xAAA1 (super contributor - 3 rounds)
+        aaa1 = next(c for c in repeat_contributors if c.contributor == "0xAAA1")
+        assert aaa1.rounds_participated == 3
+        assert aaa1.contributor_type == ContributorType.REPEAT  # 3 rounds but < 6
+        assert aaa1.total_contributed_all_rounds == 350.0  # 150 + 120 + 80
+        
+        # Check 0xBBB2 (repeat contributor - 2 rounds)
+        bbb2 = next(c for c in repeat_contributors if c.contributor == "0xBBB2")
+        assert bbb2.rounds_participated == 2
+        assert bbb2.contributor_type == ContributorType.REPEAT
+        
+        # Verify summaries were saved
+        with analyzer.db_service.get_session() as session:
+            summaries = session.execute(
+                session.query(RepeatContributorSummary)
+            ).scalars().all()
+            
+            assert len(summaries) >= 4
+    
+    def test_create_time_window_cohort(self, analyzer, sample_contributions, sample_rounds):
+        """Test creating a time-window cohort"""
+        # Track participation for all rounds
+        for round_id in [1, 2, 3]:
+            round_contributions = [c for c in sample_contributions if c["timestamp"].month == round_id]
+            analyzer.track_round_participation(round_id=round_id, contributions=round_contributions)
+        
+        # Create Q1 2026 cohort
+        cohort_metrics = analyzer.create_time_window_cohort(
+            window_start=datetime(2026, 1, 1),
+            window_end=datetime(2026, 3, 31)
+        )
+        
+        assert cohort_metrics.member_count > 0
+        assert "time_window" in cohort_metrics.cohort_id
+        
+        # Verify cohort was saved
+        with analyzer.db_service.get_session() as session:
+            cohort = session.execute(
+                session.query(ContributorCohort).filter(
+                    ContributorCohort.cohort_type == CohortType.TIME_WINDOW.value
+                )
+            ).scalar_one_or_none()
+            
+            assert cohort is not None
+    
+    def test_get_cohort_retention_timeline(self, analyzer, sample_contributions, sample_rounds):
+        """Test getting retention timeline for a cohort"""
+        # Track participation for all rounds
+        for round_id in [1, 2, 3]:
+            round_contributions = [c for c in sample_contributions if c["timestamp"].month == round_id]
+            analyzer.track_round_participation(round_id=round_id, contributions=round_contributions)
+        
+        # Create first-round cohort
+        analyzer.create_first_round_cohort(round_id=1)
+        
+        # Calculate retention for subsequent rounds
+        analyzer.calculate_retention(cohort_id="first_round_1", round_id=2)
+        analyzer.calculate_retention(cohort_id="first_round_1", round_id=3)
+        
+        # Get retention timeline
+        timeline = analyzer.get_cohort_retention_timeline(cohort_id="first_round_1")
+        
+        assert len(timeline) == 2
+        assert timeline[0]["round_id"] == 2
+        assert timeline[1]["round_id"] == 3
+        
+        # Verify timeline structure
+        for data in timeline:
+            assert "round_id" in data
+            assert "cohort_size" in data
+            assert "retained_contributors" in data
+            assert "retention_rate" in data
+            assert "calculated_at" in data
+    
+    def test_contributor_classification(self, analyzer):
+        """Test contributor classification logic"""
+        # Test one-time contributor
+        type_1 = analyzer._classify_contributor(rounds_participated=1, total_contributed=100)
+        assert type_1 == ContributorType.ONE_TIME
+        
+        # Test repeat contributor
+        type_2 = analyzer._classify_contributor(rounds_participated=3, total_contributed=500)
+        assert type_2 == ContributorType.REPEAT
+        
+        # Test super contributor (6+ rounds)
+        type_3 = analyzer._classify_contributor(rounds_participated=6, total_contributed=1000)
+        assert type_3 == ContributorType.SUPER_CONTRIBUTOR
+        
+        # Test super contributor (high total)
+        type_4 = analyzer._classify_contributor(rounds_participated=3, total_contributed=15000)
+        assert type_4 == ContributorType.SUPER_CONTRIBUTOR
+    
+    def test_output_format_validation(self, analyzer, sample_contributions, sample_rounds):
+        """Test that output formats match backend/dashboard consumption requirements"""
+        # Track participation
+        round1_contributions = [c for c in sample_contributions if c["timestamp"].month == 1]
+        analyzer.track_round_participation(round_id=1, contributions=round1_contributions)
+        
+        # Test cohort metrics output format
+        cohort_metrics = analyzer.create_first_round_cohort(round_id=1)
+        cohort_dict = cohort_metrics.to_dict()
+        
+        required_cohort_fields = [
+            "cohort_id", "member_count", "members", 
+            "total_contributed", "avg_contributed_per_member"
+        ]
+        for field in required_cohort_fields:
+            assert field in cohort_dict
+        
+        # Test retention metrics output format
+        analyzer.track_round_participation(round_id=2, contributions=sample_contributions)
+        retention_metrics = analyzer.calculate_retention(
+            cohort_id="first_round_1",
+            round_id=2
+        )
+        retention_dict = retention_metrics.to_dict()
+        
+        required_retention_fields = [
+            "cohort_id", "round_id", "cohort_size", "retained_contributors",
+            "retention_rate", "retained_total_contributed", 
+            "avg_retained_contribution", "new_contributors"
+        ]
+        for field in required_retention_fields:
+            assert field in retention_dict
+        
+        # Test repeat contributor metrics output format
+        repeat_contributors = analyzer.analyze_repeat_contributors(min_rounds=2)
+        if repeat_contributors:
+            contributor_dict = repeat_contributors[0].to_dict()
+            
+            required_contributor_fields = [
+                "contributor", "rounds_participated", "first_round_id", "last_round_id",
+                "total_contributed_all_rounds", "avg_contributed_per_round",
+                "total_projects_supported", "unique_projects_supported",
+                "contributor_type", "round_ids"
+            ]
+            for field in required_contributor_fields:
+                assert field in contributor_dict
+
+
+class TestCohortDataStructures:
+    """Test cohort data structures and serialization"""
+    
+    def test_cohort_definition_to_dict(self):
+        """Test CohortDefinition serialization"""
+        definition = CohortDefinition(
+            cohort_id="test_cohort",
+            cohort_type=CohortType.FIRST_ROUND,
+            window_start=datetime(2026, 1, 1),
+            window_end=datetime(2026, 1, 31),
+            description="Test cohort"
+        )
+        
+        data = definition.to_dict()
+        
+        assert data["cohort_id"] == "test_cohort"
+        assert data["cohort_type"] == "first_round"
+        assert "window_start" in data
+        assert "window_end" in data
+    
+    def test_cohort_metrics_to_dict(self):
+        """Test CohortMetrics serialization"""
+        metrics = CohortMetrics(
+            cohort_id="test_cohort",
+            member_count=10,
+            members=["0xAAA", "0xBBB"],
+            total_contributed=1000.0,
+            avg_contributed_per_member=100.0
+        )
+        
+        data = metrics.to_dict()
+        
+        assert data["cohort_id"] == "test_cohort"
+        assert data["member_count"] == 10
+        assert len(data["members"]) == 2
+        assert data["total_contributed"] == 1000.0
+    
+    def test_retention_metrics_to_dict(self):
+        """Test RetentionMetrics serialization"""
+        metrics = RetentionMetrics(
+            cohort_id="test_cohort",
+            round_id=2,
+            cohort_size=10,
+            retained_contributors=5,
+            retention_rate=0.5,
+            retained_total_contributed=500.0,
+            avg_retained_contribution=100.0,
+            new_contributors=3
+        )
+        
+        data = metrics.to_dict()
+        
+        assert data["cohort_id"] == "test_cohort"
+        assert data["round_id"] == 2
+        assert data["retention_rate"] == 0.5
+        assert data["retained_contributors"] == 5
+    
+    def test_repeat_contributor_metrics_to_dict(self):
+        """Test RepeatContributorMetrics serialization"""
+        metrics = RepeatContributorMetrics(
+            contributor="0xAAA",
+            rounds_participated=3,
+            first_round_id=1,
+            last_round_id=3,
+            total_contributed_all_rounds=300.0,
+            avg_contributed_per_round=100.0,
+            total_projects_supported=5,
+            unique_projects_supported=4,
+            contributor_type=ContributorType.REPEAT,
+            round_ids=[1, 2, 3],
+            first_contribution_at=datetime(2026, 1, 1),
+            last_contribution_at=datetime(2026, 3, 31)
+        )
+        
+        data = metrics.to_dict()
+        
+        assert data["contributor"] == "0xAAA"
+        assert data["rounds_participated"] == 3
+        assert data["contributor_type"] == "repeat"
+        assert len(data["round_ids"]) == 3
+        assert "first_contribution_at" in data
+        assert "last_contribution_at" in data
+
+
+def test_create_cohort_analyzer_factory():
+    """Test the factory function"""
+    analyzer = create_cohort_analyzer()
+    assert isinstance(analyzer, CohortAnalyzer)
+    
+    db_service = PostgresService()
+    analyzer_with_db = create_cohort_analyzer(db_service=db_service)
+    assert analyzer_with_db.db_service == db_service
+
+
+if __name__ == "__main__":
+    # Run tests
+    pytest.main([__file__, "-v"])

--- a/apps/data-processing/tests/test_cohort_analyzer.py
+++ b/apps/data-processing/tests/test_cohort_analyzer.py
@@ -35,12 +35,11 @@ class TestCohortAnalyzer:
     
     @pytest.fixture
     def db_service(self):
-        """Create a test database service"""
-        # Use test database URL from environment or default
-        db = PostgresService()
+        """Create a test database service backed by in-memory SQLite"""
+        db = PostgresService(database_url="sqlite:///:memory:")
         db.create_tables()
         yield db
-        # Cleanup if needed
+        db.drop_tables()
     
     @pytest.fixture
     def analyzer(self, db_service):


### PR DESCRIPTION
## Summary
Adds datasets and supporting analysis logic for cohort tracking across contribution rounds. This introduces 5 new database tables (via `cohort_models.py` + Alembic migration `006`), a `cohort_analyzer.py` module implementing participation tracking, first-round and time-window cohort creation, round-to-round retention analysis, and repeat-contributor identification/classification. Output is JSON-serializable and shaped for backend/dashboard consumption. Dataset definitions are documented in `COHORT_ANALYSIS_DATASETS.md` for contributor reference, with a working example under `examples/cohort_analysis_example.py`.

## Linked Issue
Closes #1062 

## Type of Change
- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Validation
- [x] Lint passed for affected area(s)
- [ ] Tests passed for affected area(s) — unit tests added in `tests/test_cohort_analyzer.py`, but not yet run against a live PostgreSQL instance
- [ ] Manual verification completed (if applicable) — **not yet verified**: no PostgreSQL connection available in this environment, so the migration has not been applied against a real/test database and DB-touching code paths are unconfirmed. Logic-level tests pass independent of this.

## Documentation
- [x] Documentation updated (or N/A with explanation) — see `COHORT_ANALYSIS_DATASETS.md`
- [ ] Screenshots/videos attached for UI changes — N/A, no UI changes

## Checklist
- [x] Branch name uses `feat/`, `fix/`, or `docs/`
- [x] Commit messages follow Conventional Commits
- [x] PR scope matches linked issue acceptance criteria