### PR TITLE
feat: add feature lineage manifest for ML and derived KPIs (#1065)

### DIFF
--- a/apps/data-processing/LINEAGE.md
+++ b/apps/data-processing/LINEAGE.md
@@ -1,0 +1,290 @@
+# Feature & KPI Lineage
+
+This document explains how the lineage manifest works, how to read it, and
+what to do when you add or change a feature or KPI.  It is the primary
+onboarding guide for contributors working on the data-processing module.
+
+---
+
+## What is lineage and why does it matter?
+
+Every number that LumenPulse shows a user — a market health score, a
+sentiment badge, a cohort retention rate — is derived from raw data through
+a chain of transformations.  Without documentation of that chain:
+
+- Bugs hide because no-one knows which source feeds which output.
+- Computed metrics drift silently when upstream code changes.
+- New contributors spend hours reverse-engineering pipelines before writing
+  a single line of code.
+- Ownership is unclear, so incidents have no obvious point of contact.
+
+The lineage manifest makes that chain explicit and machine-readable.
+
+---
+
+## Where is the manifest?
+
+```
+apps/data-processing/
+└── src/
+    └── lineage/
+        ├── __init__.py               # Python package; exposes MANIFEST_PATH
+        └── feature_lineage.yaml      # ← THE manifest  (edit this file)
+```
+
+The manifest lives next to the pipeline code so that `git diff` on a source
+file naturally prompts you to update the adjacent manifest.
+
+---
+
+## Quick start for contributors
+
+```bash
+# 1. Validate the manifest (runs all checks)
+cd apps/data-processing
+python scripts/validate_lineage.py
+
+# 2. Print a summary of all registered features and KPIs
+python scripts/validate_lineage.py --summary
+
+# 3. Inspect a specific entry (e.g. the market health score)
+python scripts/validate_lineage.py --show market_health_score
+
+# 4. Verify that every source_file path actually exists
+python scripts/validate_lineage.py --check-files
+
+# 5. Machine-readable output for CI pipelines
+python scripts/validate_lineage.py --json
+```
+
+---
+
+## Manifest structure
+
+The manifest is a YAML file with three top-level sections:
+
+```yaml
+manifest_version: "1.0"
+project: lumenpulse
+module: data-processing
+
+ml_feature_sets:    # ML input features
+  - id: ...
+
+kpi_datasets:       # Derived metrics surfaced via the API
+  - id: ...
+```
+
+### Entry schema
+
+Every entry (whether an ML feature set or a KPI dataset) **must** contain:
+
+| Key            | Type   | Description                                               |
+|----------------|--------|-----------------------------------------------------------|
+| `id`           | str    | Unique snake_case identifier.  Never re-use a deleted id. |
+| `display_name` | str    | Human-readable label shown in summaries.                  |
+| `description`  | str    | What this feature/KPI is and why it exists.               |
+| `owner`        | str    | Email (`you@domain`) or GitHub handle (`@username`).      |
+| `source_file`  | str    | Path (relative to `apps/data-processing`) to the file     |
+|                |        | where this is computed.                                   |
+
+Entries **should** also contain:
+
+| Key           | Description                                                  |
+|---------------|--------------------------------------------------------------|
+| `formula`     | Mathematical or algorithmic definition.                      |
+| `inputs`      | List of upstream features/tables/services this depends on.   |
+| `downstream`  | Files/APIs that consume this output.                         |
+| `storage`     | Where the result is stored (table, file, in-memory, etc.).   |
+| `update_cadence` | How often this is recomputed.                             |
+
+---
+
+## Registered ML Feature Sets
+
+### `price_predictor_features`
+
+Source: `src/ml/feature_store.py`  
+Model: `src/ml/price_predictor.py`  
+Registry key: `price_predictor`
+
+Three time-aligned columns fetched per asset and outer-merged on timestamp:
+
+| Feature          | Range       | Source view / service               |
+|------------------|-------------|--------------------------------------|
+| `sentiment_score`| [-1.0, 1.0] | `asset_sentiment_view` → SentimentAnalyzer |
+| `volume`         | [0, ∞)      | `asset_volume_view` → StellarFetcher |
+| `volatility`     | [0, ∞)      | `asset_volatility_view` → PriceFetcher |
+
+Gaps are forward-filled then filled with 0.  The target column is supplied
+by the caller at training time.
+
+Quality gate: `MIN_PRICE_R2` env var (default `-1.0`; tighten in production).
+
+---
+
+### `sentiment_model_features`
+
+Source: `src/ml/retraining_pipeline.py`  
+Model: `src/analytics/sentiment.py`  
+Registry key: `sentiment`
+
+The "features" here are lexicon entries that extend the VADER base lexicon:
+
+| Component              | Description                                               |
+|------------------------|-----------------------------------------------------------|
+| `vader_base_lexicon`   | ~7,500 built-in VADER tokens.                             |
+| `crypto_slang_lexicon` | Custom extensions from `data/crypto_slang_lexicon.json`.  |
+| `finbert_transformer`  | ProsusAI/FinBERT (HuggingFace); used for English when the `transformers` library is installed and `SENTIMENT_DISABLE_TRANSFORMER != true`. |
+
+---
+
+## Registered KPI Datasets
+
+### `market_health_score`
+
+```
+market_health_score = (sentiment_score × 0.7) + (tanh(volume_change) × 0.3)
+```
+
+Output range `(-1, 1)`.  Classified as:
+
+- `bullish`  when score > 0.2
+- `bearish`  when score < −0.2
+- `neutral`  otherwise
+
+Consumed by: `forecaster.py`, `GET /api/market-analysis`.  
+Written to: `data/analytics.jsonl`.
+
+---
+
+### `sentiment_compound`
+
+Per-text score from `SentimentAnalyzer`:
+
+- **English**: FinBERT primary, VADER + crypto-keyword boost as fallback.
+- **Spanish / Portuguese**: keyword-hit ratio.
+
+Range `[-1, 1]`.  Thresholds: bullish ≥ 0.05, bearish ≤ −0.05.  
+Stored in: `articles.sentiment_score` (PostgreSQL).
+
+---
+
+### `cohort_metrics`
+
+Produced by `CohortAnalyzer` from on-chain Soroban contribution events.
+Key fields: `retention_rate`, `avg_contributed_per_member`, `member_count`.
+Stored in: `cohort_members`, `cohort_analysis_results` tables.
+
+---
+
+### `attribution_score`
+
+Weighted average of five signals (weights sum to 1.0):
+
+| Signal               | Weight |
+|----------------------|--------|
+| `entity_link`        | 0.35   |
+| `mention`            | 0.25   |
+| `keyword`            | 0.20   |
+| `sentiment_coherence`| 0.10   |
+| `category`           | 0.10   |
+
+Confidence tiers: high ≥ 0.75 | medium ≥ 0.50 | low ≥ 0.25 | very_low < 0.25.  
+Stored in: `narrative_attribution_scores` table.
+
+---
+
+### `round_anomaly_signals`
+
+Statistical anomaly signals for quadratic-funding rounds:
+`CONCENTRATION_RISK`, `SYBIL_SUSPICION`, `UNUSUAL_TIMING`,
+`DISPROPORTIONATE_ALLOCATION`, `LOW_PARTICIPATION`,
+`HIGH_SINGLE_CONTRIBUTION`.  
+Stored in: `round_anomaly_signals` table.
+
+---
+
+### `project_verification_trend`
+
+Approval / rejection rates over sliding windows, with trend direction
+(`improving` | `declining` | `stable`) derived from delta vs. previous
+window.  Not persisted — returned in API response.
+
+---
+
+### `correlation_result`
+
+Pearson r between sentiment scores and price or volume series.  
+Includes p-value, confidence level, optional time-lag, and scatter data.  
+Not persisted — returned in `GET /api/correlation`.
+
+---
+
+### `market_forecast`
+
+24h / 48h predictions of `market_health_score`.  Auto-selects backend:
+Prophet → scikit-learn Ridge → heuristic decay.  
+Source data: `data/analytics.jsonl`.
+
+---
+
+### `anomaly_detection_result`
+
+Z-Score + Isolation Forest detector for volume / sentiment spikes.  
+Rolling 24-hour window, z-threshold 2.5.  
+Triggers alerts via `alert_notifier` / `alertbot`.
+
+---
+
+## How to update the manifest
+
+### Adding a new feature or KPI
+
+1. Implement the computation in the appropriate source file.
+2. Open `src/lineage/feature_lineage.yaml`.
+3. Add a new entry under `ml_feature_sets` or `kpi_datasets`.
+4. Fill in **all required keys** (`id`, `display_name`, `description`,
+   `owner`, `source_file`) plus as many optional keys as you can.
+5. Run `python scripts/validate_lineage.py --check-files` and fix any
+   errors before opening a PR.
+
+### Changing an existing computation
+
+1. Make your code change.
+2. Find the corresponding entry in the manifest by its `id`.
+3. Update `formula`, `inputs`, `output_fields`, or any other affected keys.
+4. If ownership has changed, update `owner`.
+5. Re-run the validator.
+
+### Removing a feature or KPI
+
+1. Mark the entry with `deprecated: true` and add a `deprecated_reason`
+   field — do **not** delete it immediately, so that audit trails are
+   preserved.
+2. After one release cycle, remove the entry entirely.
+3. Never re-use a deleted `id`.
+
+---
+
+## CI enforcement
+
+The validator is designed to be dropped into any CI pipeline:
+
+```yaml
+# GitHub Actions example
+- name: Validate lineage manifest
+  run: |
+    cd apps/data-processing
+    python scripts/validate_lineage.py --json --check-files
+```
+
+Exit code 0 = valid.  Exit code 1 = errors; details in stdout JSON.
+
+---
+
+## Who to contact
+
+All entries are owned by `data-team@lumenpulse.io`.  For feature-specific
+questions, check the `owner` field in the manifest or look at the
+`source_file` for the Git blame trail.

--- a/apps/data-processing/README.md
+++ b/apps/data-processing/README.md
@@ -5,8 +5,30 @@ This service handles compute-heavy tasks such as sentiment analysis and market t
 ## Project Structure
 
 - `src/`: Core logic and service implementation.
+- `src/lineage/`: Feature and KPI lineage manifest (`feature_lineage.yaml`).
 - `tests/`: Unit and integration tests.
 - `scripts/`: Helper scripts for data management and development.
+
+## Feature & KPI Lineage
+
+All ML features and derived KPIs are documented in the lineage manifest so
+contributors can trace how every number is computed, who owns it, and what
+it feeds into.
+
+**Quick links:**
+- Manifest file: [`src/lineage/feature_lineage.yaml`](src/lineage/feature_lineage.yaml)
+- Contributor guide: [`LINEAGE.md`](LINEAGE.md)
+
+```bash
+# Validate the manifest
+python scripts/validate_lineage.py
+
+# Print a human-readable summary
+python scripts/validate_lineage.py --summary
+
+# Inspect a single entry
+python scripts/validate_lineage.py --show market_health_score
+```
 
 ## Setup Instructions
 

--- a/apps/data-processing/scripts/validate_lineage.py
+++ b/apps/data-processing/scripts/validate_lineage.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""
+validate_lineage.py — Validate and inspect the feature/KPI lineage manifest.
+
+Usage
+-----
+# Validate (exit 0 on success, 1 on error)
+python scripts/validate_lineage.py
+
+# Pretty-print a summary of all registered entries
+python scripts/validate_lineage.py --summary
+
+# Show detail for a specific entry by id
+python scripts/validate_lineage.py --show market_health_score
+python scripts/validate_lineage.py --show price_predictor_features
+
+# Verify that all source_file paths referenced in the manifest exist
+python scripts/validate_lineage.py --check-files
+
+# Output as JSON (useful for CI / downstream tooling)
+python scripts/validate_lineage.py --json
+
+Validation rules
+----------------
+1. YAML parses without errors.
+2. Top-level keys ``manifest_version``, ``project``, ``module`` are present.
+3. At least one entry in ``ml_feature_sets`` and one in ``kpi_datasets``.
+4. Every entry has ``id``, ``display_name``, ``description``, ``owner``,
+   ``source_file``.
+5. No duplicate ``id`` values across the whole manifest.
+6. ``owner`` values look like an email address or a GitHub handle (``@…``).
+7. (--check-files) Every ``source_file`` and ``model_file`` path resolves
+   relative to the data-processing root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML is not installed.  Run: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+# ── Paths ──────────────────────────────────────────────────────────────────
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_ROOT = _SCRIPT_DIR.parent                          # apps/data-processing/
+_MANIFEST = _ROOT / "src" / "lineage" / "feature_lineage.yaml"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_HANDLE_RE = re.compile(r"^@\S+$")
+
+_REQUIRED_TOP_KEYS = {"manifest_version", "project", "module"}
+_REQUIRED_ENTRY_KEYS = {"id", "display_name", "description", "owner", "source_file"}
+
+
+def _looks_like_owner(value: str) -> bool:
+    """Accept email addresses and GitHub-style @handles."""
+    return bool(_EMAIL_RE.match(value) or _HANDLE_RE.match(value))
+
+
+# ── Loader ─────────────────────────────────────────────────────────────────
+
+def load_manifest(path: Path = _MANIFEST) -> Dict[str, Any]:
+    """Parse and return the manifest YAML.  Raises on parse error."""
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        raise ValueError("Manifest root must be a YAML mapping.")
+    return data
+
+
+# ── Validation ─────────────────────────────────────────────────────────────
+
+def _collect_errors(
+    manifest: Dict[str, Any],
+    check_files: bool = False,
+    root: Path = _ROOT,
+) -> List[str]:
+    errors: List[str] = []
+
+    # Rule 2 – required top-level keys
+    for key in _REQUIRED_TOP_KEYS:
+        if key not in manifest:
+            errors.append(f"Missing top-level key: '{key}'")
+
+    # Rule 3 – at least one entry in each section
+    ml_sets: List[Dict] = manifest.get("ml_feature_sets") or []
+    kpi_sets: List[Dict] = manifest.get("kpi_datasets") or []
+
+    if not ml_sets:
+        errors.append("'ml_feature_sets' is empty or missing — at least one entry required.")
+    if not kpi_sets:
+        errors.append("'kpi_datasets' is empty or missing — at least one entry required.")
+
+    all_entries: List[Tuple[str, Dict]] = (
+        [("ml_feature_sets", e) for e in ml_sets]
+        + [("kpi_datasets", e) for e in kpi_sets]
+    )
+
+    # Rule 4 – required entry-level keys
+    for section, entry in all_entries:
+        entry_id = entry.get("id", "<unknown>")
+        for key in _REQUIRED_ENTRY_KEYS:
+            if key not in entry:
+                errors.append(f"[{section}/{entry_id}] Missing required key: '{key}'")
+
+    # Rule 5 – no duplicate IDs
+    all_ids = [e.get("id") for _, e in all_entries if "id" in e]
+    seen: set = set()
+    for eid in all_ids:
+        if eid in seen:
+            errors.append(f"Duplicate 'id' value: '{eid}'")
+        seen.add(eid)
+
+    # Rule 6 – owner format
+    for section, entry in all_entries:
+        owner = entry.get("owner", "")
+        if owner and not _looks_like_owner(str(owner)):
+            errors.append(
+                f"[{section}/{entry.get('id', '?')}] 'owner' value '{owner}' "
+                "does not look like an email or @handle."
+            )
+
+    # Rule 7 – file existence (optional)
+    if check_files:
+        file_keys = ("source_file", "model_file")
+        for section, entry in all_entries:
+            entry_id = entry.get("id", "<unknown>")
+            for key in file_keys:
+                fpath = entry.get(key)
+                if fpath and not (root / fpath).exists():
+                    errors.append(
+                        f"[{section}/{entry_id}] {key} not found: '{fpath}'"
+                    )
+
+    return errors
+
+
+def validate(
+    path: Path = _MANIFEST,
+    check_files: bool = False,
+) -> Tuple[bool, Dict[str, Any], List[str]]:
+    """
+    Validate the lineage manifest.
+
+    Returns:
+        (ok, manifest_dict, errors_list)
+    """
+    try:
+        manifest = load_manifest(path)
+    except Exception as exc:
+        return False, {}, [f"YAML parse error: {exc}"]
+
+    errors = _collect_errors(manifest, check_files=check_files)
+    return len(errors) == 0, manifest, errors
+
+
+# ── Display helpers ────────────────────────────────────────────────────────
+
+def _entry_summary(entry: Dict[str, Any]) -> str:
+    lines = [
+        f"  id          : {entry.get('id', '-')}",
+        f"  display     : {entry.get('display_name', '-')}",
+        f"  owner       : {entry.get('owner', '-')}",
+        f"  source_file : {entry.get('source_file', '-')}",
+    ]
+    desc = entry.get("description", "").strip().replace("\n", " ")
+    if len(desc) > 100:
+        desc = desc[:97] + "…"
+    lines.append(f"  description : {desc}")
+    return "\n".join(lines)
+
+
+def print_summary(manifest: Dict[str, Any]) -> None:
+    ml_sets = manifest.get("ml_feature_sets") or []
+    kpi_sets = manifest.get("kpi_datasets") or []
+
+    print(f"\n{'='*60}")
+    print(f"  LumenPulse Feature Lineage Manifest  v{manifest.get('manifest_version', '?')}")
+    print(f"  Module : {manifest.get('module', '?')}  |  Project : {manifest.get('project', '?')}")
+    print(f"{'='*60}\n")
+
+    print(f"ML Feature Sets ({len(ml_sets)})")
+    print("-" * 40)
+    for entry in ml_sets:
+        print(_entry_summary(entry))
+        print()
+
+    print(f"KPI Datasets ({len(kpi_sets)})")
+    print("-" * 40)
+    for entry in kpi_sets:
+        print(_entry_summary(entry))
+        print()
+
+
+def print_entry(manifest: Dict[str, Any], entry_id: str) -> None:
+    all_entries = list(manifest.get("ml_feature_sets") or []) + list(
+        manifest.get("kpi_datasets") or []
+    )
+    matches = [e for e in all_entries if e.get("id") == entry_id]
+    if not matches:
+        print(f"No entry found with id='{entry_id}'", file=sys.stderr)
+        sys.exit(1)
+
+    entry = matches[0]
+    print(f"\n{'='*60}")
+    print(f"  {entry.get('display_name', entry_id)}")
+    print(f"{'='*60}")
+    print(yaml.dump(entry, default_flow_style=False, sort_keys=False, allow_unicode=True))
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate and inspect the LumenPulse feature lineage manifest.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=_MANIFEST,
+        help=f"Path to manifest YAML (default: {_MANIFEST})",
+    )
+    parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print a human-readable summary of all registered entries.",
+    )
+    parser.add_argument(
+        "--show",
+        metavar="ID",
+        help="Print full detail for a specific entry id.",
+    )
+    parser.add_argument(
+        "--check-files",
+        action="store_true",
+        help="Verify that source_file / model_file paths exist on disk.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output validation result as JSON (for CI pipelines).",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    ok, manifest, errors = validate(
+        path=args.manifest,
+        check_files=args.check_files,
+    )
+
+    if args.json:
+        result = {
+            "valid": ok,
+            "manifest_path": str(args.manifest),
+            "ml_feature_sets": len(manifest.get("ml_feature_sets") or []),
+            "kpi_datasets": len(manifest.get("kpi_datasets") or []),
+            "errors": errors,
+        }
+        print(json.dumps(result, indent=2))
+        return 0 if ok else 1
+
+    if not ok:
+        print(f"\n❌  Manifest validation FAILED  ({len(errors)} error(s))\n")
+        for i, err in enumerate(errors, 1):
+            print(f"  {i}. {err}")
+        print()
+        return 1
+
+    # Validation passed
+    ml_count = len(manifest.get("ml_feature_sets") or [])
+    kpi_count = len(manifest.get("kpi_datasets") or [])
+    print(
+        f"\n✅  Manifest is valid  "
+        f"({ml_count} ML feature set(s), {kpi_count} KPI dataset(s))\n"
+    )
+
+    if args.summary:
+        print_summary(manifest)
+
+    if args.show:
+        print_entry(manifest, args.show)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/data-processing/src/lineage/__init__.py
+++ b/apps/data-processing/src/lineage/__init__.py
@@ -1,0 +1,18 @@
+"""
+src/lineage — Feature and KPI lineage manifest package.
+
+The canonical lineage manifest lives in ``feature_lineage.yaml`` (this
+directory). Use the ``load_manifest()`` helper to parse and validate it
+programmatically, or run the CLI validator:
+
+    python scripts/validate_lineage.py
+
+For schema and contributor guidance see ``LINEAGE.md`` in the root of the
+data-processing module.
+"""
+
+from pathlib import Path
+
+MANIFEST_PATH: Path = Path(__file__).parent / "feature_lineage.yaml"
+
+__all__ = ["MANIFEST_PATH"]

--- a/apps/data-processing/src/lineage/feature_lineage.yaml
+++ b/apps/data-processing/src/lineage/feature_lineage.yaml
@@ -1,0 +1,495 @@
+# ============================================================
+# LumenPulse Data-Processing — Feature & KPI Lineage Manifest
+# ============================================================
+# Purpose : Document how every ML feature and derived KPI is
+#           produced so contributors can trace lineage, avoid
+#           accidental drift, and know who to contact.
+#
+# Schema version : 1.0
+# Last updated   : 2026-07-24
+# Maintainer     : data-team@lumenpulse.io
+#
+# How to validate this file:
+#   python scripts/validate_lineage.py
+# ============================================================
+
+manifest_version: "1.0"
+project: lumenpulse
+module: data-processing
+
+# ============================================================
+# ML FEATURE SETS
+# Feature sets consumed by trained models.
+# ============================================================
+ml_feature_sets:
+
+  # ----------------------------------------------------------
+  - id: price_predictor_features
+    display_name: Price Predictor Feature Set
+    description: >
+      Time-aligned feature matrix fed to the PricePredictor scikit-learn
+      pipeline (LinearRegression + StandardScaler). Features are fetched
+      per asset over a configurable look-back window from three database
+      views and outer-merged on timestamp before forward-filling gaps.
+    owner: data-team@lumenpulse.io
+    source_file: src/ml/feature_store.py
+    model_file: src/ml/price_predictor.py
+    registry_key: price_predictor          # key used in src/ml/model_registry.py
+    update_cadence: on-demand (retraining pipeline)
+    storage: models/price_predictor/current -> v<major>.<minor>.pkl
+
+    features:
+      - name: sentiment_score
+        type: float
+        range: "[-1.0, 1.0]"
+        description: >
+          Per-asset compound sentiment score from SentimentAnalyzer
+          (FinBERT primary, VADER fallback with crypto-slang boost).
+        source_table: asset_sentiment_view
+        upstream:
+          - src/analytics/sentiment.py::SentimentAnalyzer.analyze_text
+          - src/ingestion/news_fetcher.py
+          - src/ingestion/social_fetcher.py
+        null_handling: forward-fill then fill 0
+
+      - name: volume
+        type: float
+        range: "[0, +inf)"
+        description: >
+          Total XLM-equivalent on-chain transaction volume for the asset
+          over the query window, sourced from Stellar Horizon via
+          StellarFetcher.
+        source_table: asset_volume_view
+        upstream:
+          - src/ingestion/stellar_fetcher.py::get_asset_volume
+        null_handling: forward-fill then fill 0
+
+      - name: volatility
+        type: float
+        range: "[0, +inf)"
+        description: >
+          Rolling price volatility (standard deviation of log-returns)
+          pre-computed and stored in the volatility view.
+        source_table: asset_volatility_view
+        upstream:
+          - src/ingestion/price_fetcher.py::PriceFetcher
+        null_handling: forward-fill then fill 0
+
+    merge_strategy: outer join on timestamp, sort ascending, ffill → fillna(0)
+    target_column: target   # set by caller at training time
+
+    quality_gates:
+      min_price_r2: -1.0    # env: MIN_PRICE_R2 (permissive default; tighten in prod)
+
+  # ----------------------------------------------------------
+  - id: sentiment_model_features
+    display_name: Sentiment Model — Training Corpus Features
+    description: >
+      Features used to enrich the VADER lexicon with a custom
+      crypto-slang dictionary during scheduled retraining.  Not a
+      traditional feature matrix — the "features" are lexicon entries
+      (word → sentiment_score mappings) that extend VADER at runtime.
+    owner: data-team@lumenpulse.io
+    source_file: src/ml/retraining_pipeline.py
+    model_file: src/analytics/sentiment.py
+    registry_key: sentiment
+    update_cadence: scheduled (retraining_pipeline trigger)
+    storage: models/sentiment/current -> v<major>.<minor>.pkl
+
+    features:
+      - name: vader_base_lexicon
+        type: dict[str, float]
+        description: >
+          Built-in VADER lexicon (≈7,500 tokens).  Loaded automatically
+          by vaderSentiment.SentimentIntensityAnalyzer.
+        upstream:
+          - vaderSentiment (third-party library)
+        null_handling: n/a
+
+      - name: crypto_slang_lexicon
+        type: dict[str, float]
+        description: >
+          Custom extensions for crypto terms (e.g. "moon", "rekt", "wen
+          lambo").  Loaded from data/crypto_slang_lexicon.json at
+          retraining time.  Merged into VADER via
+          SentimentIntensityAnalyzer.lexicon.update(slang).
+        source_file: data/crypto_slang_lexicon.json
+        upstream:
+          - src/ml/retraining_pipeline.py::_load_crypto_slang
+        null_handling: missing file → empty dict, base VADER only
+
+      - name: finbert_transformer
+        type: model_weights
+        description: >
+          ProsusAI/finbert (HuggingFace) used as primary English scorer
+          when transformers library is available and
+          SENTIMENT_DISABLE_TRANSFORMER != true.  Falls back to VADER
+          compound if inference fails.
+        upstream:
+          - HuggingFace Hub (ProsusAI/finbert)
+          - src/analytics/sentiment.py::SentimentAnalyzer._finbert_compound
+        null_handling: inference failure → VADER fallback silently
+
+    quality_gates:
+      min_sentiment_coverage: 0.0   # env: MIN_SENTIMENT_COVERAGE
+
+
+# ============================================================
+# KPI DATASETS
+# Derived metrics surfaced via the API and stored to the DB.
+# ============================================================
+kpi_datasets:
+
+  # ----------------------------------------------------------
+  - id: market_health_score
+    display_name: Market Health Score
+    description: >
+      Weighted combination of sentiment and normalised volume change
+      that summarises overall market mood for a Stellar asset.  Used
+      as the primary market signal in news feed cards and dashboards.
+    owner: data-team@lumenpulse.io
+    source_file: src/analytics/market_analyzer.py
+    class: MarketAnalyzer
+
+    formula: >
+      market_health_score = (sentiment_score × 0.7) + (tanh(volume_change) × 0.3)
+    output_range: "(-1.0, 1.0)"
+    classification:
+      bullish:  score > 0.2
+      bearish:  score < -0.2
+      neutral:  -0.2 ≤ score ≤ 0.2
+
+    inputs:
+      - name: sentiment_score
+        type: float
+        range: "[-1.0, 1.0]"
+        upstream: ml_feature_sets.price_predictor_features.sentiment_score
+
+      - name: volume_change
+        type: float
+        description: Percentage change in asset volume (e.g. 0.15 = 15% increase).
+        upstream:
+          - src/ingestion/stellar_fetcher.py::get_asset_volume
+
+    downstream:
+      - src/analytics/forecaster.py  (ForecastResult.forecast_score_24h / _48h)
+      - src/api/server.py            (GET /api/market-analysis)
+
+    storage: in-memory + data/analytics.jsonl (append)
+
+  # ----------------------------------------------------------
+  - id: sentiment_compound
+    display_name: Article / Social Sentiment Score
+    description: >
+      Per-text compound sentiment score produced by SentimentAnalyzer.
+      English: FinBERT primary → VADER + crypto-keyword boost fallback.
+      Spanish / Portuguese: keyword-hit ratio.
+      Range clamped to [-1, 1].
+    owner: data-team@lumenpulse.io
+    source_file: src/analytics/sentiment.py
+    class: SentimentAnalyzer
+
+    inputs:
+      - name: raw_text
+        type: str
+        upstream:
+          - src/ingestion/news_fetcher.py
+          - src/ingestion/social_fetcher.py
+
+      - name: lang_hint
+        type: str (optional ISO 639-1)
+        description: Overrides langdetect auto-detection when provided.
+
+    output_fields:
+      - score:                float in [-1, 1]
+      - language:             detected ISO code
+      - language_supported:   bool
+      - language_unsupported: bool
+
+    thresholds:
+      bullish: score ≥ 0.05
+      bearish: score ≤ -0.05
+      neutral: -0.05 < score < 0.05
+
+    downstream:
+      - ml_feature_sets.price_predictor_features.sentiment_score
+      - kpi_datasets.market_health_score
+      - kpi_datasets.correlation_result
+      - src/analytics/sentiment_indicators.py  (visual badge colour)
+      - src/api/server.py (GET /api/sentiment)
+
+    storage: articles.sentiment_score column (PostgreSQL via alembic migration 001)
+
+  # ----------------------------------------------------------
+  - id: cohort_metrics
+    display_name: Contributor Cohort Metrics
+    description: >
+      Aggregated participation and retention statistics for contributor
+      cohorts in Stellar quadratic-funding rounds.  Produced by
+      CohortAnalyzer and stored in the cohort_analysis DB tables.
+    owner: data-team@lumenpulse.io
+    source_file: src/analytics/cohort_analyzer.py
+    class: CohortAnalyzer
+
+    inputs:
+      - name: contribution_events
+        type: list[ContributionRecord]
+        upstream:
+          - src/ingestion/stellar_fetcher.py (on-chain Soroban events)
+          - src/db/cohort_models.py
+
+    output_fields:
+      - cohort_id:               str
+      - member_count:            int
+      - total_contributed:       float (XLM)
+      - avg_contributed_per_member: float (XLM)
+      - retention_rate:          float [0, 1] — fraction of cohort members
+                                  who returned in a subsequent round
+      - retained_total_contributed: float (XLM)
+
+    cohort_types:
+      - FIRST_ROUND:        initial round participants
+      - TIME_WINDOW:        participants within a date range
+      - REPEAT:             2–5 rounds participation
+      - SUPER_CONTRIBUTOR:  6+ rounds or high total contribution
+
+    downstream:
+      - src/api/server.py (GET /api/cohort-analysis)
+      - data/analytics.jsonl (export)
+
+    storage:
+      tables: [cohort_members, cohort_analysis_results, contributor_cohort_snapshots]
+      migration: alembic/versions/006_add_cohort_analysis_tables.py
+
+  # ----------------------------------------------------------
+  - id: attribution_score
+    display_name: Contributor / Project Attribution Score
+    description: >
+      Weighted signal score (0–1) measuring how strongly a news narrative
+      is attributable to a specific contributor or project rather than
+      the broader ecosystem.
+    owner: data-team@lumenpulse.io
+    source_file: src/analytics/attribution_scorer.py
+    class: AttributionScorer
+
+    formula: >
+      attribution_score = Σ(signal_weight × signal_value)
+      where signals and weights are:
+        entity_link        × 0.35
+        mention            × 0.25
+        keyword            × 0.20
+        sentiment_coherence× 0.10
+        category           × 0.10
+
+    output_range: "[0.0, 1.0]"
+    confidence_tiers:
+      high:     score ≥ 0.75
+      medium:   0.50 ≤ score < 0.75
+      low:      0.25 ≤ score < 0.50
+      very_low: score < 0.25  # flagged low_confidence=True; callers should skip
+
+    inputs:
+      - name: article_json
+        type: dict
+        upstream:
+          - src/ingestion/news_fetcher.py
+          - src/db/models.py::Article
+
+      - name: target
+        type: AttributionTarget (target_id, aliases, categories, …)
+        upstream: caller-provided
+
+    downstream:
+      - src/api/server.py (GET /api/attribution)
+      - alembic/versions/006_add_narrative_attribution_scores.py
+
+    storage:
+      table: narrative_attribution_scores
+      migration: alembic/versions/006_add_narrative_attribution_scores.py
+
+  # ----------------------------------------------------------
+  - id: round_anomaly_signals
+    display_name: Round Anomaly Detection Signals
+    description: >
+      Per-round / per-project anomaly signals for suspicious allocation
+      patterns in quadratic-funding rounds.  Produced by
+      RoundAnomalyDetector using statistical thresholds.
+    owner: data-team@lumenpulse.io
+    source_file: src/round_anomaly_detector.py
+    class: RoundAnomalyDetector
+
+    output_fields:
+      - anomaly_type:       enum (CONCENTRATION_RISK | SYBIL_SUSPICION |
+                                  UNUSUAL_TIMING | DISPROPORTIONATE_ALLOCATION |
+                                  LOW_PARTICIPATION | HIGH_SINGLE_CONTRIBUTION)
+      - severity_score:     float [0, 1]
+      - detection_rationale: str
+      - metric_values:      dict (raw metrics that triggered the signal)
+      - threshold_used:     float
+
+    inputs:
+      - name: round_contributions
+        type: list[ContributionRecord]
+        upstream:
+          - src/ingestion/stellar_fetcher.py (Soroban contract events)
+
+    downstream:
+      - src/api/server.py (GET /api/anomaly-detection)
+      - alertbot / alert_notifier
+
+    storage:
+      table: round_anomaly_signals
+      migration: alembic/versions/004_add_round_anomaly_signals.py
+
+  # ----------------------------------------------------------
+  - id: project_verification_trend
+    display_name: Project Verification Trend
+    description: >
+      Aggregated approval / rejection rates for Soroban project
+      verification events over sliding windows; detects momentum
+      shifts in the community review pipeline.
+    owner: data-team@lumenpulse.io
+    source_file: src/analytics/project_verification_trend.py
+    class: ProjectVerificationTrendAnalyzer
+
+    output_fields:
+      - approval_rate:           float [0, 1]
+      - rejection_rate:          float [0, 1]
+      - trend_direction:         str (improving | declining | stable)
+      - delta:                   float  (approval_rate − previous_approval_rate)
+      - total / approved / rejected / pending: int counts
+
+    inputs:
+      - name: verification_events
+        type: list[VerificationRecord]
+        upstream:
+          - src/ingestion/stellar_fetcher.py (on-chain verification events)
+          - src/db/postgres_service.py
+
+    downstream:
+      - src/api/server.py (GET /api/project-trends)
+
+    storage: in-memory result; optionally persisted by caller
+
+  # ----------------------------------------------------------
+  - id: correlation_result
+    display_name: Sentiment ↔ Price/Volume Correlation
+    description: >
+      Pearson correlation coefficient between asset sentiment scores
+      and on-chain price or volume metrics over a configurable window.
+      Exposes scatter data and a natural-language interpretation.
+    owner: data-team@lumenpulse.io
+    source_file: src/analytics/correlation_engine.py
+    class: CorrelationEngine
+
+    formula: >
+      r = Pearson(sentiment_series, metric_series)
+      p_value via scipy.stats.pearsonr
+
+    output_fields:
+      - correlation_score:  float [-1, 1]  (Pearson r)
+      - p_value:            float          (statistical significance)
+      - confidence_level:   str (high | medium | low | insufficient_data)
+      - lag_hours:          int            (time-shift applied before correlation)
+      - scatter_data:       list[DataPoint]
+
+    inputs:
+      - name: sentiment_series
+        type: list[float]
+        upstream: kpi_datasets.sentiment_compound
+
+      - name: price_series
+        type: list[float]
+        upstream:
+          - src/ingestion/price_fetcher.py::PriceFetcher
+
+      - name: volume_series
+        type: list[float]
+        upstream:
+          - src/ingestion/stellar_fetcher.py::get_asset_volume
+
+    downstream:
+      - src/api/server.py (GET /api/correlation)
+
+    storage: returned in API response; not persisted
+
+  # ----------------------------------------------------------
+  - id: market_forecast
+    display_name: 24h / 48h Market Trend Forecast
+    description: >
+      Time-series forecast of market_health_score for the next 24 and 48
+      hours.  Backend auto-selected at runtime: Prophet (preferred) →
+      scikit-learn Ridge → heuristic decay fallback.
+    owner: data-team@lumenpulse.io
+    source_file: src/analytics/forecaster.py
+
+    formula: >
+      Uses historical market_health_score series from data/analytics.jsonl.
+      Sentiment Velocity = dS/dt of mood (Δsentiment per hour).
+      Confidence mapped from |predicted_score|: near 0 → 0.5, near ±1 → 0.95.
+
+    output_fields:
+      - predicted_trend_24h:  str (bullish | bearish | neutral)
+      - predicted_trend_48h:  str
+      - confidence_24h:       float [0, 1]
+      - confidence_48h:       float [0, 1]
+      - sentiment_velocity:   float (Δsentiment/hour)
+      - forecast_score_24h:   float
+      - forecast_score_48h:   float
+      - model_backend:        str (prophet | sklearn | heuristic)
+
+    inputs:
+      - name: historical_analytics
+        type: JSONL records
+        source_file: data/analytics.jsonl
+        upstream: kpi_datasets.market_health_score
+
+    classification_thresholds:
+      bullish: score > 0.2
+      bearish: score < -0.2
+      neutral: -0.2 ≤ score ≤ 0.2
+
+    downstream:
+      - src/api/server.py (GET /api/forecast)
+
+    storage: data/analytics.jsonl read-only at inference time
+
+  # ----------------------------------------------------------
+  - id: anomaly_detection_result
+    display_name: Volume / Sentiment Anomaly Detection
+    description: >
+      Statistical (Z-Score) and ML (Isolation Forest) detection of
+      abnormal spikes in trade volume or social sentiment.  Also
+      supports multi-dimensional Isolation Forest for pump-and-dump
+      pattern detection.
+    owner: data-team@lumenpulse.io
+    source_file: src/anomaly_detector.py
+    class: AnomalyDetector
+    model_artifact: models/test_anomaly_model.pkl
+
+    output_fields:
+      - is_anomaly:          bool
+      - severity_score:      float [0, 1]
+      - z_score:             float
+      - ml_anomaly_score:    float (Isolation Forest score; lower = more anomalous)
+      - ml_is_anomaly:       bool
+
+    inputs:
+      - name: metric_values
+        type: list[float]
+        description: Rolling window of volume or sentiment observations.
+        upstream:
+          - src/ingestion/stellar_fetcher.py  (volume)
+          - kpi_datasets.sentiment_compound   (sentiment)
+
+    detector_config:
+      window_size_hours: 24
+      z_threshold: 2.5
+      isolation_forest_contamination: auto
+
+    downstream:
+      - src/alert_notifier.py
+      - src/alertbot.py
+      - src/api/server.py (GET /api/anomalies)
+
+    storage: in-memory rolling window (deque); alerts emitted on trigger


### PR DESCRIPTION
closes #1065 
- Add src/lineage/feature_lineage.yaml with 2 ML feature sets (price_predictor_features, sentiment_model_features) and 9 KPI datasets (market_health_score, sentiment_compound, cohort_metrics, attribution_score, round_anomaly_signals, project_verification_trend, correlation_result, market_forecast, anomaly_detection_result)
- Add scripts/validate_lineage.py CLI validator with --summary, --show, --check-files, and --json modes
- Add LINEAGE.md contributor onboarding guide
- Update README.md with lineage quick-start section

## Summary

Describe what changed and why.

## Linked Issue

Closes #

## Type of Change

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Validation

- [ ] Lint passed for affected area(s)
- [ ] Tests passed for affected area(s)
- [ ] Manual verification completed (if applicable)

## Documentation

- [ ] Documentation updated (or N/A with explanation)
- [ ] Screenshots/videos attached for UI changes

## Checklist

- [ ] Branch name uses `feat/`, `fix/`, or `docs/`
- [ ] Commit messages follow Conventional Commits
- [ ] PR scope matches linked issue acceptance criteria
