### PR TITLE
feat: Targeted notification fanout by watchlist and preferences (#1029)

### DIFF
--- a/apps/backend/src/migrations/add-notification-suppression-logs.sql
+++ b/apps/backend/src/migrations/add-notification-suppression-logs.sql
@@ -1,0 +1,39 @@
+-- Migration: Add notification suppression logs for fanout observability
+-- Created: 2026-07-25
+
+-- Create suppression_reason enum type
+CREATE TYPE suppression_reason AS ENUM (
+    'quiet_hours',
+    'severity_threshold',
+    'daily_limit',
+    'event_category_disabled',
+    'not_in_watchlist',
+    'no_preferences',
+    'channel_unavailable'
+);
+
+-- Create notification_suppression_logs table
+CREATE TABLE IF NOT EXISTS notification_suppression_logs (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    event_category VARCHAR(50) NOT NULL,
+    notification_type VARCHAR(50) NOT NULL,
+    reason suppression_reason NOT NULL,
+    metadata JSONB,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+-- Create indexes for efficient querying
+CREATE INDEX idx_suppression_logs_user_id ON notification_suppression_logs(user_id);
+CREATE INDEX idx_suppression_logs_event_category ON notification_suppression_logs(event_category);
+CREATE INDEX idx_suppression_logs_reason ON notification_suppression_logs(reason);
+CREATE INDEX idx_suppression_logs_created_at ON notification_suppression_logs(created_at);
+CREATE INDEX idx_suppression_logs_user_event ON notification_suppression_logs(user_id, event_category);
+
+-- Add comments for documentation
+COMMENT ON TABLE notification_suppression_logs IS 'Tracks notifications suppressed during fanout for debugging and observability';
+COMMENT ON COLUMN notification_suppression_logs.user_id IS 'User whose notification was suppressed';
+COMMENT ON COLUMN notification_suppression_logs.event_category IS 'Event category that triggered the notification attempt';
+COMMENT ON COLUMN notification_suppression_logs.notification_type IS 'Type of notification that was suppressed';
+COMMENT ON COLUMN notification_suppression_logs.reason IS 'Reason for suppression: quiet_hours, severity_threshold, daily_limit, event_category_disabled, not_in_watchlist, no_preferences, channel_unavailable';
+COMMENT ON COLUMN notification_suppression_logs.metadata IS 'Additional context about the suppression event';

--- a/apps/backend/src/notification/dto/fanout.dto.ts
+++ b/apps/backend/src/notification/dto/fanout.dto.ts
@@ -96,6 +96,7 @@ export class FanoutResultDto {
   @ApiProperty({
     description: 'Breakdown of suppression reasons',
     type: 'object',
+    additionalProperties: true,
   })
   suppressionBreakdown: Record<string, number>;
 
@@ -122,7 +123,7 @@ export class SuppressionLogResponseDto {
   @ApiProperty()
   reason: string;
 
-  @ApiProperty({ type: 'object', nullable: true })
+  @ApiProperty({ type: 'object', nullable: true, additionalProperties: true })
   metadata: Record<string, unknown> | null;
 
   @ApiProperty()

--- a/apps/backend/src/notification/dto/fanout.dto.ts
+++ b/apps/backend/src/notification/dto/fanout.dto.ts
@@ -1,0 +1,130 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsEnum,
+  IsOptional,
+  IsArray,
+  ValidateNested,
+  IsObject,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import {
+  NotificationType,
+  NotificationSeverity,
+} from '../notification.entity';
+import { EventCategory } from '../../common/event-catalog';
+
+export class FanoutNotificationDto {
+  @ApiProperty({
+    description: 'Type of notification event',
+    enum: NotificationType,
+  })
+  @IsEnum(NotificationType)
+  type: NotificationType;
+
+  @ApiProperty({ description: 'Notification title' })
+  @IsString()
+  title: string;
+
+  @ApiProperty({ description: 'Notification message body' })
+  @IsString()
+  message: string;
+
+  @ApiProperty({
+    description: 'Notification severity level',
+    enum: NotificationSeverity,
+  })
+  @IsEnum(NotificationSeverity)
+  severity: NotificationSeverity;
+
+  @ApiProperty({
+    description: 'Event category for preference matching',
+    enum: EventCategory,
+  })
+  @IsEnum(EventCategory)
+  eventCategory: EventCategory;
+
+  @ApiPropertyOptional({
+    description:
+      'Metadata context for the event (e.g., projectId, symbol, poolId)',
+  })
+  @IsObject()
+  @IsOptional()
+  metadata?: Record<string, unknown>;
+}
+
+export class FanoutRequestDto {
+  @ApiProperty({
+    description: 'The notification event to fan out to targeted users',
+    type: FanoutNotificationDto,
+  })
+  @ValidateNested()
+  @Type(() => FanoutNotificationDto)
+  notification: FanoutNotificationDto;
+
+  @ApiPropertyOptional({
+    description:
+      'Specific user IDs to target. If omitted, targets all watchlist-matching users.',
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  targetUserIds?: string[];
+
+  @ApiPropertyOptional({
+    description:
+      'Symbols to match against watchlists. If omitted, derived from notification metadata.',
+    type: [String],
+  })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  symbols?: string[];
+}
+
+export class FanoutResultDto {
+  @ApiProperty({ description: 'Total users targeted for fanout' })
+  totalTargeted: number;
+
+  @ApiProperty({ description: 'Notifications successfully delivered' })
+  delivered: number;
+
+  @ApiProperty({ description: 'Notifications suppressed' })
+  suppressed: number;
+
+  @ApiProperty({
+    description: 'Breakdown of suppression reasons',
+    type: 'object',
+  })
+  suppressionBreakdown: Record<string, number>;
+
+  @ApiProperty({
+    description: 'IDs of created notifications',
+    type: [String],
+  })
+  notificationIds: string[];
+}
+
+export class SuppressionLogResponseDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty({ format: 'uuid' })
+  userId: string;
+
+  @ApiProperty()
+  eventCategory: string;
+
+  @ApiProperty()
+  notificationType: string;
+
+  @ApiProperty()
+  reason: string;
+
+  @ApiProperty({ type: 'object', nullable: true })
+  metadata: Record<string, unknown> | null;
+
+  @ApiProperty()
+  createdAt: Date;
+}

--- a/apps/backend/src/notification/notification-fanout.controller.ts
+++ b/apps/backend/src/notification/notification-fanout.controller.ts
@@ -1,0 +1,84 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Query,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiQuery,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { NotificationFanoutService } from './notification-fanout.service';
+import {
+  FanoutRequestDto,
+  FanoutResultDto,
+  SuppressionLogResponseDto,
+} from './dto/fanout.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+
+@ApiTags('notification-fanout')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('notifications')
+export class NotificationFanoutController {
+  constructor(private readonly fanoutService: NotificationFanoutService) {}
+
+  @Post('fanout')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Fan out a notification to targeted users',
+    description:
+      'Creates notifications for all users whose watchlists match the event, ' +
+      'filtered by their notification preferences. Suppressed notifications are logged for debugging.',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Fanout completed successfully',
+    type: FanoutResultDto,
+  })
+  async fanout(@Body() request: FanoutRequestDto): Promise<FanoutResultDto> {
+    return this.fanoutService.fanout(request);
+  }
+
+  @Get('suppression-logs')
+  @ApiOperation({
+    summary: 'Get notification suppression logs',
+    description:
+      'Retrieves suppression logs for debugging and observability. ' +
+      'Shows why notifications were not delivered to specific users.',
+  })
+  @ApiQuery({ name: 'userId', required: false, description: 'Filter by user ID' })
+  @ApiQuery({
+    name: 'eventCategory',
+    required: false,
+    description: 'Filter by event category',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: 'Max results (default 50)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of suppression logs',
+    type: [SuppressionLogResponseDto],
+  })
+  async getSuppressionLogs(
+    @Query('userId') userId?: string,
+    @Query('eventCategory') eventCategory?: string,
+    @Query('limit') limit?: number,
+  ): Promise<SuppressionLogResponseDto[]> {
+    return this.fanoutService.getSuppressionLogs(
+      userId,
+      eventCategory,
+      limit ?? 50,
+    );
+  }
+}

--- a/apps/backend/src/notification/notification-fanout.service.spec.ts
+++ b/apps/backend/src/notification/notification-fanout.service.spec.ts
@@ -1,0 +1,359 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationFanoutService } from './notification-fanout.service';
+import { NotificationService } from './notification.service';
+import { NotificationPreferenceService } from './notification-preference.service';
+import { NotificationDeliveryService } from './notification-delivery.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import {
+  NotificationSuppressionLog,
+  SuppressionReason,
+} from './notification-suppression-log.entity';
+import { WatchlistItem, WatchlistItemType } from '../watchlist/watchlist-item.entity';
+import { NotificationType, NotificationSeverity } from './notification.entity';
+import { EventCategory } from '../common/event-catalog';
+import { NotificationChannel } from './notification-preference.entity';
+
+const mockWatchlistRepository = {
+  createQueryBuilder: jest.fn(),
+};
+
+const mockSuppressionLogRepository = {
+  create: jest.fn(),
+  save: jest.fn(),
+  find: jest.fn(),
+};
+
+const mockNotificationService = {
+  create: jest.fn(),
+};
+
+const mockPreferenceService = {
+  findByUserId: jest.fn(),
+  isWithinQuietHours: jest.fn(),
+  meetsSeverityThreshold: jest.fn(),
+  hasReachedDailyLimit: jest.fn(),
+};
+
+const mockDeliveryService = {
+  deliverToUser: jest.fn(),
+};
+
+describe('NotificationFanoutService', () => {
+  let service: NotificationFanoutService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationFanoutService,
+        {
+          provide: NotificationService,
+          useValue: mockNotificationService,
+        },
+        {
+          provide: NotificationPreferenceService,
+          useValue: mockPreferenceService,
+        },
+        {
+          provide: NotificationDeliveryService,
+          useValue: mockDeliveryService,
+        },
+        {
+          provide: getRepositoryToken(WatchlistItem),
+          useValue: mockWatchlistRepository,
+        },
+        {
+          provide: getRepositoryToken(NotificationSuppressionLog),
+          useValue: mockSuppressionLogRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<NotificationFanoutService>(NotificationFanoutService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('fanout', () => {
+    it('should deliver notifications to watchlist-matching users', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          { userId: 'user-1' },
+          { userId: 'user-2' },
+        ]),
+      };
+      mockWatchlistRepository.createQueryBuilder.mockReturnValue(mockQuery);
+
+      mockPreferenceService.findByUserId.mockResolvedValue({
+        userId: 'user-1',
+        enabledChannels: [NotificationChannel.IN_APP],
+        eventPreferences: {},
+        quietHours: null,
+        dailyLimit: 0,
+        minSeverity: 'low',
+      });
+      mockPreferenceService.isWithinQuietHours.mockReturnValue(false);
+      mockPreferenceService.meetsSeverityThreshold.mockReturnValue(true);
+      mockPreferenceService.hasReachedDailyLimit.mockResolvedValue(false);
+
+      const savedNotification = { id: 'notif-1', type: NotificationType.PROJECT };
+      mockNotificationService.create.mockResolvedValue(savedNotification);
+      mockDeliveryService.deliverToUser.mockResolvedValue([
+        { id: 'log-1', status: 'delivered' },
+      ]);
+
+      const result = await service.fanout({
+        notification: {
+          type: NotificationType.PROJECT,
+          title: 'Project Created',
+          message: 'New project launched',
+          severity: NotificationSeverity.MEDIUM,
+          eventCategory: EventCategory.PROJECT,
+          metadata: { symbol: 'LUMEN' },
+        },
+      });
+
+      expect(result.totalTargeted).toBe(2);
+      expect(result.delivered).toBe(2);
+      expect(result.suppressed).toBe(0);
+      expect(mockNotificationService.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('should suppress notifications for users in quiet hours', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([{ userId: 'user-1' }]),
+      };
+      mockWatchlistRepository.createQueryBuilder.mockReturnValue(mockQuery);
+
+      mockPreferenceService.findByUserId.mockResolvedValue({
+        userId: 'user-1',
+        enabledChannels: [NotificationChannel.IN_APP],
+        eventPreferences: {},
+        quietHours: {
+          startHour: 22,
+          endHour: 7,
+          timezone: 'UTC',
+          allowCritical: true,
+        },
+        dailyLimit: 0,
+        minSeverity: 'low',
+      });
+      mockPreferenceService.isWithinQuietHours.mockReturnValue(true);
+
+      const result = await service.fanout({
+        notification: {
+          type: NotificationType.PRICE,
+          title: 'Price Alert',
+          message: 'Price threshold reached',
+          severity: NotificationSeverity.LOW,
+          eventCategory: EventCategory.PRICE,
+          metadata: { symbol: 'XLM' },
+        },
+      });
+
+      expect(result.totalTargeted).toBe(1);
+      expect(result.delivered).toBe(0);
+      expect(result.suppressed).toBe(1);
+      expect(result.suppressionBreakdown[SuppressionReason.QUIET_HOURS]).toBe(1);
+      expect(mockSuppressionLogRepository.save).toHaveBeenCalled();
+    });
+
+    it('should suppress notifications below severity threshold', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([{ userId: 'user-1' }]),
+      };
+      mockWatchlistRepository.createQueryBuilder.mockReturnValue(mockQuery);
+
+      mockPreferenceService.findByUserId.mockResolvedValue({
+        userId: 'user-1',
+        enabledChannels: [NotificationChannel.IN_APP],
+        eventPreferences: {},
+        quietHours: null,
+        dailyLimit: 0,
+        minSeverity: 'high',
+      });
+      mockPreferenceService.isWithinQuietHours.mockReturnValue(false);
+      mockPreferenceService.meetsSeverityThreshold.mockReturnValue(false);
+
+      const result = await service.fanout({
+        notification: {
+          type: NotificationType.PRICE,
+          title: 'Price Update',
+          message: 'Price changed',
+          severity: NotificationSeverity.LOW,
+          eventCategory: EventCategory.PRICE,
+          metadata: { symbol: 'XLM' },
+        },
+      });
+
+      expect(result.totalTargeted).toBe(1);
+      expect(result.suppressed).toBe(1);
+      expect(result.suppressionBreakdown[SuppressionReason.SEVERITY_THRESHOLD]).toBe(1);
+    });
+
+    it('should suppress notifications for disabled event categories', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([{ userId: 'user-1' }]),
+      };
+      mockWatchlistRepository.createQueryBuilder.mockReturnValue(mockQuery);
+
+      mockPreferenceService.findByUserId.mockResolvedValue({
+        userId: 'user-1',
+        enabledChannels: [NotificationChannel.IN_APP],
+        eventPreferences: {
+          price: { enabled: false, channels: [] },
+        },
+        quietHours: null,
+        dailyLimit: 0,
+        minSeverity: 'low',
+      });
+      mockPreferenceService.isWithinQuietHours.mockReturnValue(false);
+      mockPreferenceService.meetsSeverityThreshold.mockReturnValue(true);
+      mockPreferenceService.hasReachedDailyLimit.mockResolvedValue(false);
+
+      const result = await service.fanout({
+        notification: {
+          type: NotificationType.PRICE,
+          title: 'Price Update',
+          message: 'Price updated',
+          severity: NotificationSeverity.MEDIUM,
+          eventCategory: EventCategory.PRICE,
+          metadata: { symbol: 'XLM' },
+        },
+      });
+
+      expect(result.totalTargeted).toBe(1);
+      expect(result.suppressed).toBe(1);
+      expect(result.suppressionBreakdown[SuppressionReason.EVENT_CATEGORY_DISABLED]).toBe(1);
+    });
+
+    it('should use explicit targetUserIds when provided', async () => {
+      mockPreferenceService.findByUserId.mockResolvedValue({
+        userId: 'user-explicit',
+        enabledChannels: [NotificationChannel.IN_APP],
+        eventPreferences: {},
+        quietHours: null,
+        dailyLimit: 0,
+        minSeverity: 'low',
+      });
+      mockPreferenceService.isWithinQuietHours.mockReturnValue(false);
+      mockPreferenceService.meetsSeverityThreshold.mockReturnValue(true);
+      mockPreferenceService.hasReachedDailyLimit.mockResolvedValue(false);
+
+      const savedNotification = { id: 'notif-1', type: NotificationType.ADMIN };
+      mockNotificationService.create.mockResolvedValue(savedNotification);
+      mockDeliveryService.deliverToUser.mockResolvedValue([
+        { id: 'log-1', status: 'delivered' },
+      ]);
+
+      const result = await service.fanout({
+        notification: {
+          type: NotificationType.ADMIN,
+          title: 'Admin Notice',
+          message: 'System maintenance',
+          severity: NotificationSeverity.HIGH,
+          eventCategory: EventCategory.ADMIN,
+        },
+        targetUserIds: ['user-explicit'],
+      });
+
+      expect(result.totalTargeted).toBe(1);
+      expect(result.delivered).toBe(1);
+      expect(mockWatchlistRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should return empty result when no symbols resolved and no explicit targets', async () => {
+      const result = await service.fanout({
+        notification: {
+          type: NotificationType.SYSTEM,
+          title: 'System Alert',
+          message: 'General alert',
+          severity: NotificationSeverity.HIGH,
+          eventCategory: EventCategory.SYSTEM,
+        },
+      });
+
+      expect(result.totalTargeted).toBe(0);
+      expect(result.delivered).toBe(0);
+      expect(result.suppressed).toBe(0);
+    });
+
+    it('should extract symbols from metadata for watchlist matching', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      };
+      mockWatchlistRepository.createQueryBuilder.mockReturnValue(mockQuery);
+
+      await service.fanout({
+        notification: {
+          type: NotificationType.TOKEN,
+          title: 'Token Event',
+          message: 'Token burned',
+          severity: NotificationSeverity.MEDIUM,
+          eventCategory: EventCategory.TOKEN,
+          metadata: { tokenSymbol: 'LUMEN' },
+        },
+      });
+
+      expect(mockQuery.where).toHaveBeenCalledWith(
+        'w.symbol IN (:...symbols)',
+        { symbols: ['LUMEN'] },
+      );
+    });
+  });
+
+  describe('getSuppressionLogs', () => {
+    it('should return suppression logs', async () => {
+      const mockLogs = [
+        {
+          id: 'log-1',
+          userId: 'user-1',
+          eventCategory: 'price',
+          notificationType: 'price',
+          reason: SuppressionReason.QUIET_HOURS,
+          createdAt: new Date(),
+        },
+      ];
+      mockSuppressionLogRepository.find.mockResolvedValue(mockLogs);
+
+      const result = await service.getSuppressionLogs('user-1');
+
+      expect(result).toEqual(mockLogs);
+      expect(mockSuppressionLogRepository.find).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        order: { createdAt: 'DESC' },
+        take: 50,
+      });
+    });
+
+    it('should filter by event category', async () => {
+      mockSuppressionLogRepository.find.mockResolvedValue([]);
+
+      await service.getSuppressionLogs(undefined, 'price', 10);
+
+      expect(mockSuppressionLogRepository.find).toHaveBeenCalledWith({
+        where: { eventCategory: 'price' },
+        order: { createdAt: 'DESC' },
+        take: 10,
+      });
+    });
+  });
+});

--- a/apps/backend/src/notification/notification-fanout.service.spec.ts
+++ b/apps/backend/src/notification/notification-fanout.service.spec.ts
@@ -8,7 +8,7 @@ import {
   NotificationSuppressionLog,
   SuppressionReason,
 } from './notification-suppression-log.entity';
-import { WatchlistItem, WatchlistItemType } from '../watchlist/watchlist-item.entity';
+import { WatchlistItem } from '../watchlist/watchlist-item.entity';
 import { NotificationType, NotificationSeverity } from './notification.entity';
 import { EventCategory } from '../common/event-catalog';
 import { NotificationChannel } from './notification-preference.entity';

--- a/apps/backend/src/notification/notification-fanout.service.ts
+++ b/apps/backend/src/notification/notification-fanout.service.ts
@@ -8,6 +8,9 @@ import {
   NotificationSuppressionLog,
   SuppressionReason,
 } from './notification-suppression-log.entity';
+import {
+  NotificationPreference,
+} from './notification-preference.entity';
 import { WatchlistItem, WatchlistItemType } from '../watchlist/watchlist-item.entity';
 import { NotificationType, NotificationSeverity } from './notification.entity';
 import { EventCategory } from '../common/event-catalog';
@@ -257,7 +260,7 @@ export class NotificationFanoutService {
     severity: NotificationSeverity,
   ): Promise<SuppressionReason | null> {
     // Check preferences exist
-    let preferences;
+    let preferences: NotificationPreference;
     try {
       preferences = await this.preferenceService.findByUserId(userId);
     } catch {

--- a/apps/backend/src/notification/notification-fanout.service.ts
+++ b/apps/backend/src/notification/notification-fanout.service.ts
@@ -1,0 +1,341 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { NotificationService, CreateNotificationDto } from './notification.service';
+import { NotificationPreferenceService } from './notification-preference.service';
+import { NotificationDeliveryService } from './notification-delivery.service';
+import {
+  NotificationSuppressionLog,
+  SuppressionReason,
+} from './notification-suppression-log.entity';
+import { WatchlistItem, WatchlistItemType } from '../watchlist/watchlist-item.entity';
+import { NotificationType, NotificationSeverity } from './notification.entity';
+import { EventCategory } from '../common/event-catalog';
+import {
+  FanoutRequestDto,
+  FanoutResultDto,
+} from './dto/fanout.dto';
+
+/**
+ * Maps notification types to the watchlist item type they relate to.
+ * Used to resolve which users' watchlists are relevant for a given event.
+ */
+const NOTIFICATION_TO_WATCHLIST_TYPE: Record<string, WatchlistItemType> = {
+  [NotificationType.PROJECT]: WatchlistItemType.PROJECT,
+  [NotificationType.CONTRIBUTION]: WatchlistItemType.PROJECT,
+  [NotificationType.MILESTONE]: WatchlistItemType.PROJECT,
+  [NotificationType.GOVERNANCE]: WatchlistItemType.PROJECT,
+  [NotificationType.TOKEN]: WatchlistItemType.ASSET,
+  [NotificationType.POOL]: WatchlistItemType.ASSET,
+  [NotificationType.PRICE]: WatchlistItemType.ASSET,
+};
+
+/**
+ * Maps EventCategory to the NotificationEventCategory strings used in preferences
+ */
+const EVENT_CATEGORY_TO_PREFERENCE_KEY: Record<string, string> = {
+  [EventCategory.PROJECT]: 'project',
+  [EventCategory.CONTRIBUTION]: 'contribution',
+  [EventCategory.MILESTONE]: 'milestone',
+  [EventCategory.GOVERNANCE]: 'governance',
+  [EventCategory.TOKEN]: 'token',
+  [EventCategory.POOL]: 'pool',
+  [EventCategory.PRICE]: 'price',
+  [EventCategory.MODULE]: 'system_alert',
+  [EventCategory.ADMIN]: 'system_alert',
+  [EventCategory.REPUTATION]: 'portfolio_update',
+  [EventCategory.SYSTEM]: 'anomaly',
+};
+
+@Injectable()
+export class NotificationFanoutService {
+  private readonly logger = new Logger(NotificationFanoutService.name);
+
+  constructor(
+    private readonly notificationService: NotificationService,
+    private readonly preferenceService: NotificationPreferenceService,
+    private readonly deliveryService: NotificationDeliveryService,
+    @InjectRepository(WatchlistItem)
+    private readonly watchlistRepository: Repository<WatchlistItem>,
+    @InjectRepository(NotificationSuppressionLog)
+    private readonly suppressionLogRepository: Repository<NotificationSuppressionLog>,
+  ) {}
+
+  /**
+   * Fan out a notification to all users whose watchlists match the event context,
+   * filtered by their stored notification preferences.
+   */
+  async fanout(request: FanoutRequestDto): Promise<FanoutResultDto> {
+    const { notification, targetUserIds, symbols } = request;
+    const eventCategoryKey =
+      EVENT_CATEGORY_TO_PREFERENCE_KEY[notification.eventCategory] ??
+      notification.eventCategory;
+
+    // Resolve target user IDs from watchlists or explicit list
+    const resolvedUserIds = await this.resolveTargetUsers(
+      notification.type,
+      notification.metadata,
+      targetUserIds,
+      symbols,
+    );
+
+    this.logger.log(
+      `Fanout for ${notification.type} [${notification.eventCategory}]: ` +
+        `${resolvedUserIds.length} target users resolved`,
+    );
+
+    const result: FanoutResultDto = {
+      totalTargeted: resolvedUserIds.length,
+      delivered: 0,
+      suppressed: 0,
+      suppressionBreakdown: {},
+      notificationIds: [],
+    };
+
+    // Process each target user
+    for (const userId of resolvedUserIds) {
+      const suppressionReason = await this.checkSuppression(
+        userId,
+        eventCategoryKey,
+        notification.severity,
+      );
+
+      if (suppressionReason) {
+        result.suppressed++;
+        result.suppressionBreakdown[suppressionReason] =
+          (result.suppressionBreakdown[suppressionReason] ?? 0) + 1;
+
+        await this.logSuppression(
+          userId,
+          notification.eventCategory,
+          notification.type,
+          suppressionReason,
+        );
+        continue;
+      }
+
+      // Create the notification for this user
+      const createDto: CreateNotificationDto = {
+        type: notification.type,
+        title: notification.title,
+        message: notification.message,
+        severity: notification.severity,
+        metadata: {
+          ...notification.metadata,
+          fanout: true,
+          eventCategory: notification.eventCategory,
+        },
+        userId,
+      };
+
+      const savedNotification =
+        await this.notificationService.create(createDto);
+
+      result.notificationIds.push(savedNotification.id);
+
+      // Deliver to all enabled channels
+      try {
+        const logs = await this.deliveryService.deliverToUser(
+          savedNotification,
+          userId,
+          eventCategoryKey,
+        );
+        result.delivered += logs.length > 0 ? 1 : 0;
+      } catch (error) {
+        this.logger.error(
+          `Delivery failed for user ${userId}, notification ${savedNotification.id}`,
+          error,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Fanout complete: ${result.delivered} delivered, ` +
+        `${result.suppressed} suppressed out of ${result.totalTargeted} targeted`,
+    );
+
+    return result;
+  }
+
+  /**
+   * Resolve which users should receive this notification based on
+   * watchlist membership and/or explicit targeting.
+   */
+  private async resolveTargetUsers(
+    notificationType: string,
+    metadata: Record<string, unknown> | undefined,
+    explicitUserIds: string[] | undefined,
+    explicitSymbols: string[] | undefined,
+  ): Promise<string[]> {
+    // If explicit user IDs are provided, use those directly
+    if (explicitUserIds && explicitUserIds.length > 0) {
+      return [...new Set(explicitUserIds)];
+    }
+
+    // Determine symbols to match against watchlists
+    const symbolsToMatch = this.extractSymbolsFromMetadata(
+      notificationType,
+      metadata,
+      explicitSymbols,
+    );
+
+    if (symbolsToMatch.length === 0) {
+      this.logger.warn(
+        `No symbols resolved for fanout of ${notificationType}. ` +
+          `Provide explicit targetUserIds or ensure metadata contains relevant identifiers.`,
+      );
+      return [];
+    }
+
+    // Determine watchlist type to filter by
+    const watchlistType = NOTIFICATION_TO_WATCHLIST_TYPE[notificationType];
+
+    // Find all users who have any of these symbols in their watchlist
+    const query = this.watchlistRepository
+      .createQueryBuilder('w')
+      .select('DISTINCT w.userId', 'userId')
+      .where('w.symbol IN (:...symbols)', { symbols: symbolsToMatch });
+
+    if (watchlistType) {
+      query.andWhere('w.type = :type', { type: watchlistType });
+    }
+
+    const rows = await query.getRawMany<{ userId: string }>();
+    return rows.map((r) => r.userId);
+  }
+
+  /**
+   * Extract relevant symbols from the notification metadata.
+   * Supports explicit symbols override, then falls back to metadata fields.
+   */
+  private extractSymbolsFromMetadata(
+    notificationType: string,
+    metadata: Record<string, unknown> | undefined,
+    explicitSymbols: string[] | undefined,
+  ): string[] {
+    if (explicitSymbols && explicitSymbols.length > 0) {
+      return explicitSymbols.map((s) => s.toUpperCase());
+    }
+
+    if (!metadata) return [];
+
+    const symbols: string[] = [];
+
+    // Common metadata fields that contain symbol references
+    const symbolFields = ['symbol', 'symbols', 'tokenSymbol', 'assetSymbol'];
+    for (const field of symbolFields) {
+      const val = metadata[field];
+      if (typeof val === 'string') {
+        symbols.push(val.toUpperCase());
+      } else if (Array.isArray(val)) {
+        symbols.push(...val.filter((v): v is string => typeof v === 'string').map((v) => v.toUpperCase()));
+      }
+    }
+
+    // For project-related events, use projectId as a fallback symbol
+    if (
+      [NotificationType.PROJECT, NotificationType.CONTRIBUTION, NotificationType.MILESTONE].includes(
+        notificationType as NotificationType,
+      )
+    ) {
+      const projectId = metadata['projectId'] as string | undefined;
+      if (projectId && !symbols.includes(projectId.toUpperCase())) {
+        symbols.push(projectId.toUpperCase());
+      }
+    }
+
+    return [...new Set(symbols)];
+  }
+
+  /**
+   * Check whether a notification to a specific user should be suppressed.
+   * Returns the suppression reason or null if delivery should proceed.
+   */
+  private async checkSuppression(
+    userId: string,
+    eventCategoryKey: string,
+    severity: NotificationSeverity,
+  ): Promise<SuppressionReason | null> {
+    // Check preferences exist
+    let preferences;
+    try {
+      preferences = await this.preferenceService.findByUserId(userId);
+    } catch {
+      // No preferences found - user gets default delivery (not suppressed)
+      return null;
+    }
+
+    // Check quiet hours
+    if (this.preferenceService.isWithinQuietHours(preferences, severity)) {
+      return SuppressionReason.QUIET_HOURS;
+    }
+
+    // Check severity threshold
+    if (
+      !this.preferenceService.meetsSeverityThreshold(
+        preferences,
+        severity,
+        eventCategoryKey,
+      )
+    ) {
+      return SuppressionReason.SEVERITY_THRESHOLD;
+    }
+
+    // Check daily limit
+    if (await this.preferenceService.hasReachedDailyLimit(userId)) {
+      return SuppressionReason.DAILY_LIMIT;
+    }
+
+    // Check if event category is disabled
+    const eventPref = preferences.eventPreferences[eventCategoryKey];
+    if (eventPref && !eventPref.enabled) {
+      return SuppressionReason.EVENT_CATEGORY_DISABLED;
+    }
+
+    return null;
+  }
+
+  /**
+   * Record a suppression event for debugging and observability.
+   */
+  private async logSuppression(
+    userId: string,
+    eventCategory: string,
+    notificationType: string,
+    reason: SuppressionReason,
+  ): Promise<void> {
+    try {
+      const log = this.suppressionLogRepository.create({
+        userId,
+        eventCategory,
+        notificationType,
+        reason,
+        metadata: { timestamp: new Date().toISOString() },
+      });
+      await this.suppressionLogRepository.save(log);
+    } catch (error) {
+      this.logger.error(
+        `Failed to log suppression for user ${userId}: ${error}`,
+      );
+    }
+  }
+
+  /**
+   * Retrieve suppression logs for observability/debugging.
+   */
+  async getSuppressionLogs(
+    userId?: string,
+    eventCategory?: string,
+    limit: number = 50,
+  ): Promise<NotificationSuppressionLog[]> {
+    const where: Record<string, unknown> = {};
+    if (userId) where.userId = userId;
+    if (eventCategory) where.eventCategory = eventCategory;
+
+    return this.suppressionLogRepository.find({
+      where,
+      order: { createdAt: 'DESC' },
+      take: limit,
+    });
+  }
+}

--- a/apps/backend/src/notification/notification-suppression-log.entity.ts
+++ b/apps/backend/src/notification/notification-suppression-log.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum SuppressionReason {
+  QUIET_HOURS = 'quiet_hours',
+  SEVERITY_THRESHOLD = 'severity_threshold',
+  DAILY_LIMIT = 'daily_limit',
+  EVENT_CATEGORY_DISABLED = 'event_category_disabled',
+  NOT_IN_WATCHLIST = 'not_in_watchlist',
+  NO_PREFERENCES = 'no_preferences',
+  CHANNEL_UNAVAILABLE = 'channel_unavailable',
+}
+
+@Entity('notification_suppression_logs')
+@Index(['userId'])
+@Index(['eventCategory'])
+@Index(['reason'])
+@Index(['createdAt'])
+@Index(['userId', 'eventCategory'])
+export class NotificationSuppressionLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  eventCategory: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  notificationType: string;
+
+  @Column({
+    type: 'enum',
+    enum: SuppressionReason,
+  })
+  reason: SuppressionReason;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, unknown> | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/apps/backend/src/notification/notification.module.ts
+++ b/apps/backend/src/notification/notification.module.ts
@@ -4,10 +4,14 @@ import { Notification } from './notification.entity';
 import { PushToken } from './push-token.entity';
 import { NotificationPreference } from './notification-preference.entity';
 import { NotificationDeliveryLog } from './notification-delivery-log.entity';
+import { NotificationSuppressionLog } from './notification-suppression-log.entity';
+import { WatchlistItem } from '../watchlist/watchlist-item.entity';
 import { NotificationService } from './notification.service';
 import { NotificationPreferenceService } from './notification-preference.service';
 import { NotificationDeliveryService } from './notification-delivery.service';
+import { NotificationFanoutService } from './notification-fanout.service';
 import { NotificationPreferenceController } from './notification-preference.controller';
+import { NotificationFanoutController } from './notification-fanout.controller';
 import { ProfilingModule } from '../common/profiling/profiling.module';
 
 @Module({
@@ -17,6 +21,8 @@ import { ProfilingModule } from '../common/profiling/profiling.module';
       PushToken,
       NotificationPreference,
       NotificationDeliveryLog,
+      NotificationSuppressionLog,
+      WatchlistItem,
     ]),
     ProfilingModule,
   ],
@@ -24,12 +30,14 @@ import { ProfilingModule } from '../common/profiling/profiling.module';
     NotificationService,
     NotificationPreferenceService,
     NotificationDeliveryService,
+    NotificationFanoutService,
   ],
   exports: [
     NotificationService,
     NotificationPreferenceService,
     NotificationDeliveryService,
+    NotificationFanoutService,
   ],
-  controllers: [NotificationPreferenceController],
+  controllers: [NotificationPreferenceController, NotificationFanoutController],
 })
 export class NotificationModule {}


### PR DESCRIPTION
## Summary

This PR implements targeted notification delivery that filters users based on their **watchlist items** and **stored notification preferences**, replacing the previous broad/generic fanout approach.

Closes #1029

---

## What Changed

### New Files
| File | Purpose |
|------|---------|
| `notification-fanout.service.ts` | Core fanout logic — resolves target users from watchlists, checks preferences, creates per-user notifications |
| `notification-fanout.controller.ts` | REST API endpoints for fanout trigger and suppression log querying |
| `notification-suppression-log.entity.ts` | TypeORM entity tracking suppressed notifications with reasons |
| `dto/fanout.dto.ts` | Request/response DTOs with Swagger documentation |
| `add-notification-suppression-logs.sql` | SQL migration for the suppression logs table |
| `notification-fanout.service.spec.ts` | 10 unit tests covering all fanout paths |

### Modified Files
| File | Change |
|------|--------|
| `notification.module.ts` | Registered new services, entities, and controller |

---

## Architecture

```
Event Trigger
     │
     ▼
POST /notifications/fanout
     │
     ▼
NotificationFanoutService.fanout()
     │
     ├── 1. Resolve target users from watchlists
     │      (matches symbols from metadata against watchlist_items)
     │
     ├── 2. For each user, check preferences:
     │      ├── Quiet hours?         → suppress + log
     │      ├── Severity threshold?  → suppress + log
     │      ├── Daily limit?         → suppress + log
     │      └── Category disabled?   → suppress + log
     │
     ├── 3. Create notification (per user)
     │
     └── 4. Deliver to enabled channels
            (IN_APP, EMAIL, PUSH, WEBHOOK, SMS)
```

## Acceptance Criteria Checklist

- [x] **Fanout logic filters by preference and watchlist context**
  - `resolveTargetUsers()` queries `watchlist_items` by symbol extracted from event metadata
  - `checkSuppression()` evaluates quiet hours, severity threshold, daily limits, and per-category enable/disable

- [x] **At least one event category uses targeted delivery**
  - All event categories (project, contribution, milestone, governance, token, pool, price, etc.) are supported
  - `NOTIFICATION_TO_WATCHLIST_TYPE` maps each notification type to the correct watchlist filter (PROJECT or ASSET)
  - `EVENT_CATEGORY_TO_PREFERENCE_KEY` maps event categories to preference keys

- [x] **Suppressed notifications are observable for debugging**
  - `NotificationSuppressionLog` entity records every suppression with userId, eventCategory, notificationType, reason, and metadata
  - `GET /notifications/suppression-logs` endpoint supports filtering by userId and eventCategory
  - Suppression reasons: `quiet_hours`, `severity_threshold`, `daily_limit`, `event_category_disabled`

- [x] **Design remains compatible with additional channels later**
  - Delivery fans out through the existing `NotificationDeliveryService.deliverToUser()` which already supports IN_APP, EMAIL, PUSH, WEBHOOK, and SMS channels
  - New channels can be added to `NotificationChannel` enum without touching fanout logic

---

## API Endpoints

### `POST /notifications/fanout`
Trigger targeted notification fanout.

**Request body:**
```json
{
  "notification": {
    "type": "project",
    "title": "Project Verified",
    "message": "Project LUMEN has been verified",
    "severity": "high",
    "eventCategory": "project",
    "metadata": { "symbol": "LUMEN", "projectId": "abc-123" }
  },
  "targetUserIds": ["optional-explicit-user-id"],
  "symbols": ["optional-explicit-symbol"]
}
```

**Response:**
```json
{
  "totalTargeted": 15,
  "delivered": 12,
  "suppressed": 3,
  "suppressionBreakdown": {
    "quiet_hours": 2,
    "severity_threshold": 1
  },
  "notificationIds": ["uuid-1", "uuid-2", "..."]
}
```

### `GET /notifications/suppression-logs?userId=&eventCategory=&limit=50`
Query suppression logs for debugging.

---

## Testing

All 10 unit tests pass:
- ✅ Delivers to watchlist-matching users
- ✅ Suppresses during quiet hours
- ✅ Suppresses below severity threshold
- ✅ Suppresses for disabled event categories
- ✅ Uses explicit targetUserIds when provided
- ✅ Returns empty result when no symbols/targets
- ✅ Extracts symbols from metadata correctly
- ✅ Returns suppression logs
- ✅ Filters suppression logs by event category
- ✅ Defined and injectable

---

## Migration

A new SQL migration `add-notification-suppression-logs.sql` creates the `notification_suppression_logs` table with indexes on userId, eventCategory, reason, and createdAt for efficient querying.

---

## Screenshots

N/A — Backend-only change.

---

## Checklist

- [x] Code follows existing NestJS patterns and conventions
- [x] TypeORM entity with proper indexes
- [x] DTOs with class-validator and Swagger decorators
- [x] Unit tests with mocked repositories (following existing test patterns)
- [x] No breaking changes to existing endpoints
- [x] Module registration updated
- [x] SQL migration provided
- [x] All existing tests continue to pass