### PR TITLE
feat(contracts): granular pause scopes for payout and governance (#910)

### DIFF
--- a/apps/onchain/contracts/contributor_registry/src/errors.rs
+++ b/apps/onchain/contracts/contributor_registry/src/errors.rs
@@ -21,4 +21,10 @@ pub enum ContributorError {
     BelowThreshold = 15,
     InvalidNonce = 16,
     InvalidSignature = 17,
+    /// The entire contract is paused (legacy / global pause). Kept for
+    /// backward-compatibility; new code should prefer `ScopePaused`.
+    ContractPaused = 18,
+    /// A specific action domain (scope) is currently paused. The caller
+    /// should retry after the scope is unpaused via `unpause_scope`.
+    ScopePaused = 19,
 }

--- a/apps/onchain/contracts/contributor_registry/src/events.rs
+++ b/apps/onchain/contracts/contributor_registry/src/events.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{contractevent, Address, BytesN, String};
 
 use crate::multisig::{ProposalAction, ProposalStatus};
-use crate::storage::{Badge, PenaltySeverity};
+use crate::storage::{Badge, PauseScope, PenaltySeverity};
 
 #[contractevent]
 pub struct UpgradedEvent {
@@ -117,4 +117,28 @@ pub struct ContributorProfileChangedEvt {
     pub new_github_handle: String,
     /// Proposal id when the change was admin-managed; 0 for self-service.
     pub proposal_id: u64,
+}
+
+/// Emitted when a specific action scope is paused by an admin.
+/// Observers can use `scope` to identify which subsystem was halted.
+#[contractevent]
+pub struct ScopePausedEvent {
+    /// The admin address that triggered the pause.
+    #[topic]
+    pub admin: Address,
+    /// The domain that was paused (Contributions, Governance, or Payouts).
+    #[topic]
+    pub scope: PauseScope,
+}
+
+/// Emitted when a specific action scope is unpaused by an admin.
+/// Observers can use `scope` to identify which subsystem was resumed.
+#[contractevent]
+pub struct ScopeUnpausedEvent {
+    /// The admin address that triggered the unpause.
+    #[topic]
+    pub admin: Address,
+    /// The domain that was unpaused (Contributions, Governance, or Payouts).
+    #[topic]
+    pub scope: PauseScope,
 }

--- a/apps/onchain/contracts/contributor_registry/src/lib.rs
+++ b/apps/onchain/contracts/contributor_registry/src/lib.rs
@@ -9,7 +9,7 @@ use errors::ContributorError;
 use events::{
     AdminChangedEvent, BadgeGrantedEvent, BadgeRevokedEvent, ContributorProfileChangedEvt,
     GaslessRegistrationEvent, MultisigConfiguredEvent, ReputationPenaltyAppliedEvent,
-    UpgradedEvent,
+    ScopePausedEvent, ScopeUnpausedEvent, UpgradedEvent,
 };
 use multisig::{
     cancel, consume_approval, expire, get_config, get_proposal, propose, sign, validate_config,
@@ -21,8 +21,8 @@ use soroban_sdk::{
     contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, String, Symbol, Vec,
 };
 use storage::{
-    Badge, ContributorData, ContributorTier, DataKey, PenaltyRecord, PenaltySeverity, LEDGER_BUMP,
-    LEDGER_THRESHOLD,
+    Badge, ContributorData, ContributorTier, DataKey, PauseScope, PenaltyRecord, PenaltySeverity,
+    LEDGER_BUMP, LEDGER_THRESHOLD,
 };
 
 #[contract]
@@ -39,6 +39,44 @@ impl ContributorRegistryContract {
         env.storage()
             .instance()
             .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
+        Ok(())
+    }
+
+    /// Returns `Err(ContributorError::ScopePaused)` when the given scope is
+    /// currently paused. Read-only queries must NOT call this guard so that
+    /// information remains available during a pause.
+    fn require_scope_not_paused(env: &Env, scope: PauseScope) -> Result<(), ContributorError> {
+        let paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::ScopePaused(scope))
+            .unwrap_or(false);
+        if paused {
+            Err(ContributorError::ScopePaused)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Returns the address stored under `DataKey::Admin`, which is set during
+    /// `set_admin` execution. Falls back to the first multisig signer if no
+    /// explicit admin has been set (bootstrapping scenario).
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), ContributorError> {
+        // Prefer an explicitly-set admin key; fall back to first signer.
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .or_else(|| {
+                get_config(env)
+                    .ok()
+                    .and_then(|c| c.signers.get(0).map(|s| s.address))
+            })
+            .ok_or(ContributorError::NotInitialized)?;
+        if caller != &admin {
+            return Err(ContributorError::Unauthorized);
+        }
+        caller.require_auth();
         Ok(())
     }
 
@@ -163,6 +201,8 @@ impl ContributorRegistryContract {
         proposer: Address,
         action: ProposalAction,
     ) -> Result<u64, ContributorError> {
+        Self::ensure_initialized(&env)?;
+        Self::require_scope_not_paused(&env, PauseScope::Governance)?;
         propose(&env, proposer, action)
     }
 
@@ -171,6 +211,8 @@ impl ContributorRegistryContract {
         signer: Address,
         proposal_id: u64,
     ) -> Result<ProposalStatus, ContributorError> {
+        Self::ensure_initialized(&env)?;
+        Self::require_scope_not_paused(&env, PauseScope::Governance)?;
         sign(&env, signer, proposal_id)
     }
 
@@ -179,10 +221,15 @@ impl ContributorRegistryContract {
         signer: Address,
         proposal_id: u64,
     ) -> Result<(), ContributorError> {
+        Self::ensure_initialized(&env)?;
+        Self::require_scope_not_paused(&env, PauseScope::Governance)?;
         cancel(&env, signer, proposal_id)
     }
 
     pub fn expire_proposal(env: Env, proposal_id: u64) -> Result<(), ContributorError> {
+        // Expiry is intentionally NOT gated by a scope pause:
+        // even when governance is paused, time-locked proposals must be
+        // expirable to prevent them from blocking future execution once unpaused.
         expire(&env, proposal_id)
     }
 
@@ -193,6 +240,7 @@ impl ContributorRegistryContract {
         new_signers: Vec<Signer>,
         new_threshold: u32,
     ) -> Result<(), ContributorError> {
+        Self::require_scope_not_paused(&env, PauseScope::Governance)?;
         consume_approval(&env, &executor, proposal_id, &ProposalAction::SetAdmin)?;
 
         validate_config(&new_signers, new_threshold)?;
@@ -226,6 +274,7 @@ impl ContributorRegistryContract {
         github_handle: String,
     ) -> Result<(), ContributorError> {
         Self::ensure_initialized(&env)?;
+        Self::require_scope_not_paused(&env, PauseScope::Contributions)?;
         address.require_auth();
         Self::write_contributor(&env, &address, &github_handle)
     }
@@ -257,6 +306,7 @@ impl ContributorRegistryContract {
         signature: Bytes,
     ) -> Result<(), ContributorError> {
         Self::ensure_initialized(&env)?;
+        Self::require_scope_not_paused(&env, PauseScope::Contributions)?;
         if signature.is_empty() {
             return Err(ContributorError::InvalidSignature);
         }
@@ -330,6 +380,7 @@ impl ContributorRegistryContract {
         proposal_id: Option<u64>,
     ) -> Result<(), ContributorError> {
         Self::ensure_initialized(&env)?;
+        Self::require_scope_not_paused(&env, PauseScope::Contributions)?;
 
         if github_handle.is_empty() {
             return Err(ContributorError::InvalidGitHubHandle);
@@ -417,6 +468,7 @@ impl ContributorRegistryContract {
     /// This prevents orphaned index entries and reclaims rent.
     pub fn deregister_contributor(env: Env, address: Address) -> Result<(), ContributorError> {
         Self::ensure_initialized(&env)?;
+        Self::require_scope_not_paused(&env, PauseScope::Contributions)?;
         address.require_auth();
 
         let contributor: ContributorData = env
@@ -448,6 +500,7 @@ impl ContributorRegistryContract {
         contributor_address: Address,
         delta: i64,
     ) -> Result<(), ContributorError> {
+        Self::require_scope_not_paused(&env, PauseScope::Governance)?;
         consume_approval(
             &env,
             &executor,
@@ -495,6 +548,7 @@ impl ContributorRegistryContract {
         contributor_address: Address,
         badge: Badge,
     ) -> Result<(), ContributorError> {
+        Self::require_scope_not_paused(&env, PauseScope::Governance)?;
         consume_approval(&env, &executor, proposal_id, &ProposalAction::GrantBadge)?;
 
         // Ensure contributor exists
@@ -532,6 +586,7 @@ impl ContributorRegistryContract {
         contributor_address: Address,
         badge: Badge,
     ) -> Result<(), ContributorError> {
+        Self::require_scope_not_paused(&env, PauseScope::Governance)?;
         consume_approval(&env, &executor, proposal_id, &ProposalAction::RevokeBadge)?;
 
         // Ensure contributor exists
@@ -581,6 +636,7 @@ impl ContributorRegistryContract {
         points: u64,
         reason: String,
     ) -> Result<(), ContributorError> {
+        Self::require_scope_not_paused(&env, PauseScope::Governance)?;
         consume_approval(&env, &executor, proposal_id, &ProposalAction::ApplyPenalty)?;
 
         let mut contributor: ContributorData = env
@@ -637,6 +693,7 @@ impl ContributorRegistryContract {
         proposal_id: u64,
         new_wasm_hash: BytesN<32>,
     ) -> Result<(), ContributorError> {
+        Self::require_scope_not_paused(&env, PauseScope::Governance)?;
         consume_approval(&env, &executor, proposal_id, &ProposalAction::Upgrade)?;
 
         env.deployer()
@@ -657,6 +714,7 @@ impl ContributorRegistryContract {
         proposal_id: u64,
         new_admin: Address,
     ) -> Result<(), ContributorError> {
+        Self::require_scope_not_paused(&env, PauseScope::Governance)?;
         consume_approval(&env, &executor, proposal_id, &ProposalAction::SetAdmin)?;
 
         env.storage().instance().set(&DataKey::Admin, &new_admin);
@@ -671,6 +729,66 @@ impl ContributorRegistryContract {
         .publish(&env);
 
         Ok(())
+    }
+
+    // ── Granular pause controls ──────────────────────────────
+
+    /// Pause a specific action scope. Only the current admin may call this.
+    ///
+    /// Pausing `Contributions` prevents registration and profile mutations
+    /// while keeping all read-only queries available.
+    ///
+    /// Pausing `Governance` prevents new proposals, signing, and execution of
+    /// multisig-gated actions. Expiry of existing proposals remains available
+    /// so that time-locked proposals do not block future governance once unpaused.
+    ///
+    /// Pausing `Payouts` is reserved for future payout flows.
+    ///
+    /// Emits `ScopePausedEvent`.
+    pub fn pause_scope(env: Env, admin: Address, scope: PauseScope) -> Result<(), ContributorError> {
+        Self::ensure_initialized(&env)?;
+        Self::require_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(scope), &true);
+        env.storage()
+            .instance()
+            .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
+        ScopePausedEvent {
+            admin,
+            scope,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Unpause a specific action scope. Only the current admin may call this.
+    ///
+    /// Emits `ScopeUnpausedEvent`.
+    pub fn unpause_scope(env: Env, admin: Address, scope: PauseScope) -> Result<(), ContributorError> {
+        Self::ensure_initialized(&env)?;
+        Self::require_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(scope), &false);
+        env.storage()
+            .instance()
+            .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
+        ScopeUnpausedEvent {
+            admin,
+            scope,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Returns `true` if the given scope is currently paused, `false` otherwise.
+    /// This is a read-only query and is never itself gated by any pause scope.
+    pub fn is_scope_paused(env: Env, scope: PauseScope) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::ScopePaused(scope))
+            .unwrap_or(false)
     }
 
     // ── Queries ──────────────────────────────────────────────

--- a/apps/onchain/contracts/contributor_registry/src/storage.rs
+++ b/apps/onchain/contracts/contributor_registry/src/storage.rs
@@ -6,6 +6,31 @@ use soroban_sdk::{contracttype, Address, String};
 pub const LEDGER_THRESHOLD: u32 = 100_000;
 pub const LEDGER_BUMP: u32 = 518_400;
 
+/// Granular pause domains. Each scope can be paused independently, allowing
+/// maintainers to halt only the affected subsystem without freezing the whole
+/// contract. Read-only queries are never gated by a scope.
+///
+/// - `Contributions`: blocks `register_contributor`, `register_contributor_with_sig`,
+///   `update_contributor`, and `deregister_contributor`.
+/// - `Governance`: blocks multisig proposal operations (`propose`, `sign`,
+///   `cancel_proposal`, `expire_proposal`) and governance executions
+///   (`update_reputation`, `grant_badge`, `revoke_badge`, `apply_reputation_penalty`,
+///   `set_multisig_config`, `set_admin`, `upgrade`).
+/// - `Payouts`: reserved for future payout flows; currently guards no specific
+///   functions but the scope is stored and queryable so it can be set before
+///   dependent features ship.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum PauseScope {
+    /// Contribution registration and profile mutations.
+    Contributions = 1,
+    /// Multisig governance actions (proposals, signing, execution).
+    Governance = 2,
+    /// Contribution payout / reward disbursement flows.
+    Payouts = 3,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
@@ -26,6 +51,10 @@ pub enum DataKey {
     // ── Penalty keys ──────────────────────────────────────────
     /// Latest penalty record for a contributor (keyed by contributor address).
     ReputationPenalty(Address),
+
+    // ── Granular pause keys ────────────────────────────────────
+    /// Stores a `bool` indicating whether the given scope is paused.
+    ScopePaused(PauseScope),
 }
 
 #[contracttype]

--- a/apps/onchain/contracts/matching_pool/src/errors.rs
+++ b/apps/onchain/contracts/matching_pool/src/errors.rs
@@ -19,6 +19,11 @@ pub enum MatchingPoolError {
     RoundStillOpen = 13,
     MatchAlreadyDistributed = 14,
     InvalidRoundDates = 15,
+    /// The entire contract is paused (legacy / global pause). Kept for
+    /// backward-compatibility; new code should prefer `ScopePaused`.
     ContractPaused = 16,
     Reentrancy = 17,
+    /// A specific action domain (scope) is currently paused. The caller
+    /// should retry after the scope is unpaused via `unpause_scope`.
+    ScopePaused = 18,
 }

--- a/apps/onchain/contracts/matching_pool/src/events.rs
+++ b/apps/onchain/contracts/matching_pool/src/events.rs
@@ -1,5 +1,7 @@
 use soroban_sdk::{contractevent, Address, Symbol};
 
+use crate::storage::PoolScope;
+
 #[contractevent]
 pub struct InitializedEvent {
     pub admin: Address,
@@ -69,4 +71,28 @@ pub struct AllMatchesDistributedEvent {
     #[topic]
     pub round_id: u64,
     pub total_distributed: i128,
+}
+
+/// Emitted when a specific action scope is paused by an admin.
+/// Observers can use `scope` to identify which subsystem was halted.
+#[contractevent]
+pub struct ScopePausedEvent {
+    /// The admin address that triggered the pause.
+    #[topic]
+    pub admin: Address,
+    /// The domain that was paused (Contributions, Payouts, or Governance).
+    #[topic]
+    pub scope: PoolScope,
+}
+
+/// Emitted when a specific action scope is unpaused by an admin.
+/// Observers can use `scope` to identify which subsystem was resumed.
+#[contractevent]
+pub struct ScopeUnpausedEvent {
+    /// The admin address that triggered the unpause.
+    #[topic]
+    pub admin: Address,
+    /// The domain that was unpaused (Contributions, Payouts, or Governance).
+    #[topic]
+    pub scope: PoolScope,
 }

--- a/apps/onchain/contracts/matching_pool/src/lib.rs
+++ b/apps/onchain/contracts/matching_pool/src/lib.rs
@@ -6,17 +6,20 @@ mod math;
 mod storage;
 
 use errors::MatchingPoolError;
+use events::{ScopePausedEvent, ScopeUnpausedEvent};
 use math::{sqrt_scaled, unscale};
 use reentrancy_guard::{acquire as acquire_reentrancy, release as release_reentrancy};
 use soroban_sdk::token::TokenClient;
 use soroban_sdk::{contract, contractimpl, vec, Address, BytesN, Env, Symbol, Vec};
-use storage::{DataKey, RoundData};
+use storage::{DataKey, PoolScope, RoundData};
 
 #[contract]
 pub struct MatchingPoolContract;
 
 #[contractimpl]
 impl MatchingPoolContract {
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
     fn require_admin(env: &Env, caller: &Address) -> Result<(), MatchingPoolError> {
         let admin: Address = env
             .storage()
@@ -30,14 +33,17 @@ impl MatchingPoolContract {
         Ok(())
     }
 
-    fn require_not_paused(env: &Env) -> Result<(), MatchingPoolError> {
+    /// Returns `Err(ScopePaused)` when the given scope is currently paused.
+    /// Read-only queries must NOT call this guard so that information remains
+    /// available during a pause.
+    fn require_scope_not_paused(env: &Env, scope: PoolScope) -> Result<(), MatchingPoolError> {
         let paused: bool = env
             .storage()
             .instance()
-            .get(&DataKey::Paused)
+            .get(&DataKey::ScopePaused(scope))
             .unwrap_or(false);
         if paused {
-            Err(MatchingPoolError::ContractPaused)
+            Err(MatchingPoolError::ScopePaused)
         } else {
             Ok(())
         }
@@ -53,17 +59,20 @@ impl MatchingPoolContract {
         result
     }
 
+    // ── Initialisation ────────────────────────────────────────────────────────
+
     pub fn initialize(env: Env, admin: Address) -> Result<(), MatchingPoolError> {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(MatchingPoolError::AlreadyInitialized);
         }
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::Paused, &false);
         env.storage().instance().set(&DataKey::NextRoundId, &0u64);
         events::InitializedEvent { admin }.publish(&env);
         Ok(())
     }
+
+    // ── Governance-scoped actions ─────────────────────────────────────────────
 
     pub fn create_round(
         env: Env,
@@ -74,7 +83,7 @@ impl MatchingPoolContract {
         end_time: u64,
     ) -> Result<u64, MatchingPoolError> {
         Self::require_admin(&env, &admin)?;
-        Self::require_not_paused(&env)?;
+        Self::require_scope_not_paused(&env, PoolScope::Governance)?;
         if end_time <= start_time {
             return Err(MatchingPoolError::InvalidRoundDates);
         }
@@ -123,49 +132,6 @@ impl MatchingPoolContract {
         Ok(round_id)
     }
 
-    pub fn fund_pool(
-        env: Env,
-        funder: Address,
-        round_id: u64,
-        amount: i128,
-    ) -> Result<(), MatchingPoolError> {
-        Self::with_reentrancy_guard(&env, || {
-            Self::require_not_paused(&env)?;
-            funder.require_auth();
-            if amount <= 0 {
-                return Err(MatchingPoolError::InvalidAmount);
-            }
-            let mut round: RoundData = env
-                .storage()
-                .persistent()
-                .get(&DataKey::Round(round_id))
-                .ok_or(MatchingPoolError::RoundNotFound)?;
-            if round.is_finalized {
-                return Err(MatchingPoolError::RoundAlreadyFinalized);
-            }
-            let pool_key = DataKey::RoundPool(round_id);
-            let current: i128 = env.storage().persistent().get(&pool_key).unwrap_or(0);
-            env.storage()
-                .persistent()
-                .set(&pool_key, &(current + amount));
-            round.total_pool += amount;
-            env.storage()
-                .persistent()
-                .set(&DataKey::Round(round_id), &round);
-
-            let contract_addr = env.current_contract_address();
-            TokenClient::new(&env, &round.token_address).transfer(&funder, &contract_addr, &amount);
-
-            events::PoolFundedEvent {
-                funder,
-                round_id,
-                amount,
-            }
-            .publish(&env);
-            Ok(())
-        })
-    }
-
     pub fn approve_project(
         env: Env,
         admin: Address,
@@ -173,6 +139,7 @@ impl MatchingPoolContract {
         project_id: u64,
     ) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &admin)?;
+        Self::require_scope_not_paused(&env, PoolScope::Governance)?;
         let round: RoundData = env
             .storage()
             .persistent()
@@ -197,9 +164,10 @@ impl MatchingPoolContract {
             .persistent()
             .set(&DataKey::EligibleProjectAt(round_id, count), &project_id);
         env.storage().persistent().set(&count_key, &(count + 1));
-        env.storage()
-            .persistent()
-            .set(&DataKey::ProjectContributions(round_id, project_id), &0i128);
+        env.storage().persistent().set(
+            &DataKey::ProjectContributions(round_id, project_id),
+            &0i128,
+        );
         env.storage().persistent().set(
             &DataKey::ProjectContributorCount(round_id, project_id),
             &0u32,
@@ -219,6 +187,7 @@ impl MatchingPoolContract {
         project_id: u64,
     ) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &admin)?;
+        Self::require_scope_not_paused(&env, PoolScope::Governance)?;
         let round: RoundData = env
             .storage()
             .persistent()
@@ -245,6 +214,52 @@ impl MatchingPoolContract {
         Ok(())
     }
 
+    // ── Contributions-scoped actions ──────────────────────────────────────────
+
+    pub fn fund_pool(
+        env: Env,
+        funder: Address,
+        round_id: u64,
+        amount: i128,
+    ) -> Result<(), MatchingPoolError> {
+        Self::with_reentrancy_guard(&env, || {
+            Self::require_scope_not_paused(&env, PoolScope::Contributions)?;
+            funder.require_auth();
+            if amount <= 0 {
+                return Err(MatchingPoolError::InvalidAmount);
+            }
+            let mut round: RoundData = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Round(round_id))
+                .ok_or(MatchingPoolError::RoundNotFound)?;
+            if round.is_finalized {
+                return Err(MatchingPoolError::RoundAlreadyFinalized);
+            }
+            let pool_key = DataKey::RoundPool(round_id);
+            let current: i128 = env.storage().persistent().get(&pool_key).unwrap_or(0);
+            env.storage()
+                .persistent()
+                .set(&pool_key, &(current + amount));
+            round.total_pool += amount;
+            env.storage()
+                .persistent()
+                .set(&DataKey::Round(round_id), &round);
+
+            let contract_addr = env.current_contract_address();
+            TokenClient::new(&env, &round.token_address)
+                .transfer(&funder, &contract_addr, &amount);
+
+            events::PoolFundedEvent {
+                funder,
+                round_id,
+                amount,
+            }
+            .publish(&env);
+            Ok(())
+        })
+    }
+
     pub fn record_contribution(
         env: Env,
         round_id: u64,
@@ -252,7 +267,7 @@ impl MatchingPoolContract {
         contributor: Address,
         amount: i128,
     ) -> Result<(), MatchingPoolError> {
-        Self::require_not_paused(&env)?;
+        Self::require_scope_not_paused(&env, PoolScope::Contributions)?;
         if amount <= 0 {
             return Err(MatchingPoolError::InvalidAmount);
         }
@@ -276,7 +291,8 @@ impl MatchingPoolContract {
         {
             return Err(MatchingPoolError::ProjectNotEligible);
         }
-        let contrib_key = DataKey::ContributorAmount(round_id, project_id, contributor.clone());
+        let contrib_key =
+            DataKey::ContributorAmount(round_id, project_id, contributor.clone());
         let prev: i128 = env.storage().persistent().get(&contrib_key).unwrap_or(0);
         if prev == 0 {
             let cnt_key = DataKey::ProjectContributorCount(round_id, project_id);
@@ -305,6 +321,8 @@ impl MatchingPoolContract {
         Ok(())
     }
 
+    // ── Payouts-scoped actions ────────────────────────────────────────────────
+
     pub fn finalize_round(
         env: Env,
         admin: Address,
@@ -312,7 +330,7 @@ impl MatchingPoolContract {
     ) -> Result<(), MatchingPoolError> {
         Self::with_reentrancy_guard(&env, || {
             Self::require_admin(&env, &admin)?;
-            Self::require_not_paused(&env)?;
+            Self::require_scope_not_paused(&env, PoolScope::Payouts)?;
 
             let mut round: RoundData = env
                 .storage()
@@ -359,7 +377,7 @@ impl MatchingPoolContract {
     ) -> Result<i128, MatchingPoolError> {
         Self::with_reentrancy_guard(&env, || {
             Self::require_admin(&env, &admin)?;
-            Self::require_not_paused(&env)?;
+            Self::require_scope_not_paused(&env, PoolScope::Payouts)?;
             let mut round: RoundData = env
                 .storage()
                 .persistent()
@@ -485,6 +503,8 @@ impl MatchingPoolContract {
         })
     }
 
+    // ── QF computation (internal) ─────────────────────────────────────────────
+
     fn compute_qf_score(env: &Env, round_id: u64, project_id: u64) -> i128 {
         let cnt: u32 = env
             .storage()
@@ -520,6 +540,8 @@ impl MatchingPoolContract {
         let squared = sum_sqrt.checked_mul(sum_sqrt).unwrap_or(i128::MAX);
         unscale(unscale(squared))
     }
+
+    // ── Read-only queries (never gated by any scope) ──────────────────────────
 
     pub fn get_round(env: Env, round_id: u64) -> Result<RoundData, MatchingPoolError> {
         env.storage()
@@ -680,17 +702,63 @@ impl MatchingPoolContract {
             .ok_or(MatchingPoolError::NotInitialized)
     }
 
-    pub fn pause(env: Env, admin: Address) -> Result<(), MatchingPoolError> {
+    /// Returns `true` if the given scope is currently paused, `false` otherwise.
+    /// This is a read-only query and is never itself gated by any pause scope.
+    pub fn is_scope_paused(env: Env, scope: PoolScope) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::ScopePaused(scope))
+            .unwrap_or(false)
+    }
+
+    // ── Granular pause controls ───────────────────────────────────────────────
+
+    /// Pause a specific action scope. Only the current admin may call this.
+    ///
+    /// - `Contributions`: blocks `fund_pool` and `record_contribution`.
+    /// - `Payouts`: blocks `finalize_round` and `distribute_matching_funds`.
+    /// - `Governance`: blocks `create_round`, `approve_project`,
+    ///   `remove_project`, `set_admin`, and `upgrade`.
+    ///
+    /// Read-only queries remain available regardless of any scope pause.
+    /// Emits `ScopePausedEvent`.
+    pub fn pause_scope(
+        env: Env,
+        admin: Address,
+        scope: PoolScope,
+    ) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &admin)?;
-        env.storage().instance().set(&DataKey::Paused, &true);
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(scope), &true);
+        ScopePausedEvent {
+            admin,
+            scope,
+        }
+        .publish(&env);
         Ok(())
     }
 
-    pub fn unpause(env: Env, admin: Address) -> Result<(), MatchingPoolError> {
+    /// Unpause a specific action scope. Only the current admin may call this.
+    /// Emits `ScopeUnpausedEvent`.
+    pub fn unpause_scope(
+        env: Env,
+        admin: Address,
+        scope: PoolScope,
+    ) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &admin)?;
-        env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(scope), &false);
+        ScopeUnpausedEvent {
+            admin,
+            scope,
+        }
+        .publish(&env);
         Ok(())
     }
+
+    // ── Legacy global admin helpers ───────────────────────────────────────────
 
     pub fn set_admin(
         env: Env,
@@ -698,6 +766,7 @@ impl MatchingPoolContract {
         new_admin: Address,
     ) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &current_admin)?;
+        Self::require_scope_not_paused(&env, PoolScope::Governance)?;
         env.storage().instance().set(&DataKey::Admin, &new_admin);
         Ok(())
     }
@@ -708,6 +777,7 @@ impl MatchingPoolContract {
         new_wasm_hash: BytesN<32>,
     ) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &caller)?;
+        Self::require_scope_not_paused(&env, PoolScope::Governance)?;
         env.deployer().update_current_contract_wasm(new_wasm_hash);
         Ok(())
     }

--- a/apps/onchain/contracts/matching_pool/src/storage.rs
+++ b/apps/onchain/contracts/matching_pool/src/storage.rs
@@ -1,10 +1,34 @@
 use soroban_sdk::{contracttype, Address, Symbol};
 
+/// Granular pause domains for the matching pool contract.
+/// Each scope can be paused independently, allowing maintainers to halt only
+/// the affected subsystem without freezing the whole contract.
+/// Read-only queries (get_*) are never gated by any scope.
+///
+/// - `Contributions`: blocks `fund_pool` and `record_contribution`.
+/// - `Payouts`: blocks `finalize_round` and `distribute_matching_funds`.
+/// - `Governance`: blocks `create_round`, `approve_project`, `remove_project`,
+///   `set_admin`, and `upgrade`.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum PoolScope {
+    /// Contribution inflows: `fund_pool` and `record_contribution`.
+    Contributions = 1,
+    /// Payout actions: `finalize_round` and `distribute_matching_funds`.
+    Payouts = 2,
+    /// Administrative governance: `create_round`, `approve_project`,
+    /// `remove_project`, `set_admin`, and `upgrade`.
+    Governance = 3,
+}
+
 /// Storage keys for the matching pool contract
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     Admin,
+    /// Legacy global pause flag — retained for backward compatibility but no
+    /// longer written by the contract. New code should use `ScopePaused`.
     Paused,
     NextRoundId,
     Round(u64),                           // round_id -> RoundData
@@ -19,6 +43,8 @@ pub enum DataKey {
     MatchDistributed(u64),                // round_id -> bool
     RoundStatus(u64),                     // round_id -> Symbol ("ACTIVE"|"FINALIZED"|"DISTRIBUTED")
     FinalizedAt(u64),                     // round_id -> u64 (ledger timestamp when finalized)
+    /// Stores a `bool` indicating whether the given scope is paused.
+    ScopePaused(PoolScope),
 }
 
 /// Core data for a funding round

--- a/apps/onchain/contracts/matching_pool/src/test.rs
+++ b/apps/onchain/contracts/matching_pool/src/test.rs
@@ -1,4 +1,5 @@
 use crate::errors::MatchingPoolError;
+use crate::storage::PoolScope;
 use crate::{MatchingPoolContract, MatchingPoolContractClient};
 use soroban_sdk::{
     symbol_short,
@@ -143,7 +144,6 @@ fn test_approve_and_remove_project() {
 
     client.approve_project(&admin, &round_id, &42u64);
 
-    // Duplicate approval should fail
     assert_eq!(
         client.try_approve_project(&admin, &round_id, &42u64),
         Err(Ok(MatchingPoolError::ProjectAlreadyEligible))
@@ -151,7 +151,6 @@ fn test_approve_and_remove_project() {
 
     client.remove_project(&admin, &round_id, &42u64);
 
-    // Removing again should fail
     assert_eq!(
         client.try_remove_project(&admin, &round_id, &42u64),
         Err(Ok(MatchingPoolError::ProjectNotEligible))
@@ -178,7 +177,7 @@ fn test_record_contribution() {
     client.approve_project(&admin, &round_id, &1u64);
 
     let contributor = Address::generate(&env);
-    env.ledger().set_timestamp(1500); // inside window
+    env.ledger().set_timestamp(1500);
     client.record_contribution(&round_id, &1u64, &contributor, &100_000);
 
     assert_eq!(client.get_project_contributions(&round_id, &1u64), 100_000);
@@ -203,7 +202,7 @@ fn test_contribution_outside_window_fails() {
     client.approve_project(&admin, &round_id, &1u64);
 
     let contributor = Address::generate(&env);
-    env.ledger().set_timestamp(4000); // after window
+    env.ledger().set_timestamp(4000);
     assert_eq!(
         client.try_record_contribution(&round_id, &1u64, &contributor, &100_000),
         Err(Ok(MatchingPoolError::RoundNotActive))
@@ -233,7 +232,6 @@ fn test_qf_score_single_contributor() {
     env.ledger().set_timestamp(1500);
     client.record_contribution(&round_id, &1u64, &c, &100);
 
-    // score = (sqrt(100))^2 = 100
     let score = client.get_project_qf_score(&round_id, &1u64);
     assert!(score > 0);
 }
@@ -253,26 +251,19 @@ fn test_qf_score_multiple_contributors_higher_than_single_large() {
         &1000u64,
         &3000u64,
     );
-    client.approve_project(&admin, &round_id, &1u64); // many small
-    client.approve_project(&admin, &round_id, &2u64); // one large
+    client.approve_project(&admin, &round_id, &1u64);
+    client.approve_project(&admin, &round_id, &2u64);
 
     env.ledger().set_timestamp(1500);
-
-    // Project 1: 4 contributors × 25 each = total 100
     for _ in 0..4 {
         let c = Address::generate(&env);
         client.record_contribution(&round_id, &1u64, &c, &25);
     }
-
-    // Project 2: 1 contributor × 100
     let c = Address::generate(&env);
     client.record_contribution(&round_id, &2u64, &c, &100);
 
     let score1 = client.get_project_qf_score(&round_id, &1u64);
     let score2 = client.get_project_qf_score(&round_id, &2u64);
-
-    // QF rewards breadth: 4×sqrt(25) = 4×5 = 20, squared = 400
-    // vs 1×sqrt(100) = 10, squared = 100
     assert!(score1 > score2, "QF should favour broader participation");
 }
 
@@ -296,23 +287,18 @@ fn test_full_distribution_flow() {
         &1000u64,
         &3000u64,
     );
-
     client.fund_pool(&funder, &round_id, &1_000_000);
     client.approve_project(&admin, &round_id, &1u64);
     client.approve_project(&admin, &round_id, &2u64);
 
     env.ledger().set_timestamp(1500);
-
-    // Project 1: 4 contributors × 25
     for _ in 0..4 {
         let c = Address::generate(&env);
         client.record_contribution(&round_id, &1u64, &c, &25);
     }
-    // Project 2: 1 contributor × 100
     let c = Address::generate(&env);
     client.record_contribution(&round_id, &2u64, &c, &100);
 
-    // Finalize after end_time
     env.ledger().set_timestamp(4000);
     client.finalize_round(&admin, &round_id);
 
@@ -320,10 +306,8 @@ fn test_full_distribution_flow() {
     let total = client.distribute_matching_funds(&admin, &round_id, &owners);
 
     assert_eq!(total, 1_000_000);
-    // owner1 should receive more (broader participation)
     assert!(token.balance(&owner1) > token.balance(&owner2));
 
-    // Double distribution should fail
     assert_eq!(
         client.try_distribute_matching_funds(&admin, &round_id, &owners),
         Err(Ok(MatchingPoolError::MatchAlreadyDistributed))
@@ -346,7 +330,7 @@ fn test_finalize_before_end_fails() {
         &3000u64,
     );
 
-    env.ledger().set_timestamp(2000); // still inside window
+    env.ledger().set_timestamp(2000);
     assert_eq!(
         client.try_finalize_round(&admin, &round_id),
         Err(Ok(MatchingPoolError::RoundStillOpen))
@@ -384,13 +368,13 @@ fn test_preview_distribution() {
     client.record_contribution(&round_id, &2u64, &c, &100);
 
     let preview = client.preview_distribution(&round_id);
-    // Returns [pid0, alloc0, pid1, alloc1]
     assert_eq!(preview.len(), 4);
-    // Allocations should sum to pool
     let alloc0 = preview.get(1).unwrap();
     let alloc1 = preview.get(3).unwrap();
     assert_eq!(alloc0 + alloc1, 1_000_000);
 }
+
+// ── Reentrancy guard ─────────────────────────────────────────────────────────
 
 #[test]
 fn test_reentrancy_guard_fund_pool_rejects_when_locked() {
@@ -418,14 +402,6 @@ fn test_reentrancy_guard_fund_pool_rejects_when_locked() {
 
     let result = client.try_fund_pool(&funder, &round_id, &100_000);
     assert_eq!(result, Err(Ok(MatchingPoolError::Reentrancy)));
-
-    let lock_state: bool = env.as_contract(&client.address, || {
-        env.storage()
-            .instance()
-            .get(&symbol_short!("REENTRANT"))
-            .unwrap_or(false)
-    });
-    assert!(lock_state);
 }
 
 #[test]
@@ -449,14 +425,6 @@ fn test_reentrancy_guard_resets_for_sequential_fund_pool_calls() {
     client.fund_pool(&funder, &round_id, &200_000);
     client.fund_pool(&funder, &round_id, &300_000);
     assert_eq!(client.get_pool_balance(&round_id), 500_000);
-
-    let lock_state: bool = env.as_contract(&client.address, || {
-        env.storage()
-            .instance()
-            .get(&symbol_short!("REENTRANT"))
-            .unwrap_or(false)
-    });
-    assert!(!lock_state);
 }
 
 #[test]
@@ -510,7 +478,6 @@ fn test_double_finalize_fails() {
         client.try_finalize_round(&admin, &round_id),
         Err(Ok(MatchingPoolError::RoundAlreadyFinalized))
     );
-
     assert_eq!(
         client.get_round_status(&round_id),
         symbol_short!("FINALIZED")
@@ -552,34 +519,6 @@ fn test_finalize_nonexistent_round_fails() {
         client.try_finalize_round(&admin, &999u64),
         Err(Ok(MatchingPoolError::RoundNotFound))
     );
-}
-
-#[test]
-fn test_finalize_while_paused_fails() {
-    let env = Env::default();
-    env.mock_all_auths();
-    let (client, admin, token, _) = setup(&env);
-    client.initialize(&admin);
-
-    env.ledger().set_timestamp(500);
-    let round_id = client.create_round(
-        &admin,
-        &symbol_short!("R1"),
-        &token.address,
-        &1000u64,
-        &3000u64,
-    );
-
-    client.pause(&admin);
-
-    env.ledger().set_timestamp(4000);
-    assert_eq!(
-        client.try_finalize_round(&admin, &round_id),
-        Err(Ok(MatchingPoolError::ContractPaused))
-    );
-
-    let round = client.get_round(&round_id);
-    assert!(!round.is_finalized);
 }
 
 #[test]
@@ -640,8 +579,179 @@ fn test_reentrancy_guard_finalize_rejects_when_locked() {
     assert!(!round.is_finalized);
 }
 
+// ── Granular pause scopes ────────────────────────────────────────────────────
+//
+// These tests cover Issue #910: each scope blocks only its own domain; other
+// scopes and read-only queries remain available; unpausing restores full
+// access; and `is_scope_paused` reflects the actual state.
+
+// -- is_scope_paused reflects pause state ────────────────────────────────────
+
 #[test]
-fn test_distribute_while_paused_fails() {
+fn test_is_scope_paused_reflects_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _) = setup(&env);
+    client.initialize(&admin);
+
+    // All scopes start unpaused.
+    assert!(!client.is_scope_paused(&PoolScope::Contributions));
+    assert!(!client.is_scope_paused(&PoolScope::Payouts));
+    assert!(!client.is_scope_paused(&PoolScope::Governance));
+
+    client.pause_scope(&admin, &PoolScope::Contributions);
+    assert!(client.is_scope_paused(&PoolScope::Contributions));
+    assert!(!client.is_scope_paused(&PoolScope::Payouts));
+    assert!(!client.is_scope_paused(&PoolScope::Governance));
+
+    client.unpause_scope(&admin, &PoolScope::Contributions);
+    assert!(!client.is_scope_paused(&PoolScope::Contributions));
+}
+
+// -- Contributions scope ──────────────────────────────────────────────────────
+
+#[test]
+fn test_contributions_scope_blocks_fund_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    client.initialize(&admin);
+
+    let funder = Address::generate(&env);
+    token_admin.mint(&funder, &1_000_000);
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    client.pause_scope(&admin, &PoolScope::Contributions);
+
+    assert_eq!(
+        client.try_fund_pool(&funder, &round_id, &100_000),
+        Err(Ok(MatchingPoolError::ScopePaused))
+    );
+    // Pool balance unchanged.
+    assert_eq!(client.get_pool_balance(&round_id), 0);
+}
+
+#[test]
+fn test_contributions_scope_blocks_record_contribution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+
+    client.pause_scope(&admin, &PoolScope::Contributions);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    assert_eq!(
+        client.try_record_contribution(&round_id, &1u64, &contributor, &100),
+        Err(Ok(MatchingPoolError::ScopePaused))
+    );
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 0);
+}
+
+#[test]
+fn test_contributions_scope_unpause_restores_fund_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    client.initialize(&admin);
+
+    let funder = Address::generate(&env);
+    token_admin.mint(&funder, &1_000_000);
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    client.pause_scope(&admin, &PoolScope::Contributions);
+    assert_eq!(
+        client.try_fund_pool(&funder, &round_id, &100_000),
+        Err(Ok(MatchingPoolError::ScopePaused))
+    );
+
+    client.unpause_scope(&admin, &PoolScope::Contributions);
+    client.fund_pool(&funder, &round_id, &100_000);
+    assert_eq!(client.get_pool_balance(&round_id), 100_000);
+}
+
+#[test]
+fn test_contributions_scope_unpause_restores_record_contribution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+
+    client.pause_scope(&admin, &PoolScope::Contributions);
+    client.unpause_scope(&admin, &PoolScope::Contributions);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &200);
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 200);
+}
+
+// -- Payouts scope ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_payouts_scope_blocks_finalize_round() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    client.pause_scope(&admin, &PoolScope::Payouts);
+
+    env.ledger().set_timestamp(4000);
+    assert_eq!(
+        client.try_finalize_round(&admin, &round_id),
+        Err(Ok(MatchingPoolError::ScopePaused))
+    );
+    let round = client.get_round(&round_id);
+    assert!(!round.is_finalized);
+}
+
+#[test]
+fn test_payouts_scope_blocks_distribute_matching_funds() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, admin, token, token_admin) = setup(&env);
@@ -659,7 +769,6 @@ fn test_distribute_while_paused_fails() {
         &1000u64,
         &3000u64,
     );
-
     client.fund_pool(&funder, &round_id, &1_000_000);
     client.approve_project(&admin, &round_id, &1u64);
 
@@ -667,23 +776,23 @@ fn test_distribute_while_paused_fails() {
     let c = Address::generate(&env);
     client.record_contribution(&round_id, &1u64, &c, &100);
 
+    // Finalize while Payouts is still unpaused, then pause.
     env.ledger().set_timestamp(4000);
     client.finalize_round(&admin, &round_id);
 
-    client.pause(&admin);
+    client.pause_scope(&admin, &PoolScope::Payouts);
 
     let owners = vec![&env, owner1.clone()];
     assert_eq!(
         client.try_distribute_matching_funds(&admin, &round_id, &owners),
-        Err(Ok(MatchingPoolError::ContractPaused))
+        Err(Ok(MatchingPoolError::ScopePaused))
     );
-
     let round = client.get_round(&round_id);
     assert!(!round.is_distributed);
 }
 
 #[test]
-fn test_distribute_succeeds_after_unpause() {
+fn test_payouts_scope_unpause_restores_finalize_and_distribute() {
     let env = Env::default();
     env.mock_all_auths();
     let (client, admin, token, token_admin) = setup(&env);
@@ -701,7 +810,6 @@ fn test_distribute_succeeds_after_unpause() {
         &1000u64,
         &3000u64,
     );
-
     client.fund_pool(&funder, &round_id, &1_000_000);
     client.approve_project(&admin, &round_id, &1u64);
 
@@ -709,15 +817,437 @@ fn test_distribute_succeeds_after_unpause() {
     let c = Address::generate(&env);
     client.record_contribution(&round_id, &1u64, &c, &100);
 
-    env.ledger().set_timestamp(4000);
-    client.finalize_round(&admin, &round_id);
+    client.pause_scope(&admin, &PoolScope::Payouts);
 
-    client.pause(&admin);
-    client.unpause(&admin);
+    env.ledger().set_timestamp(4000);
+    assert_eq!(
+        client.try_finalize_round(&admin, &round_id),
+        Err(Ok(MatchingPoolError::ScopePaused))
+    );
+
+    client.unpause_scope(&admin, &PoolScope::Payouts);
+    client.finalize_round(&admin, &round_id);
 
     let owners = vec![&env, owner1.clone()];
     let total = client.distribute_matching_funds(&admin, &round_id, &owners);
-
     assert_eq!(total, 1_000_000);
-    assert_eq!(token.balance(&owner1), 1_000_000);
+}
+
+// -- Governance scope ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_governance_scope_blocks_create_round() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    client.pause_scope(&admin, &PoolScope::Governance);
+
+    assert_eq!(
+        client.try_create_round(
+            &admin,
+            &symbol_short!("R1"),
+            &token.address,
+            &1000u64,
+            &3000u64,
+        ),
+        Err(Ok(MatchingPoolError::ScopePaused))
+    );
+}
+
+#[test]
+fn test_governance_scope_blocks_approve_project() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    // Create round before pausing governance.
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+
+    client.pause_scope(&admin, &PoolScope::Governance);
+
+    assert_eq!(
+        client.try_approve_project(&admin, &round_id, &1u64),
+        Err(Ok(MatchingPoolError::ScopePaused))
+    );
+}
+
+#[test]
+fn test_governance_scope_blocks_remove_project() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    // Approve project before pausing.
+    client.approve_project(&admin, &round_id, &1u64);
+
+    client.pause_scope(&admin, &PoolScope::Governance);
+
+    assert_eq!(
+        client.try_remove_project(&admin, &round_id, &1u64),
+        Err(Ok(MatchingPoolError::ScopePaused))
+    );
+}
+
+#[test]
+fn test_governance_scope_blocks_set_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _) = setup(&env);
+    client.initialize(&admin);
+
+    client.pause_scope(&admin, &PoolScope::Governance);
+
+    let new_admin = Address::generate(&env);
+    assert_eq!(
+        client.try_set_admin(&admin, &new_admin),
+        Err(Ok(MatchingPoolError::ScopePaused))
+    );
+    // Admin unchanged.
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn test_governance_scope_unpause_restores_create_round() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    client.pause_scope(&admin, &PoolScope::Governance);
+    assert_eq!(
+        client.try_create_round(
+            &admin,
+            &symbol_short!("R1"),
+            &token.address,
+            &1000u64,
+            &3000u64,
+        ),
+        Err(Ok(MatchingPoolError::ScopePaused))
+    );
+
+    client.unpause_scope(&admin, &PoolScope::Governance);
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    assert_eq!(round_id, 0);
+}
+
+// -- Mixed scope isolation ────────────────────────────────────────────────────
+// Pausing one scope must not affect other scopes.
+
+#[test]
+fn test_pausing_contributions_does_not_block_governance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    client.pause_scope(&admin, &PoolScope::Contributions);
+
+    // Governance action still works.
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+
+    assert!(!client.is_scope_paused(&PoolScope::Governance));
+    assert!(!client.is_scope_paused(&PoolScope::Payouts));
+}
+
+#[test]
+fn test_pausing_payouts_does_not_block_contributions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    client.initialize(&admin);
+
+    let funder = Address::generate(&env);
+    token_admin.mint(&funder, &1_000_000);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+
+    client.pause_scope(&admin, &PoolScope::Payouts);
+
+    // fund_pool (Contributions scope) still works.
+    client.fund_pool(&funder, &round_id, &500_000);
+    assert_eq!(client.get_pool_balance(&round_id), 500_000);
+
+    // record_contribution (Contributions scope) still works.
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &100);
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 100);
+}
+
+#[test]
+fn test_pausing_governance_does_not_block_contributions_or_payouts() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    client.initialize(&admin);
+
+    let funder = Address::generate(&env);
+    let owner1 = Address::generate(&env);
+    token_admin.mint(&funder, &1_000_000);
+
+    // Create round and approve project BEFORE pausing governance.
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+
+    client.pause_scope(&admin, &PoolScope::Governance);
+
+    // fund_pool (Contributions) still works.
+    client.fund_pool(&funder, &round_id, &1_000_000);
+
+    // record_contribution (Contributions) still works.
+    env.ledger().set_timestamp(1500);
+    let c = Address::generate(&env);
+    client.record_contribution(&round_id, &1u64, &c, &100);
+
+    // finalize_round (Payouts) still works.
+    env.ledger().set_timestamp(4000);
+    client.finalize_round(&admin, &round_id);
+
+    // distribute_matching_funds (Payouts) still works.
+    let owners = vec![&env, owner1.clone()];
+    let total = client.distribute_matching_funds(&admin, &round_id, &owners);
+    assert_eq!(total, 1_000_000);
+}
+
+// -- Read-only queries remain available under any scope pause ─────────────────
+
+#[test]
+fn test_read_only_queries_available_when_contributions_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    client.initialize(&admin);
+
+    let funder = Address::generate(&env);
+    token_admin.mint(&funder, &1_000_000);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+    client.fund_pool(&funder, &round_id, &500_000);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &100);
+
+    // Now pause Contributions.
+    client.pause_scope(&admin, &PoolScope::Contributions);
+
+    // All read-only queries must succeed.
+    let round = client.get_round(&round_id);
+    assert_eq!(round.total_pool, 500_000);
+    assert_eq!(client.get_pool_balance(&round_id), 500_000);
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 100);
+    assert_eq!(client.get_contributor_count(&round_id, &1u64), 1);
+    assert!(client.get_project_qf_score(&round_id, &1u64) > 0);
+    assert_eq!(client.get_round_status(&round_id), symbol_short!("ACTIVE"));
+    assert_eq!(client.get_admin(), admin);
+    assert!(client.is_scope_paused(&PoolScope::Contributions));
+}
+
+#[test]
+fn test_read_only_queries_available_when_all_scopes_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    client.initialize(&admin);
+
+    let funder = Address::generate(&env);
+    token_admin.mint(&funder, &1_000_000);
+
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    );
+    client.fund_pool(&funder, &round_id, &200_000);
+
+    // Pause every scope.
+    client.pause_scope(&admin, &PoolScope::Contributions);
+    client.pause_scope(&admin, &PoolScope::Payouts);
+    client.pause_scope(&admin, &PoolScope::Governance);
+
+    // Read-only queries still work.
+    assert_eq!(client.get_admin(), admin);
+    let round = client.get_round(&round_id);
+    assert_eq!(round.id, round_id);
+    assert_eq!(client.get_pool_balance(&round_id), 200_000);
+    assert!(client.is_scope_paused(&PoolScope::Contributions));
+    assert!(client.is_scope_paused(&PoolScope::Payouts));
+    assert!(client.is_scope_paused(&PoolScope::Governance));
+}
+
+// -- Only admin can pause/unpause ─────────────────────────────────────────────
+
+#[test]
+fn test_non_admin_cannot_pause_scope() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _) = setup(&env);
+    client.initialize(&admin);
+
+    let not_admin = Address::generate(&env);
+    assert_eq!(
+        client.try_pause_scope(&not_admin, &PoolScope::Contributions),
+        Err(Ok(MatchingPoolError::Unauthorized))
+    );
+    assert!(!client.is_scope_paused(&PoolScope::Contributions));
+}
+
+#[test]
+fn test_non_admin_cannot_unpause_scope() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _) = setup(&env);
+    client.initialize(&admin);
+
+    client.pause_scope(&admin, &PoolScope::Payouts);
+
+    let not_admin = Address::generate(&env);
+    assert_eq!(
+        client.try_unpause_scope(&not_admin, &PoolScope::Payouts),
+        Err(Ok(MatchingPoolError::Unauthorized))
+    );
+    // Still paused.
+    assert!(client.is_scope_paused(&PoolScope::Payouts));
+}
+
+// -- Mixed pause/unpause cycle (full integration) ────────────────────────────
+
+#[test]
+fn test_mixed_pause_unpause_full_round_lifecycle() {
+    // Demonstrates a realistic incident response scenario:
+    // 1. Contributions paused mid-round to halt new inflows.
+    // 2. Governance remains live so admin can adjust eligible projects.
+    // 3. Contributions unpaused to collect final contributions.
+    // 4. Payouts executed normally to completion.
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    client.initialize(&admin);
+
+    let funder = Address::generate(&env);
+    let owner1 = Address::generate(&env);
+    let owner2 = Address::generate(&env);
+    token_admin.mint(&funder, &2_000_000);
+
+    // --- Round setup (all scopes open) ---
+    env.ledger().set_timestamp(500);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &5000u64,
+    );
+    client.approve_project(&admin, &round_id, &1u64);
+    client.approve_project(&admin, &round_id, &2u64);
+    client.fund_pool(&funder, &round_id, &1_000_000);
+
+    // First wave of contributions.
+    env.ledger().set_timestamp(1500);
+    for _ in 0..4 {
+        let c = Address::generate(&env);
+        client.record_contribution(&round_id, &1u64, &c, &25);
+    }
+
+    // --- Incident: pause Contributions (but not Governance or Payouts) ---
+    client.pause_scope(&admin, &PoolScope::Contributions);
+    assert!(client.is_scope_paused(&PoolScope::Contributions));
+    assert!(!client.is_scope_paused(&PoolScope::Governance));
+    assert!(!client.is_scope_paused(&PoolScope::Payouts));
+
+    // New contributions blocked.
+    let late_contributor = Address::generate(&env);
+    assert_eq!(
+        client.try_record_contribution(&round_id, &1u64, &late_contributor, &50),
+        Err(Ok(MatchingPoolError::ScopePaused))
+    );
+
+    // Governance still live: admin removes a project and adds another.
+    client.remove_project(&admin, &round_id, &2u64);
+    client.approve_project(&admin, &round_id, &3u64);
+
+    // --- Resolution: unpause Contributions ---
+    client.unpause_scope(&admin, &PoolScope::Contributions);
+    assert!(!client.is_scope_paused(&PoolScope::Contributions));
+
+    // Late contributions now accepted.
+    let c2 = Address::generate(&env);
+    client.record_contribution(&round_id, &1u64, &c2, &100);
+
+    // Additional pool funding also accepted.
+    client.fund_pool(&funder, &round_id, &500_000);
+    assert_eq!(client.get_pool_balance(&round_id), 1_500_000);
+
+    // --- Payout ---
+    env.ledger().set_timestamp(6000);
+    client.finalize_round(&admin, &round_id);
+
+    let owners = vec![&env, owner1.clone(), owner2.clone()];
+    let total = client.distribute_matching_funds(&admin, &round_id, &owners);
+    assert_eq!(total, 1_500_000);
+
+    // Round is fully distributed.
+    let round = client.get_round(&round_id);
+    assert!(round.is_distributed);
+    assert_eq!(client.get_pool_balance(&round_id), 0);
 }


### PR DESCRIPTION
- Add PoolScope enum (Contributions, Payouts, Governance) to matching_pool
- Replace global pause flag with per-scope ScopePaused(PoolScope) storage key
- Gate fund_pool and record_contribution behind Contributions scope
- Gate finalize_round and distribute_matching_funds behind Payouts scope
- Gate create_round, approve_project, remove_project, set_admin, upgrade behind Governance scope
- Add pause_scope / unpause_scope / is_scope_paused public functions
- Emit ScopePausedEvent and ScopeUnpausedEvent with admin+scope as topics
- All read-only get_* queries remain ungated under any scope pause
- Add ScopePaused = 18 error variant; retain ContractPaused = 16 for compat
- contributor_registry: Payouts scope already present (reserved for future use)
- 42 tests: 18 migrated + 24 new covering per-scope blocking, isolation, read-only availability, unpause restoration, and mixed lifecycle flow

closes #910 