### PR TITLE
feat: standardize event versioning across Soroban contracts (Closes #1057)

### DIFF
--- a/apps/onchain/EVENTS_GUIDE.md
+++ b/apps/onchain/EVENTS_GUIDE.md
@@ -1,0 +1,138 @@
+# Event Versioning Guide
+
+Every Soroban contract that emits events **must** follow the canonical versioning
+pattern described below. This allows backend and data-processing consumers to
+detect schema changes and evolve safely.
+
+## Canonical Pattern
+
+### 1. Declare an `EVENT_VERSION` constant
+
+```rust
+/// Current schema version for every event emitted by this contract.
+/// Bump this when any event's fields are added, removed, or re-ordered.
+pub const EVENT_VERSION: u32 = 1;
+```
+
+### 2. Each event struct includes `version` as its first data field
+
+```rust
+#[contractevent]
+pub struct SomeEvent {
+    pub version: u32,   // ← always first
+    // ... business fields
+}
+```
+
+The `version` field comes **after** any `#[topic]` attributes (topics are
+indexed separately by the Soroban host) but is the first non-topic field:
+
+```rust
+#[contractevent]
+pub struct SomeEvent {
+    #[topic]
+    pub entity_id: u64,
+    pub version: u32,       // ← first data field
+    pub amount: i128,
+}
+```
+
+### 3. Publish helpers fill `version` automatically
+
+```rust
+pub fn emit_some_event(env: &Env, entity_id: u64, amount: i128) {
+    SomeEvent {
+        version: EVENT_VERSION,
+        entity_id,
+        amount,
+    }
+    .publish(env);
+}
+```
+
+Do **not** let callers choose the version — it is always hardcoded to
+`EVENT_VERSION` at compile time.
+
+### 4. Expose a `get_event_version` query
+
+Add a read-only function to the contract impl:
+
+```rust
+pub fn get_event_version(_env: Env) -> u32 {
+    events::EVENT_VERSION
+}
+```
+
+Consumers call this at startup to verify their parser is up to date.
+
+## Bumping the Version
+
+Increment `EVENT_VERSION` when you:
+
+- Add a new field to an existing event.
+- Remove a field from an existing event.
+- Rename or re-order fields of an existing event.
+
+Do **not** bump the version when:
+
+- Adding a **new** event type (each struct is independently identified by the
+  Soroban host via its topic symbol).
+- Changing only field *values* but not the schema.
+
+## How Consumers Detect Schema Changes
+
+1. On startup the consumer calls `contract.get_event_version()`.
+2. It compares the returned version with the version its parser expects.
+3. If they differ the consumer can log a warning, reject processing, or load a
+   different parser — whichever is appropriate.
+4. Every received event also carries `version` in its data body, so a consumer
+   that processes events asynchronously (e.g. from an indexer) can validate
+   each event individually.
+
+## Adding a New Event
+
+1. Add the new struct in `events.rs` with `pub version: u32` as the first
+   non-topic field.
+2. Add a `pub fn emit_*` helper that fills `version: EVENT_VERSION`.
+3. Call the helper from `lib.rs` at the appropriate emission point.
+4. No version bump needed — the new event is a distinct type from the
+   consumer's perspective.
+
+## Example: Before and After
+
+### Before (no versioning)
+
+```rust
+#[contractevent]
+pub struct TokensClaimedEvent {
+    #[topic]
+    pub beneficiary: Address,
+    pub amount_claimed: i128,
+    pub remaining: i128,
+}
+```
+
+### After (canonical pattern)
+
+```rust
+pub const EVENT_VERSION: u32 = 1;
+
+#[contractevent]
+pub struct TokensClaimedEvent {
+    pub version: u32,
+    #[topic]
+    pub beneficiary: Address,
+    pub amount_claimed: i128,
+    pub remaining: i128,
+}
+
+pub fn publish_tokens_claimed(env: &Env, beneficiary: Address, amount_claimed: i128, remaining: i128) {
+    TokensClaimedEvent {
+        version: EVENT_VERSION,
+        beneficiary,
+        amount_claimed,
+        remaining,
+    }
+    .publish(env);
+}
+```

--- a/apps/onchain/contracts/lumenpulse-curation/src/events.rs
+++ b/apps/onchain/contracts/lumenpulse-curation/src/events.rs
@@ -1,11 +1,26 @@
 use crate::types::ProjectMetadata;
 use soroban_sdk::{contractevent, Address, Env, Symbol};
 
+// ── Event Versioning ────────────────────────────────────────────────────────
+//
+// All events in this contract carry a `version` field as their first element.
+// Bump `EVENT_VERSION` when the fields of any event are added, removed, or
+// re-ordered. Consumers MUST check the `version` field they receive against
+// the expected value to detect schema drift at runtime.
+//
+// See apps/onchain/EVENTS_GUIDE.md for the canonical pattern.
+
+/// Current schema version for every event emitted by this contract.
+/// Consumers should call `get_event_version()` on the deployed contract to
+/// detect whether their parser is up to date.
+pub const EVENT_VERSION: u32 = 1;
+
 // ── Event Struct Definitions ────────────────────────────────────────────────
 
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProjectProposedEvent {
+    pub version: u32,
     pub project_id: u64,
     pub proposer: Address,
     pub name: Symbol,
@@ -14,6 +29,7 @@ pub struct ProjectProposedEvent {
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VoteCastEvent {
+    pub version: u32,
     pub project_id: u64,
     pub voter: Address,
     pub approve: bool,
@@ -23,18 +39,21 @@ pub struct VoteCastEvent {
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProjectVerifiedEvent {
+    pub version: u32,
     pub project_id: u64,
 }
 
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProjectRejectedEvent {
+    pub version: u32,
     pub project_id: u64,
 }
 
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProposalExpiredEvent {
+    pub version: u32,
     pub project_id: u64,
 }
 
@@ -61,6 +80,7 @@ pub fn emit_project_proposed(
     let project_name_symbol = Symbol::new(env, name_str);
 
     ProjectProposedEvent {
+        version: EVENT_VERSION,
         project_id,
         proposer: proposer.clone(),
         name: project_name_symbol,
@@ -76,6 +96,7 @@ pub fn emit_vote_cast(
     voting_power: u64,
 ) {
     VoteCastEvent {
+        version: EVENT_VERSION,
         project_id,
         voter: voter.clone(),
         approve,
@@ -85,13 +106,25 @@ pub fn emit_vote_cast(
 }
 
 pub fn emit_project_verified(env: &Env, project_id: u64) {
-    ProjectVerifiedEvent { project_id }.publish(env);
+    ProjectVerifiedEvent {
+        version: EVENT_VERSION,
+        project_id,
+    }
+    .publish(env);
 }
 
 pub fn emit_project_rejected(env: &Env, project_id: u64) {
-    ProjectRejectedEvent { project_id }.publish(env);
+    ProjectRejectedEvent {
+        version: EVENT_VERSION,
+        project_id,
+    }
+    .publish(env);
 }
 
 pub fn emit_proposal_expired(env: &Env, project_id: u64) {
-    ProposalExpiredEvent { project_id }.publish(env);
+    ProposalExpiredEvent {
+        version: EVENT_VERSION,
+        project_id,
+    }
+    .publish(env);
 }

--- a/apps/onchain/contracts/lumenpulse-curation/src/lib.rs
+++ b/apps/onchain/contracts/lumenpulse-curation/src/lib.rs
@@ -10,7 +10,7 @@ pub use types::{ProjectMetadata, ProjectStatus, ProposalState, VoteRecord};
 
 use soroban_sdk::{contract, contractimpl, token, Address, Env};
 
-use events::*;
+use events::{self, *};
 use storage::*;
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -263,6 +263,13 @@ impl CommunityCurationContract {
 
     pub fn get_verify_threshold_bps(_env: Env) -> u32 {
         VERIFY_THRESHOLD_BPS
+    }
+
+    /// Returns the current event schema version so consumers can detect
+    /// breaking changes in event field layout.  Consumers SHOULD check this
+    /// at startup and compare with their expected version.
+    pub fn get_event_version(_env: Env) -> u32 {
+        events::EVENT_VERSION
     }
 
     // ── Internal Helpers ─────────────────────────────────────────────────────

--- a/apps/onchain/contracts/treasury/src/events.rs
+++ b/apps/onchain/contracts/treasury/src/events.rs
@@ -2,9 +2,24 @@ use soroban_sdk::{contractevent, Address, Env};
 
 use crate::storage::{ProposalAction, ProposalStatus};
 
+// ── Event Versioning ────────────────────────────────────────────────────────
+//
+// All events in this contract carry a `version` field as their first element.
+// Bump `EVENT_VERSION` when the fields of any event are added, removed, or
+// re-ordered. Consumers MUST check the `version` field they receive against
+// the expected value to detect schema drift at runtime.
+//
+// See apps/onchain/EVENTS_GUIDE.md for the canonical pattern.
+
+/// Current schema version for every event emitted by this contract.
+/// Consumers should call `get_event_version()` on the deployed contract to
+/// detect whether their parser is up to date.
+pub const EVENT_VERSION: u32 = 1;
+
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StreamCreatedEvent {
+    pub version: u32,
     #[topic]
     pub beneficiary: Address,
     pub amount: i128,
@@ -15,6 +30,7 @@ pub struct StreamCreatedEvent {
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TokensClaimedEvent {
+    pub version: u32,
     #[topic]
     pub beneficiary: Address,
     pub amount_claimed: i128,
@@ -24,6 +40,7 @@ pub struct TokensClaimedEvent {
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BeneficiaryRotatedEvent {
+    pub version: u32,
     #[topic]
     pub old_beneficiary: Address,
     #[topic]
@@ -37,6 +54,7 @@ pub struct BeneficiaryRotatedEvent {
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProposalCreatedEvent {
+    pub version: u32,
     #[topic]
     pub proposal_id: u64,
     pub proposer: Address,
@@ -48,6 +66,7 @@ pub struct ProposalCreatedEvent {
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SignatureCollectedEvent {
+    pub version: u32,
     #[topic]
     pub proposal_id: u64,
     pub signer: Address,
@@ -59,6 +78,7 @@ pub struct SignatureCollectedEvent {
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProposalExecutedEvent {
+    pub version: u32,
     #[topic]
     pub proposal_id: u64,
     pub executor: Address,
@@ -68,6 +88,7 @@ pub struct ProposalExecutedEvent {
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ProposalCancelledEvent {
+    pub version: u32,
     #[topic]
     pub proposal_id: u64,
     pub cancelled_by: Address,
@@ -76,6 +97,7 @@ pub struct ProposalCancelledEvent {
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MultisigConfiguredEvt {
+    pub version: u32,
     #[topic]
     pub configured_by: Address,
     pub threshold: u32,
@@ -92,6 +114,7 @@ pub fn publish_stream_created(
     duration: u64,
 ) {
     StreamCreatedEvent {
+        version: EVENT_VERSION,
         beneficiary,
         amount,
         start_time,
@@ -107,6 +130,7 @@ pub fn publish_tokens_claimed(
     remaining: i128,
 ) {
     TokensClaimedEvent {
+        version: EVENT_VERSION,
         beneficiary,
         amount_claimed,
         remaining,
@@ -122,6 +146,7 @@ pub fn publish_beneficiary_rotated(
     remaining_amount: i128,
 ) {
     BeneficiaryRotatedEvent {
+        version: EVENT_VERSION,
         old_beneficiary,
         new_beneficiary,
         claimed_amount,
@@ -139,6 +164,7 @@ pub fn publish_proposal_created(
     threshold: u32,
 ) {
     ProposalCreatedEvent {
+        version: EVENT_VERSION,
         proposal_id,
         proposer,
         action,
@@ -157,6 +183,7 @@ pub fn publish_signature_collected(
     status: ProposalStatus,
 ) {
     SignatureCollectedEvent {
+        version: EVENT_VERSION,
         proposal_id,
         signer,
         weight_collected,
@@ -173,6 +200,7 @@ pub fn publish_proposal_executed(
     action: ProposalAction,
 ) {
     ProposalExecutedEvent {
+        version: EVENT_VERSION,
         proposal_id,
         executor,
         action,
@@ -182,6 +210,7 @@ pub fn publish_proposal_executed(
 
 pub fn publish_proposal_cancelled(env: &Env, proposal_id: u64, cancelled_by: Address) {
     ProposalCancelledEvent {
+        version: EVENT_VERSION,
         proposal_id,
         cancelled_by,
     }
@@ -195,9 +224,65 @@ pub fn publish_multisig_configured(
     signer_count: u32,
 ) {
     MultisigConfiguredEvt {
+        version: EVENT_VERSION,
         configured_by,
         threshold,
         signer_count,
+    }
+    .publish(env);
+}
+
+// ── Stream lifecycle events ──────────────────────────────────
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StreamCancelledEvent {
+    pub version: u32,
+    #[topic]
+    pub beneficiary: Address,
+    pub total_unlocked: i128,
+    pub refunded: i128,
+    pub current_time: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EmergencyStopEvent {
+    pub version: u32,
+    #[topic]
+    pub beneficiary: Address,
+    pub reason: soroban_sdk::String,
+    pub refunded: i128,
+}
+
+pub fn publish_stream_cancelled(
+    env: &Env,
+    beneficiary: &Address,
+    total_unlocked: i128,
+    refunded: i128,
+    current_time: u64,
+) {
+    StreamCancelledEvent {
+        version: EVENT_VERSION,
+        beneficiary: beneficiary.clone(),
+        total_unlocked,
+        refunded,
+        current_time,
+    }
+    .publish(env);
+}
+
+pub fn publish_emergency_stop(
+    env: &Env,
+    beneficiary: &Address,
+    reason: soroban_sdk::String,
+    refunded: i128,
+) {
+    EmergencyStopEvent {
+        version: EVENT_VERSION,
+        beneficiary: beneficiary.clone(),
+        reason,
+        refunded,
     }
     .publish(env);
 }

--- a/apps/onchain/contracts/treasury/src/lib.rs
+++ b/apps/onchain/contracts/treasury/src/lib.rs
@@ -410,6 +410,13 @@ impl TreasuryContract {
             .ok_or(TreasuryError::NotInitialized)
     }
 
+    /// Returns the current event schema version so consumers can detect
+    /// breaking changes in event field layout.  Consumers SHOULD check this
+    /// at startup and compare with their expected version.
+    pub fn get_event_version(_env: Env) -> u32 {
+        events::EVENT_VERSION
+    }
+
     // ============================================
     // CANCELLATION & RECOVERY FUNCTIONS
     // ============================================
@@ -461,10 +468,12 @@ impl TreasuryContract {
             token_client.transfer(&contract_address, &beneficiary, &refundable);
         }
 
-        #[allow(deprecated)]
-        env.events().publish(
-            (String::from_str(&env, "stream_cancelled"),),
-            (&beneficiary, total_unlocked, refundable, current_time),
+        events::publish_stream_cancelled(
+            &env,
+            &beneficiary,
+            total_unlocked,
+            refundable,
+            current_time,
         );
 
         env.storage().persistent().remove(&stream_key);
@@ -512,11 +521,7 @@ impl TreasuryContract {
             token_client.transfer(&contract_address, &beneficiary, &full_refund);
         }
 
-        #[allow(deprecated)]
-        env.events().publish(
-            (String::from_str(&env, "emergency_stop"),),
-            (&beneficiary, reason, full_refund),
-        );
+        events::publish_emergency_stop(&env, &beneficiary, reason, full_refund);
 
         env.storage().persistent().remove(&stream_key);
 


### PR DESCRIPTION
## Summary

Standardize event versioning across deployed Soroban smart contracts so backend and data-processing consumers can evolve safely. Every emitted event now carries a `version` field, each contract exposes a `get_event_version()` query, and the pattern is documented for contributors.

## Changes

### Canonical Pattern (`apps/onchain/EVENTS_GUIDE.md`)
- Every event struct includes `version: u32` as its first data (non-topic) field
- Each contract defines `pub const EVENT_VERSION: u32` — bump when fields are added/removed/reordered
- Publish helpers hardcode `version: EVENT_VERSION` — callers cannot override
- Each contract exposes `get_event_version() -> u32` for consumer-side detection

### Contract 1: `lumenpulse-curation` (5 events)
- `ProjectProposedEvent`, `VoteCastEvent`, `ProjectVerifiedEvent`, `ProjectRejectedEvent`, `ProposalExpiredEvent` — all gained `version` field
- Added `get_event_version()` query

### Contract 2: `treasury` (9 events)
- `StreamCreatedEvent`, `TokensClaimedEvent`, `BeneficiaryRotatedEvent`, `ProposalCreatedEvent`, `SignatureCollectedEvent`, `ProposalExecutedEvent`, `ProposalCancelledEvent`, `MultisigConfiguredEvt` — all gained `version` field
- New `StreamCancelledEvent` and `EmergencyStopEvent` (replaced raw `env.events().publish()` calls)
- Added `get_event_version()` query

### Schema Detection for Consumers
- **Startup check**: Call `contract.get_event_version()` — compare with expected parser version
- **Per-event check**: Every event body includes `version` as first field; async/indexer consumers validate per-event

### Documentation
- Created `apps/onchain/EVENTS_GUIDE.md` with full examples, bumping rules, and migration guide for contributors adding new events

## Acceptance Criteria Met
- [x] Core contract events include a consistent versioning strategy
- [x] Event schema changes can be detected by consumers (via `get_event_version()` query)
- [x] Approach is documented for contributors adding new events (`EVENTS_GUIDE.md`)
- [x] At least two contracts adopt the canonical pattern (lumenpulse-curation + treasury)

Closes #1057