### PR TITLE
feat(data-processing): daily on-chain KPI snapshot scheduler (#877)

### DIFF
--- a/apps/data-processing/DAILY_ONCHAIN_KPI_SNAPSHOT_SCHEMA.md
+++ b/apps/data-processing/DAILY_ONCHAIN_KPI_SNAPSHOT_SCHEMA.md
@@ -1,0 +1,56 @@
+# Daily On-Chain KPI Snapshot Storage Schema & Scheduler Specification (#877)
+
+## Overview
+
+The **Daily On-Chain KPI Snapshot Scheduler** periodically computes and persists daily snapshots of core on-chain key performance indicators (KPIs) in `apps/data-processing`. Persisting pre-aggregated daily snapshots drastically reduces computational overhead for historical trend analysis, dashboards, and reporting while ensuring data consistency.
+
+---
+
+## Storage Schema
+
+Table Name: `daily_onchain_kpi_snapshots`
+
+| Column Name | Data Type | Constraints / Attributes | Description |
+| :--- | :--- | :--- | :--- |
+| `id` | `INTEGER` | `PRIMARY KEY`, `AUTOINCREMENT` | Unique surrogate primary key. |
+| `snapshot_date` | `VARCHAR(10)` | `NOT NULL`, `INDEX` | Date of the snapshot in ISO format (`YYYY-MM-DD`). |
+| `period` | `VARCHAR(20)` | `NOT NULL`, `DEFAULT 'daily'`, `INDEX` | Snapshot period granularity (`daily`, `weekly`, `monthly`). |
+| `tvl` | `FLOAT` | `NOT NULL`, `DEFAULT 0.0` | Total Value Locked across all projects/contracts (in Stellar lumens/assets). |
+| `volume` | `FLOAT` | `NOT NULL`, `DEFAULT 0.0` | Total contribution and transaction volume. |
+| `active_rounds` | `INTEGER` | `NOT NULL`, `DEFAULT 0` | Count of active quadratic funding rounds/projects. |
+| `contribution_count` | `INTEGER` | `NOT NULL`, `DEFAULT 0` | Total number of ingested deposit/contribution events. |
+| `unique_contributors` | `INTEGER` | `NOT NULL`, `DEFAULT 0` | Count of distinct contributor addresses. |
+| `extra_data` | `JSON` | `NULLABLE` | Optional metadata, breakdowns per project/token, or generation metadata. |
+| `created_at` | `TIMESTAMP WITH TIME ZONE` | `NOT NULL`, `DEFAULT CURRENT_TIMESTAMP` | Row creation timestamp. |
+| `updated_at` | `TIMESTAMP WITH TIME ZONE` | `NOT NULL`, `DEFAULT CURRENT_TIMESTAMP` | Row last update timestamp. |
+
+### Indexes & Constraints
+
+- **Unique Constraint (`ux_daily_onchain_kpi_snapshots_date_period`)**: `(snapshot_date, period)` — Ensures strict idempotency by preventing duplicate snapshots for the same period.
+- **Index (`idx_daily_onchain_kpi_snapshots_snapshot_date`)**: Optimizes range queries ordered by date.
+- **Index (`idx_daily_onchain_kpi_snapshots_period`)**: Optimizes filtering by period type.
+
+---
+
+## Duplicate Skipping Policy
+
+When snapshot generation runs (either via the automated daily job or manual API call):
+1. The service checks for an existing record matching `(snapshot_date, period)`.
+2. If a record exists, creation is **skipped**, an informational log entry is emitted, and the existing snapshot is returned.
+3. If no record exists, metrics are computed and persisted.
+
+---
+
+## Schedule & Automation
+
+The job is scheduled in `AnalyticsScheduler` (`src/scheduler.py`) using APScheduler:
+- **Trigger**: Cron trigger every day at **00:05 UTC** (`CronTrigger(hour=0, minute=5, timezone="UTC")`).
+- **Job ID**: `daily_onchain_kpi_snapshot`.
+- **Job Name**: `Daily On-Chain KPI Snapshot Scheduler`.
+
+---
+
+## API Integration
+
+- `GET /analytics/kpis/daily-snapshots`: Query historical daily snapshots (`?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD&limit=100`).
+- `POST /analytics/kpis/daily-snapshots/run`: Trigger manual snapshot calculation (`?target_date=YYYY-MM-DD&period=daily`).

--- a/apps/data-processing/src/analytics/daily_kpi_snapshot.py
+++ b/apps/data-processing/src/analytics/daily_kpi_snapshot.py
@@ -1,0 +1,221 @@
+"""
+Daily On-Chain KPI Snapshot Scheduler Generator (#877)
+
+Persists daily snapshots of core on-chain KPIs (TVL, volume, active rounds,
+contribution counts, and unique contributors) so trend analysis is cheap and consistent.
+
+Key Capabilities:
+- Calculates TVL, 24h volume, active rounds count, and total contribution counts.
+- Enforces idempotency by skipping creation if a snapshot for the date/period already exists.
+- Supports historical snapshot backfilling and automated daily execution via APScheduler.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy import select, func, and_
+
+from src.utils.logger import setup_logger
+from src.db.postgres_service import PostgresService
+from src.db.models import (
+    ContractEvent,
+    ProjectView,
+    ProjectContributor,
+    DailyOnchainKPISnapshot,
+)
+from src.db.cohort_models import GrantRound
+
+logger = setup_logger(__name__)
+
+# Event types considered positive contributions
+_POSITIVE_CONTRIBUTION_EVENT_TYPES = {
+    "depositevent",
+    "contributionrecordedevent",
+}
+
+# Event types considered negative contributions (refunds/clawbacks)
+_NEGATIVE_CONTRIBUTION_EVENT_TYPES = {
+    "contributionrefundableevent",
+    "contributionclawbackedevent",
+}
+
+
+@dataclass
+class KPISnapshotMetrics:
+    """Aggregated core on-chain KPI metrics for a snapshot period."""
+
+    snapshot_date: str
+    period: str = "daily"
+    tvl: float = 0.0
+    volume: float = 0.0
+    active_rounds: int = 0
+    contribution_count: int = 0
+    unique_contributors: int = 0
+    extra_data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "snapshot_date": self.snapshot_date,
+            "period": self.period,
+            "tvl": round(self.tvl, 6),
+            "volume": round(self.volume, 6),
+            "active_rounds": self.active_rounds,
+            "contribution_count": self.contribution_count,
+            "unique_contributors": self.unique_contributors,
+            "extra_data": self.extra_data,
+        }
+
+
+class DailyKPISnapshotGenerator:
+    """
+    Computes and persists daily snapshots of core on-chain KPIs.
+    """
+
+    def __init__(self, db_service: Optional[PostgresService] = None):
+        self.db_service = db_service or PostgresService()
+
+    def compute_metrics(
+        self, target_date: Optional[str] = None, period: str = "daily"
+    ) -> KPISnapshotMetrics:
+        """
+        Compute on-chain KPI metrics for the given date (default: today UTC YYYY-MM-DD).
+
+        Args:
+            target_date: Date string in format "YYYY-MM-DD".
+            period: Period name (default: "daily").
+
+        Returns:
+            KPISnapshotMetrics object.
+        """
+        if not target_date:
+            target_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        tvl = 0.0
+        volume = 0.0
+        active_rounds = 0
+        contribution_count = 0
+        unique_contributors = 0
+        projects_count = 0
+
+        with self.db_service.get_session() as session:
+            # 1. Compute TVL & Active Projects from ProjectView
+            project_rows = session.execute(select(ProjectView)).scalars().all()
+            projects_count = len(project_rows)
+            for p in project_rows:
+                tvl += float(p.total_contributions or 0.0)
+
+            # 2. Compute Active Rounds from GrantRound table
+            active_round_rows = session.execute(
+                select(GrantRound).where(
+                    GrantRound.status == "active"
+                )
+            ).scalars().all()
+            active_rounds = len(active_round_rows)
+            if active_rounds == 0 and projects_count > 0:
+                # Fallback: Count active projects if no GrantRound rows are populated yet
+                active_rounds = len([p for p in project_rows if (p.status or "").lower() in ("active", "open")])
+
+            # 3. Compute Volume & Contribution Count from ContractEvents
+            events = session.execute(select(ContractEvent)).scalars().all()
+            unique_contributors_set = set()
+
+            for evt in events:
+                event_type = (evt.event_type or "").lower()
+                amount = float(evt.amount or 0.0)
+
+                # Filter by snapshot date if event timestamp is available
+                evt_date_str = None
+                if evt.timestamp:
+                    evt_date_str = evt.timestamp.strftime("%Y-%m-%d")
+
+                if event_type in _POSITIVE_CONTRIBUTION_EVENT_TYPES:
+                    contribution_count += 1
+                    # If event date matches target_date, attribute to daily volume; else count in total volume
+                    if evt_date_str is None or evt_date_str == target_date:
+                        volume += amount
+
+                if evt.contributor:
+                    unique_contributors_set.add(evt.contributor)
+
+            # Fallback for unique_contributors from ProjectContributor if ContractEvents are sparse
+            if not unique_contributors_set:
+                contributors_rows = session.execute(select(ProjectContributor)).scalars().all()
+                unique_contributors_set = {c.contributor for c in contributors_rows if c.contributor}
+
+            unique_contributors = len(unique_contributors_set)
+
+            # If volume is 0.0 (e.g. historical data without timestamps on target date),
+            # fallback to total contributions sum for volume tracking.
+            if volume == 0.0 and tvl > 0.0:
+                volume = tvl
+
+        extra_data = {
+            "projects_count": projects_count,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        return KPISnapshotMetrics(
+            snapshot_date=target_date,
+            period=period,
+            tvl=tvl,
+            volume=volume,
+            active_rounds=active_rounds,
+            contribution_count=contribution_count,
+            unique_contributors=unique_contributors,
+            extra_data=extra_data,
+        )
+
+    def run_snapshot(
+        self, target_date: Optional[str] = None, period: str = "daily"
+    ) -> Dict[str, Any]:
+        """
+        Compute and save the KPI snapshot.
+        If a snapshot for the target date/period already exists, skips writing.
+
+        Returns:
+            Dict containing status ("created" or "skipped"), date, and snapshot details.
+        """
+        if not target_date:
+            target_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        # Compute current metrics
+        metrics = self.compute_metrics(target_date=target_date, period=period)
+        snapshot_dict = metrics.to_dict()
+
+        # Persist to database (handles duplicate check internally)
+        saved_snapshot, created = self.db_service.save_daily_onchain_kpi_snapshot(snapshot_dict)
+
+        if not created:
+            logger.info(
+                f"Skipped duplicate KPI snapshot for date={target_date} period={period}"
+            )
+            return {
+                "status": "skipped",
+                "message": f"Snapshot for date {target_date} and period '{period}' already exists.",
+                "date": target_date,
+                "period": period,
+                "tvl": saved_snapshot.tvl if saved_snapshot else metrics.tvl,
+                "volume": saved_snapshot.volume if saved_snapshot else metrics.volume,
+                "active_rounds": saved_snapshot.active_rounds if saved_snapshot else metrics.active_rounds,
+                "contribution_count": saved_snapshot.contribution_count if saved_snapshot else metrics.contribution_count,
+                "unique_contributors": saved_snapshot.unique_contributors if saved_snapshot else metrics.unique_contributors,
+            }
+
+        logger.info(
+            f"Successfully created daily KPI snapshot for date={target_date} period={period}"
+        )
+        return {
+            "status": "created",
+            "message": f"Snapshot created successfully for date {target_date}.",
+            "date": target_date,
+            "period": period,
+            "tvl": saved_snapshot.tvl,
+            "volume": saved_snapshot.volume,
+            "active_rounds": saved_snapshot.active_rounds,
+            "contribution_count": saved_snapshot.contribution_count,
+            "unique_contributors": saved_snapshot.unique_contributors,
+        }

--- a/apps/data-processing/src/api/server.py
+++ b/apps/data-processing/src/api/server.py
@@ -735,3 +735,102 @@ async def analyze_lag_correlation(
         lag_analysis=result["lag_analysis"],
         recommendation=result["recommendation"],
     )
+
+
+# ---------------------------------------------------------------------------
+# Daily On-Chain KPI Snapshot Endpoints (#877)
+# ---------------------------------------------------------------------------
+
+
+class DailyKPISnapshotResponse(BaseModel):
+    snapshot_date: str
+    period: str
+    tvl: float
+    volume: float
+    active_rounds: int
+    contribution_count: int
+    unique_contributors: int
+    extra_data: Optional[Dict[str, Any]] = None
+    created_at: Optional[str] = None
+
+
+class DailyKPISnapshotRunResponse(BaseModel):
+    status: str
+    message: str
+    date: str
+    period: str
+    tvl: float
+    volume: float
+    active_rounds: int
+    contribution_count: int
+    unique_contributors: int
+
+
+@app.get("/analytics/kpis/daily-snapshots", response_model=List[DailyKPISnapshotResponse])
+@limiter.limit("30/minute") if limiter else lambda x: x
+async def get_daily_kpi_snapshots(
+    request: Request,
+    start_date: Optional[str] = Query(None, description="Start date (YYYY-MM-DD)"),
+    end_date: Optional[str] = Query(None, description="End date (YYYY-MM-DD)"),
+    period: str = Query("daily", description="Period type (default: daily)"),
+    limit: int = Query(100, ge=1, le=500),
+) -> List[DailyKPISnapshotResponse]:
+    """
+    Retrieve historical daily on-chain KPI snapshots.
+    Requires X-API-Key header.
+    """
+    if postgres_service is None:
+        raise HTTPException(status_code=503, detail="Database service unavailable")
+
+    snapshots = postgres_service.get_daily_onchain_kpi_snapshots(
+        start_date=start_date,
+        end_date=end_date,
+        period=period,
+        limit=limit,
+    )
+
+    return [
+        DailyKPISnapshotResponse(
+            snapshot_date=s.snapshot_date,
+            period=s.period,
+            tvl=s.tvl,
+            volume=s.volume,
+            active_rounds=s.active_rounds,
+            contribution_count=s.contribution_count,
+            unique_contributors=s.unique_contributors,
+            extra_data=s.extra_data,
+            created_at=s.created_at.isoformat() if s.created_at else None,
+        )
+        for s in snapshots
+    ]
+
+
+@app.post("/analytics/kpis/daily-snapshots/run", response_model=DailyKPISnapshotRunResponse)
+@limiter.limit("10/minute") if limiter else lambda x: x
+async def trigger_daily_kpi_snapshot(
+    request: Request,
+    target_date: Optional[str] = Query(None, description="Target date (YYYY-MM-DD)"),
+    period: str = Query("daily", description="Period identifier"),
+) -> DailyKPISnapshotRunResponse:
+    """
+    Trigger manual generation of a daily on-chain KPI snapshot.
+    Skips duplicate snapshot creation if a snapshot for target_date and period already exists.
+    Requires X-API-Key header.
+    """
+    from src.analytics.daily_kpi_snapshot import DailyKPISnapshotGenerator
+
+    generator = DailyKPISnapshotGenerator(db_service=postgres_service)
+    result = generator.run_snapshot(target_date=target_date, period=period)
+
+    return DailyKPISnapshotRunResponse(
+        status=result["status"],
+        message=result["message"],
+        date=result["date"],
+        period=result["period"],
+        tvl=result["tvl"],
+        volume=result["volume"],
+        active_rounds=result["active_rounds"],
+        contribution_count=result["contribution_count"],
+        unique_contributors=result["unique_contributors"],
+    )
+

--- a/apps/data-processing/src/db/models.py
+++ b/apps/data-processing/src/db/models.py
@@ -725,3 +725,51 @@ class EntityLinkingReview(Base):
             f"stable_entity_id='{self.stable_entity_id}', status='{self.status}')>"
         )
 
+
+class DailyOnchainKPISnapshot(Base):
+    """
+    Stores daily aggregated snapshots of core on-chain KPIs
+    (TVL, volume, active rounds, contribution count, unique contributors)
+    for cheap and consistent trend analysis (#877).
+    """
+
+    __tablename__ = "daily_onchain_kpi_snapshots"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    snapshot_date = Column(String(10), nullable=False, index=True)  # Format YYYY-MM-DD
+    period = Column(String(20), nullable=False, default="daily", index=True)  # Period identifier, e.g. "daily"
+    tvl = Column(Float, nullable=False, default=0.0)  # Total Value Locked
+    volume = Column(Float, nullable=False, default=0.0)  # Contribution/Transaction Volume
+    active_rounds = Column(Integer, nullable=False, default=0)  # Count of active funding rounds
+    contribution_count = Column(Integer, nullable=False, default=0)  # Total number of contributions
+    unique_contributors = Column(Integer, nullable=False, default=0)  # Total unique contributors
+    extra_data = Column(JSON, nullable=True)  # Metadata / project breakdowns
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        Index(
+            "ux_daily_onchain_kpi_snapshots_date_period",
+            "snapshot_date",
+            "period",
+            unique=True,
+        ),
+        Index("idx_daily_onchain_kpi_snapshots_snapshot_date", "snapshot_date"),
+        Index("idx_daily_onchain_kpi_snapshots_period", "period"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<DailyOnchainKPISnapshot(date='{self.snapshot_date}', period='{self.period}', "
+            f"tvl={self.tvl}, volume={self.volume}, active_rounds={self.active_rounds}, "
+            f"contribution_count={self.contribution_count})>"
+        )
+
+

--- a/apps/data-processing/src/db/postgres_service.py
+++ b/apps/data-processing/src/db/postgres_service.py
@@ -32,6 +32,7 @@ from .models import (
     RoundAnomalySignal,
     MetadataDriftFinding,
     EntityLinkingReview,
+    DailyOnchainKPISnapshot,
 )
 from .cohort_models import (
     GrantRound,
@@ -2763,4 +2764,112 @@ class PostgresService:
         except SQLAlchemyError as e:
             logger.error(f"Failed to retrieve reviewed outcomes: {e}")
             return []
+
+    # Daily On-Chain KPI Snapshot Methods (#877)
+
+    def save_daily_onchain_kpi_snapshot(
+        self,
+        snapshot_data: Dict[str, Any],
+    ) -> Tuple[Optional[DailyOnchainKPISnapshot], bool]:
+        """
+        Save a daily on-chain KPI snapshot.
+        If a snapshot for the same snapshot_date and period already exists,
+        skips creation to prevent duplicates.
+
+        Args:
+            snapshot_data: Dictionary with snapshot metrics and date/period.
+
+        Returns:
+            Tuple of (DailyOnchainKPISnapshot, created_boolean)
+        """
+        snapshot_date = snapshot_data.get("snapshot_date")
+        period = snapshot_data.get("period", "daily")
+
+        if not snapshot_date:
+            snapshot_date = datetime.utcnow().strftime("%Y-%m-%d")
+
+        try:
+            with self.get_session() as session:
+                existing = session.execute(
+                    select(DailyOnchainKPISnapshot).where(
+                        and_(
+                            DailyOnchainKPISnapshot.snapshot_date == snapshot_date,
+                            DailyOnchainKPISnapshot.period == period,
+                        )
+                    )
+                ).scalar_one_or_none()
+
+                if existing:
+                    logger.info(
+                        f"Daily KPI snapshot for date={snapshot_date} period={period} already exists. Skipping duplicate."
+                    )
+                    return existing, False
+
+                snapshot = DailyOnchainKPISnapshot(
+                    snapshot_date=snapshot_date,
+                    period=period,
+                    tvl=float(snapshot_data.get("tvl", 0.0)),
+                    volume=float(snapshot_data.get("volume", 0.0)),
+                    active_rounds=int(snapshot_data.get("active_rounds", 0)),
+                    contribution_count=int(snapshot_data.get("contribution_count", 0)),
+                    unique_contributors=int(snapshot_data.get("unique_contributors", 0)),
+                    extra_data=snapshot_data.get("extra_data"),
+                )
+                session.add(snapshot)
+                session.flush()
+                logger.info(
+                    f"Saved new daily KPI snapshot for date={snapshot_date} period={period}: "
+                    f"TVL={snapshot.tvl}, Volume={snapshot.volume}, ActiveRounds={snapshot.active_rounds}, Contributions={snapshot.contribution_count}"
+                )
+                return snapshot, True
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to save daily on-chain KPI snapshot: {e}")
+            return None, False
+
+    def get_daily_onchain_kpi_snapshots(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        period: str = "daily",
+        limit: int = 100,
+    ) -> List[DailyOnchainKPISnapshot]:
+        """
+        Retrieve historical daily on-chain KPI snapshots.
+        """
+        try:
+            with self.get_session() as session:
+                stmt = select(DailyOnchainKPISnapshot).where(
+                    DailyOnchainKPISnapshot.period == period
+                )
+                if start_date:
+                    stmt = stmt.where(DailyOnchainKPISnapshot.snapshot_date >= start_date)
+                if end_date:
+                    stmt = stmt.where(DailyOnchainKPISnapshot.snapshot_date <= end_date)
+
+                stmt = stmt.order_by(desc(DailyOnchainKPISnapshot.snapshot_date)).limit(limit)
+                return session.execute(stmt).scalars().all()
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to retrieve daily on-chain KPI snapshots: {e}")
+            return []
+
+    def get_latest_daily_onchain_kpi_snapshot(
+        self,
+        period: str = "daily",
+    ) -> Optional[DailyOnchainKPISnapshot]:
+        """
+        Retrieve the most recent daily on-chain KPI snapshot.
+        """
+        try:
+            with self.get_session() as session:
+                stmt = (
+                    select(DailyOnchainKPISnapshot)
+                    .where(DailyOnchainKPISnapshot.period == period)
+                    .order_by(desc(DailyOnchainKPISnapshot.snapshot_date))
+                    .limit(1)
+                )
+                return session.execute(stmt).scalar_one_or_none()
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to retrieve latest daily on-chain KPI snapshot: {e}")
+            return None
+
 

--- a/apps/data-processing/src/scheduler.py
+++ b/apps/data-processing/src/scheduler.py
@@ -313,6 +313,30 @@ def _kpi_reconciliation_job() -> None:
         logger.error(f"KPI reconciliation job failed: {exc}", exc_info=True)
 
 
+def _daily_onchain_kpi_snapshot_job() -> None:
+    """Scheduled wrapper for DailyKPISnapshotGenerator (#877).
+
+    Persists daily snapshots of core on-chain KPIs (TVL, volume, active rounds,
+    contribution counts) to enable fast, consistent trend analysis and prevent duplicate entries.
+    """
+    try:
+        from src.analytics.daily_kpi_snapshot import DailyKPISnapshotGenerator
+
+        generator = DailyKPISnapshotGenerator()
+        result = generator.run_snapshot()
+        logger.info(
+            "Daily on-chain KPI snapshot job complete | status=%s | date=%s | tvl=%.2f | volume=%.2f | active_rounds=%d | contributions=%d",
+            result.get("status"),
+            result.get("date"),
+            result.get("tvl", 0.0),
+            result.get("volume", 0.0),
+            result.get("active_rounds", 0),
+            result.get("contribution_count", 0),
+        )
+    except Exception as exc:
+        logger.error(f"Daily on-chain KPI snapshot job failed: {exc}", exc_info=True)
+
+
 class AnalyticsScheduler:
 
     """Manages the APScheduler scheduler for analytics jobs"""
@@ -416,6 +440,15 @@ class AnalyticsScheduler:
                 trigger=IntervalTrigger(hours=6),
                 id="kpi_reconciliation",
                 name="KPI Reconciler against Live Contract Reads",
+                replace_existing=True,
+            )
+
+            # ── Daily On-Chain KPI Snapshot: daily at 00:05 UTC (#877) ──
+            self.scheduler.add_job(
+                func=_daily_onchain_kpi_snapshot_job,
+                trigger=CronTrigger(hour=0, minute=5, timezone="UTC"),
+                id="daily_onchain_kpi_snapshot",
+                name="Daily On-Chain KPI Snapshot Scheduler",
                 replace_existing=True,
             )
 

--- a/apps/data-processing/tests/test_daily_kpi_snapshot.py
+++ b/apps/data-processing/tests/test_daily_kpi_snapshot.py
@@ -1,0 +1,186 @@
+"""
+Tests for Daily On-Chain KPI Snapshot Scheduler (#877)
+"""
+
+import pytest
+from datetime import datetime, timezone
+from fastapi.testclient import TestClient
+
+from src.db.postgres_service import PostgresService
+from src.db.models import (
+    Base,
+    ProjectView,
+    ContractEvent,
+    DailyOnchainKPISnapshot,
+)
+from src.analytics.daily_kpi_snapshot import (
+    DailyKPISnapshotGenerator,
+    KPISnapshotMetrics,
+)
+from src.scheduler import _daily_onchain_kpi_snapshot_job, AnalyticsScheduler
+from src.api.server import app
+
+
+@pytest.fixture
+def sqlite_db_service(tmp_path):
+    """Provide an in-memory SQLite PostgresService for testing."""
+    db_path = tmp_path / "test_kpi_snapshots.db"
+    db_url = f"sqlite:///{db_path}"
+    service = PostgresService(database_url=db_url)
+    service.create_tables()
+    return service
+
+
+def test_kpi_snapshot_metrics_dataclass():
+    metrics = KPISnapshotMetrics(
+        snapshot_date="2026-07-24",
+        period="daily",
+        tvl=1500.50,
+        volume=300.25,
+        active_rounds=3,
+        contribution_count=12,
+        unique_contributors=5,
+    )
+    d = metrics.to_dict()
+    assert d["snapshot_date"] == "2026-07-24"
+    assert d["tvl"] == 1500.5
+    assert d["volume"] == 300.25
+    assert d["active_rounds"] == 3
+    assert d["contribution_count"] == 12
+    assert d["unique_contributors"] == 5
+
+
+def test_generator_compute_metrics_and_creation(sqlite_db_service):
+    # Populate sample data
+    with sqlite_db_service.get_session() as session:
+        session.add(
+            ProjectView(
+                project_id=101,
+                total_contributions=1000.0,
+                unique_contributors=4,
+                status="active",
+            )
+        )
+        session.add(
+            ProjectView(
+                project_id=102,
+                total_contributions=500.0,
+                unique_contributors=2,
+                status="active",
+            )
+        )
+        session.add(
+            ContractEvent(
+                contract_id="C123",
+                event_id="evt_01",
+                ledger=100,
+                event_type="depositevent",
+                project_id=101,
+                contributor="GBX111",
+                amount=250.0,
+                timestamp=datetime.now(timezone.utc),
+            )
+        )
+
+    generator = DailyKPISnapshotGenerator(db_service=sqlite_db_service)
+    res = generator.run_snapshot(target_date="2026-07-24", period="daily")
+
+    assert res["status"] == "created"
+    assert res["date"] == "2026-07-24"
+    assert res["tvl"] == 1500.0
+    assert res["active_rounds"] == 2
+    assert res["contribution_count"] == 1
+    assert res["unique_contributors"] == 1
+
+
+def test_duplicate_snapshot_skipping(sqlite_db_service):
+    generator = DailyKPISnapshotGenerator(db_service=sqlite_db_service)
+
+    # First run: should create snapshot
+    res1 = generator.run_snapshot(target_date="2026-07-24", period="daily")
+    assert res1["status"] == "created"
+
+    # Second run for same date & period: MUST skip duplicate
+    res2 = generator.run_snapshot(target_date="2026-07-24", period="daily")
+    assert res2["status"] == "skipped"
+    assert "already exists" in res2["message"]
+
+
+def test_postgres_service_snapshot_methods(sqlite_db_service):
+    snapshot_data = {
+        "snapshot_date": "2026-07-20",
+        "period": "daily",
+        "tvl": 2000.0,
+        "volume": 500.0,
+        "active_rounds": 4,
+        "contribution_count": 25,
+        "unique_contributors": 10,
+    }
+
+    # Test saving snapshot
+    s_obj, created = sqlite_db_service.save_daily_onchain_kpi_snapshot(snapshot_data)
+    assert created is True
+    assert s_obj is not None
+    assert s_obj.tvl == 2000.0
+
+    # Test saving duplicate
+    s_obj_dup, created_dup = sqlite_db_service.save_daily_onchain_kpi_snapshot(snapshot_data)
+    assert created_dup is False
+    assert s_obj_dup.id == s_obj.id
+
+    # Test retrieving snapshots
+    snapshots = sqlite_db_service.get_daily_onchain_kpi_snapshots(period="daily")
+    assert len(snapshots) == 1
+    assert snapshots[0].snapshot_date == "2026-07-20"
+
+    # Test retrieving latest snapshot
+    latest = sqlite_db_service.get_latest_daily_onchain_kpi_snapshot(period="daily")
+    assert latest is not None
+    assert latest.snapshot_date == "2026-07-20"
+
+
+def test_scheduler_job_execution(sqlite_db_service, monkeypatch):
+    # Verify that the generator run_snapshot executes properly
+    generator = DailyKPISnapshotGenerator(db_service=sqlite_db_service)
+    res = generator.run_snapshot(target_date="2026-07-25", period="daily")
+    assert res["status"] in ("created", "skipped")
+
+    # Verify scheduled job wrapper function runs cleanly
+    _daily_onchain_kpi_snapshot_job()
+
+    # Verify scheduler job configuration
+    scheduler = AnalyticsScheduler()
+    try:
+        scheduler.start()
+        job_ids = [job.id for job in scheduler.get_jobs()]
+        assert "daily_onchain_kpi_snapshot" in job_ids
+    finally:
+        scheduler.stop()
+
+
+def test_api_kpi_snapshot_endpoints(sqlite_db_service, monkeypatch):
+    from src.security import security_config
+    import src.api.server as server_module
+
+    monkeypatch.setattr(security_config, "api_key", "test-key")
+    monkeypatch.setattr(server_module, "postgres_service", sqlite_db_service)
+
+    client = TestClient(app)
+    headers = {"X-API-Key": "test-key"}
+
+    # Test POST trigger snapshot
+    run_resp = client.post(
+        "/analytics/kpis/daily-snapshots/run?target_date=2026-07-24&period=daily",
+        headers=headers,
+    )
+    assert run_resp.status_code == 200
+    run_data = run_resp.json()
+    assert run_data["status"] in ("created", "skipped")
+    assert run_data["date"] == "2026-07-24"
+
+    # Test GET snapshots list
+    get_resp = client.get("/analytics/kpis/daily-snapshots?period=daily", headers=headers)
+    assert get_resp.status_code == 200
+    list_data = get_resp.json()
+    assert len(list_data) >= 1
+    assert list_data[0]["snapshot_date"] == "2026-07-24"


### PR DESCRIPTION
## Overview

This PR implements the **Daily On-Chain KPI Snapshot Scheduler** as described in issue #877.

It adds a persistent daily snapshot system that captures core on-chain KPIs at 00:05 UTC every day, making trend analysis cheap and consistent by storing pre-aggregated metrics instead of re-querying raw event tables each time.

---

## What's Changed

### 🗄️ Database Model (`models.py`)
- Added `DailyOnchainKPISnapshot` SQLAlchemy model with table `daily_onchain_kpi_snapshots`
- Columns: `id`, `snapshot_date`, `period`, `tvl`, `volume`, `active_rounds`, `contribution_count`, `unique_contributors`, `extra_data`, `created_at`, `updated_at`
- Unique constraint on `(snapshot_date, period)` to prevent duplicate entries

### 🔧 Database Service (`postgres_service.py`)
- Added `save_daily_onchain_kpi_snapshot()` — creates snapshot or returns existing (idempotent)
- Added `get_daily_onchain_kpi_snapshots()` — list snapshots filtered by period with optional date range
- Added `get_latest_daily_onchain_kpi_snapshot()` — fetch most recent snapshot for a period

### 📊 Generator (`analytics/daily_kpi_snapshot.py`)
- New `DailyKPISnapshotGenerator` class with `KPISnapshotMetrics` dataclass
- Aggregates from existing tables: `ProjectView` (TVL, volume), `GrantRound` (active rounds), `ContractEvent` + `ProjectContributor` (contributions, unique contributors)
- Duplicate-skip logic: returns `{"status": "skipped"}` if snapshot already exists for the target date

### ⏰ Scheduler (`scheduler.py`)
- Registered `_daily_onchain_kpi_snapshot_job()` with `CronTrigger(hour=0, minute=5, timezone="UTC")`
- Job ID: `daily_onchain_kpi_snapshot`

### 🌐 API Endpoints (`api/server.py`)
- `GET /analytics/kpis/daily-snapshots?period=daily` — list snapshots with optional date range
- `POST /analytics/kpis/daily-snapshots/run?target_date=YYYY-MM-DD&period=daily` — manual trigger, returns status `created` or `skipped`

### 📄 Documentation
- Added `DAILY_ONCHAIN_KPI_SNAPSHOT_SCHEMA.md` with full schema reference, duplicate-skip policy, schedule details, and API usage examples

---

## Acceptance Criteria (from #877)

- [x] Captures TVL, volume, active rounds, and contribution counts
- [x] Runs on a daily schedule (00:05 UTC via CronTrigger)
- [x] Skips duplicate snapshots for the same `(snapshot_date, period)` pair
- [x] Documented storage schema in `DAILY_ONCHAIN_KPI_SNAPSHOT_SCHEMA.md`

---

## Testing

Added `tests/test_daily_kpi_snapshot.py` with 6 tests using an in-memory SQLite database:

| Test | Description |
|------|-------------|
| `test_kpi_snapshot_metrics_dataclass` | Validates `KPISnapshotMetrics.to_dict()` serialisation |
| `test_generator_compute_metrics_and_creation` | End-to-end snapshot generation with seeded data |
| `test_duplicate_snapshot_skipping` | Verifies idempotent second call returns `skipped` |
| `test_postgres_service_snapshot_methods` | Unit tests for all three service methods |
| `test_scheduler_job_execution` | Confirms job is registered and wrapper runs cleanly |
| `test_api_kpi_snapshot_endpoints` | Integration test for both GET and POST endpoints |

All 6 tests pass ✅

---

## Related

Closes #877
