### PR TITLE
feat(backend): add portfolio anomaly review API

### DIFF
--- a/apps/backend/src/database/migrations/1803000000000-CreatePortfolioAnomalies.ts
+++ b/apps/backend/src/database/migrations/1803000000000-CreatePortfolioAnomalies.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreatePortfolioAnomalies1803000000000 implements MigrationInterface {
+  name = 'CreatePortfolioAnomalies1803000000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE portfolio_anomalies (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        "userId" UUID NOT NULL,
+        title VARCHAR(255) NOT NULL,
+        description TEXT,
+        anomaly_type VARCHAR(100) NOT NULL,
+        severity VARCHAR(20) NOT NULL DEFAULT 'medium',
+        status VARCHAR(20) NOT NULL DEFAULT 'unresolved',
+        "reviewerId" UUID,
+        "reviewerNotes" TEXT,
+        "reviewedAt" TIMESTAMPTZ,
+        "reviewerNotesUpdatedAt" TIMESTAMPTZ,
+        "createdAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT now(),
+        version INTEGER NOT NULL DEFAULT 1
+      );
+
+      CREATE INDEX idx_portfolio_anomalies_user_created_at
+        ON portfolio_anomalies ("userId", "createdAt" DESC);
+
+      CREATE INDEX idx_portfolio_anomalies_status
+        ON portfolio_anomalies (status);
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP TABLE IF EXISTS portfolio_anomalies;
+    `);
+  }
+}

--- a/apps/backend/src/portfolio/dto/portfolio-anomaly.dto.ts
+++ b/apps/backend/src/portfolio/dto/portfolio-anomaly.dto.ts
@@ -1,0 +1,102 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsEnum, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import {
+  PortfolioAnomalySeverity,
+  PortfolioAnomalyStatus,
+} from '../entities/portfolio-anomaly.entity';
+
+export class CreatePortfolioAnomalyDto {
+  @ApiProperty({ description: 'The affected user identifier' })
+  @IsString()
+  @IsNotEmpty()
+  userId: string;
+
+  @ApiProperty({ description: 'Short anomaly title' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  title: string;
+
+  @ApiPropertyOptional({ description: 'Detailed anomaly description' })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ description: 'Machine-readable anomaly category' })
+  @IsString()
+  @IsNotEmpty()
+  anomalyType: string;
+
+  @ApiProperty({
+    enum: PortfolioAnomalySeverity,
+    description: 'Severity for the anomaly',
+  })
+  @IsEnum(PortfolioAnomalySeverity)
+  severity: PortfolioAnomalySeverity;
+}
+
+export class ReviewPortfolioAnomalyDto {
+  @ApiProperty({
+    enum: PortfolioAnomalyStatus,
+    description: 'Desired review state for the anomaly',
+  })
+  @IsEnum(PortfolioAnomalyStatus)
+  status: PortfolioAnomalyStatus;
+
+  @ApiPropertyOptional({ description: 'Reviewer follow-up notes' })
+  @IsOptional()
+  @IsString()
+  reviewerNotes?: string;
+}
+
+export class PortfolioAnomalyResponseDto {
+  @ApiProperty({ description: 'Anomaly identifier' })
+  id: string;
+
+  @ApiProperty({ description: 'Affected user identifier' })
+  userId: string;
+
+  @ApiProperty({ description: 'Short anomaly title' })
+  title: string;
+
+  @ApiPropertyOptional({ description: 'Detailed anomaly description' })
+  description: string | null;
+
+  @ApiProperty({ description: 'Machine-readable anomaly category' })
+  anomalyType: string;
+
+  @ApiProperty({ enum: PortfolioAnomalySeverity })
+  severity: PortfolioAnomalySeverity | string;
+
+  @ApiProperty({ enum: PortfolioAnomalyStatus })
+  status: PortfolioAnomalyStatus | string;
+
+  @ApiPropertyOptional({ description: 'Reviewer identifier' })
+  reviewerId: string | null;
+
+  @ApiPropertyOptional({ description: 'Reviewer follow-up notes' })
+  reviewerNotes: string | null;
+
+  @ApiPropertyOptional({ description: 'When the anomaly was reviewed' })
+  reviewedAt: Date | null;
+
+  @ApiPropertyOptional({ description: 'When the review notes were last updated' })
+  reviewerNotesUpdatedAt: Date | null;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  updatedAt: Date;
+
+  @ApiProperty({ description: 'Optimistic locking version' })
+  version: number;
+}
+
+export class PortfolioAnomaliesListResponseDto {
+  @ApiProperty({ type: [PortfolioAnomalyResponseDto] })
+  anomalies: PortfolioAnomalyResponseDto[];
+
+  @ApiProperty({ description: 'Total number of anomalies' })
+  total: number;
+}

--- a/apps/backend/src/portfolio/entities/portfolio-anomaly.entity.ts
+++ b/apps/backend/src/portfolio/entities/portfolio-anomaly.entity.ts
@@ -1,0 +1,75 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  VersionColumn,
+} from 'typeorm';
+
+export enum PortfolioAnomalyStatus {
+  UNRESOLVED = 'unresolved',
+  ACKNOWLEDGED = 'acknowledged',
+}
+
+export enum PortfolioAnomalySeverity {
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high',
+}
+
+@Entity('portfolio_anomalies')
+@Index(['userId', 'createdAt'])
+@Index(['status'])
+export class PortfolioAnomaly {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  title: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string | null;
+
+  @Column({ type: 'varchar', length: 100 })
+  anomalyType: string;
+
+  @Column({
+    type: 'varchar',
+    length: 20,
+    default: PortfolioAnomalySeverity.MEDIUM,
+  })
+  severity: PortfolioAnomalySeverity | string;
+
+  @Column({
+    type: 'varchar',
+    length: 20,
+    default: PortfolioAnomalyStatus.UNRESOLVED,
+  })
+  status: PortfolioAnomalyStatus | string;
+
+  @Column({ type: 'uuid', nullable: true })
+  reviewerId: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  reviewerNotes: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  reviewedAt: Date | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  reviewerNotesUpdatedAt: Date | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+
+  @VersionColumn({ default: 1 })
+  version: number;
+}

--- a/apps/backend/src/portfolio/portfolio-anomaly.controller.ts
+++ b/apps/backend/src/portfolio/portfolio-anomaly.controller.ts
@@ -1,0 +1,110 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { Request } from 'express';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/decorators/auth.decorators';
+import { UserRole } from '../users/entities/user.entity';
+import {
+  CreatePortfolioAnomalyDto,
+  PortfolioAnomalyResponseDto,
+  PortfolioAnomaliesListResponseDto,
+  ReviewPortfolioAnomalyDto,
+} from './dto/portfolio-anomaly.dto';
+import { PortfolioAnomalyService } from './portfolio-anomaly.service';
+import { PortfolioAnomaly } from './entities/portfolio-anomaly.entity';
+
+interface RequestWithUser extends Request {
+  user: {
+    id: string;
+    role?: string;
+  };
+}
+
+@ApiTags('portfolio anomalies')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(JwtAuthGuard)
+@Controller('portfolio/anomalies')
+export class PortfolioAnomalyController {
+  constructor(private readonly portfolioAnomalyService: PortfolioAnomalyService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.REVIEWER)
+  @ApiOperation({ summary: 'Create a portfolio anomaly record' })
+  @ApiResponse({ status: 201, description: 'Anomaly created', type: PortfolioAnomalyResponseDto })
+  async createAnomaly(
+    @Body() dto: CreatePortfolioAnomalyDto,
+  ): Promise<PortfolioAnomalyResponseDto> {
+    const anomaly = await this.portfolioAnomalyService.createAnomaly(dto);
+    return this.toResponse(anomaly);
+  }
+
+  @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.REVIEWER)
+  @ApiOperation({ summary: 'List anomalies for a user or all users' })
+  @ApiQuery({ name: 'userId', required: false, description: 'Filter anomalies by user' })
+  @ApiResponse({ status: 200, description: 'Anomalies listed', type: PortfolioAnomaliesListResponseDto })
+  async listAnomalies(
+    @Query('userId') userId?: string,
+  ): Promise<PortfolioAnomaliesListResponseDto> {
+    const anomalies = await this.portfolioAnomalyService.getAnomalies(userId);
+    return {
+      anomalies: anomalies.map((anomaly) => this.toResponse(anomaly)),
+      total: anomalies.length,
+    };
+  }
+
+  @Post(':id/review')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.REVIEWER)
+  @ApiOperation({ summary: 'Acknowledge or reopen a portfolio anomaly' })
+  @ApiResponse({ status: 200, description: 'Anomaly reviewed', type: PortfolioAnomalyResponseDto })
+  async reviewAnomaly(
+    @Param('id') id: string,
+    @Body() dto: ReviewPortfolioAnomalyDto,
+    @Req() req: RequestWithUser,
+  ): Promise<PortfolioAnomalyResponseDto> {
+    const anomaly = await this.portfolioAnomalyService.reviewAnomaly(
+      id,
+      req.user.id,
+      dto,
+    );
+    return this.toResponse(anomaly);
+  }
+
+  private toResponse(anomaly: PortfolioAnomaly): PortfolioAnomalyResponseDto {
+    return {
+      id: anomaly.id,
+      userId: anomaly.userId,
+      title: anomaly.title,
+      description: anomaly.description ?? null,
+      anomalyType: anomaly.anomalyType,
+      severity: anomaly.severity,
+      status: anomaly.status,
+      reviewerId: anomaly.reviewerId ?? null,
+      reviewerNotes: anomaly.reviewerNotes ?? null,
+      reviewedAt: anomaly.reviewedAt ?? null,
+      reviewerNotesUpdatedAt: anomaly.reviewerNotesUpdatedAt ?? null,
+      createdAt: anomaly.createdAt,
+      updatedAt: anomaly.updatedAt,
+      version: anomaly.version,
+    };
+  }
+}

--- a/apps/backend/src/portfolio/portfolio-anomaly.service.spec.ts
+++ b/apps/backend/src/portfolio/portfolio-anomaly.service.spec.ts
@@ -1,0 +1,98 @@
+import { ConflictException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { OptimisticLockVersionMismatchError, Repository } from 'typeorm';
+import { PortfolioAnomalyService } from './portfolio-anomaly.service';
+import {
+  PortfolioAnomaly,
+  PortfolioAnomalySeverity,
+  PortfolioAnomalyStatus,
+} from './entities/portfolio-anomaly.entity';
+
+describe('PortfolioAnomalyService', () => {
+  let service: PortfolioAnomalyService;
+  let repository: jest.Mocked<Repository<PortfolioAnomaly>>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PortfolioAnomalyService,
+        {
+          provide: getRepositoryToken(PortfolioAnomaly),
+          useValue: {
+            create: jest.fn(),
+            save: jest.fn(),
+            find: jest.fn(),
+            findOne: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<PortfolioAnomalyService>(PortfolioAnomalyService);
+    repository = module.get(getRepositoryToken(PortfolioAnomaly));
+  });
+
+  it('persists reviewer notes and acknowledges an anomaly', async () => {
+    const anomaly = Object.assign(new PortfolioAnomaly(), {
+      id: 'anomaly-1',
+      status: PortfolioAnomalyStatus.UNRESOLVED,
+      reviewerNotes: null,
+      reviewerNotesUpdatedAt: null,
+      reviewedAt: null,
+      version: 1,
+    });
+
+    repository.create.mockReturnValue(anomaly);
+    repository.save.mockResolvedValueOnce(anomaly);
+
+    const created = await service.createAnomaly({
+      userId: 'user-1',
+      title: 'Large drawdown',
+      description: 'Portfolio value dropped sharply',
+      anomalyType: 'portfolio_drawdown',
+      severity: PortfolioAnomalySeverity.HIGH,
+    });
+
+    expect(created).toBe(anomaly);
+
+    repository.findOne.mockResolvedValue(anomaly);
+    repository.save.mockResolvedValueOnce({
+      ...anomaly,
+      status: PortfolioAnomalyStatus.ACKNOWLEDGED,
+      reviewerNotes: 'Reviewed by support',
+      reviewerNotesUpdatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      reviewedAt: new Date('2026-01-01T00:00:00.000Z'),
+      version: 2,
+    });
+
+    const updated = await service.reviewAnomaly('anomaly-1', 'reviewer-1', {
+      status: PortfolioAnomalyStatus.ACKNOWLEDGED,
+      reviewerNotes: 'Reviewed by support',
+    });
+
+    expect(updated.status).toBe(PortfolioAnomalyStatus.ACKNOWLEDGED);
+    expect(updated.reviewerNotes).toBe('Reviewed by support');
+    expect(updated.reviewedAt).toBeInstanceOf(Date);
+    expect(updated.reviewerNotesUpdatedAt).toBeInstanceOf(Date);
+  });
+
+  it('raises a conflict exception when a concurrent update is detected', async () => {
+    const anomaly = Object.assign(new PortfolioAnomaly(), {
+      id: 'anomaly-2',
+      status: PortfolioAnomalyStatus.UNRESOLVED,
+      version: 1,
+    });
+
+    repository.findOne.mockResolvedValue(anomaly);
+    repository.save.mockRejectedValueOnce(
+      new OptimisticLockVersionMismatchError('PortfolioAnomaly', 1, 2),
+    );
+
+    await expect(
+      service.reviewAnomaly('anomaly-2', 'reviewer-2', {
+        status: PortfolioAnomalyStatus.UNRESOLVED,
+      }),
+    ).rejects.toThrow(ConflictException);
+  });
+});

--- a/apps/backend/src/portfolio/portfolio-anomaly.service.ts
+++ b/apps/backend/src/portfolio/portfolio-anomaly.service.ts
@@ -1,0 +1,90 @@
+import {
+  ConflictException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { OptimisticLockVersionMismatchError, Repository } from 'typeorm';
+import {
+  PortfolioAnomaly,
+  PortfolioAnomalySeverity,
+  PortfolioAnomalyStatus,
+} from './entities/portfolio-anomaly.entity';
+import {
+  CreatePortfolioAnomalyDto,
+  ReviewPortfolioAnomalyDto,
+} from './dto/portfolio-anomaly.dto';
+
+@Injectable()
+export class PortfolioAnomalyService {
+  private readonly logger = new Logger(PortfolioAnomalyService.name);
+
+  constructor(
+    @InjectRepository(PortfolioAnomaly)
+    private readonly anomalyRepository: Repository<PortfolioAnomaly>,
+  ) {}
+
+  async createAnomaly(
+    dto: CreatePortfolioAnomalyDto,
+  ): Promise<PortfolioAnomaly> {
+    const anomaly = this.anomalyRepository.create({
+      userId: dto.userId,
+      title: dto.title,
+      description: dto.description ?? null,
+      anomalyType: dto.anomalyType,
+      severity: dto.severity ?? PortfolioAnomalySeverity.MEDIUM,
+      status: PortfolioAnomalyStatus.UNRESOLVED,
+    });
+
+    return this.anomalyRepository.save(anomaly);
+  }
+
+  async getAnomalies(userId?: string): Promise<PortfolioAnomaly[]> {
+    const where = userId ? { userId } : undefined;
+    return this.anomalyRepository.find({
+      where,
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async reviewAnomaly(
+    id: string,
+    reviewerId: string,
+    dto: ReviewPortfolioAnomalyDto,
+  ): Promise<PortfolioAnomaly> {
+    const anomaly = await this.anomalyRepository.findOne({ where: { id } });
+    if (!anomaly) {
+      throw new NotFoundException(`Anomaly ${id} not found`);
+    }
+
+    anomaly.status = dto.status;
+    anomaly.reviewerId = reviewerId;
+
+    if (dto.reviewerNotes !== undefined) {
+      anomaly.reviewerNotes = dto.reviewerNotes;
+      anomaly.reviewerNotesUpdatedAt = new Date();
+    }
+
+    if (
+      dto.status === PortfolioAnomalyStatus.ACKNOWLEDGED &&
+      !anomaly.reviewedAt
+    ) {
+      anomaly.reviewedAt = new Date();
+    }
+
+    if (dto.status === PortfolioAnomalyStatus.UNRESOLVED) {
+      anomaly.reviewedAt = null;
+    }
+
+    try {
+      return await this.anomalyRepository.save(anomaly);
+    } catch (error) {
+      if (error instanceof OptimisticLockVersionMismatchError) {
+        this.logger.warn(`Concurrent update detected for anomaly ${id}`);
+        throw new ConflictException('Anomaly was updated by another reviewer');
+      }
+      throw error;
+    }
+  }
+}

--- a/apps/backend/src/portfolio/portfolio.module.ts
+++ b/apps/backend/src/portfolio/portfolio.module.ts
@@ -25,6 +25,9 @@ import { StellarModule } from '../stellar/stellar.module';
 import { PriceModule } from '../price/price.module';
 import { MaterializedSnapshotService } from './materialized-snapshot.service';
 import { ProfilingModule } from '../common/profiling/profiling.module';
+import { PortfolioAnomaly } from './entities/portfolio-anomaly.entity';
+import { PortfolioAnomalyService } from './portfolio-anomaly.service';
+import { PortfolioAnomalyController } from './portfolio-anomaly.controller';
 
 @Module({
   imports: [
@@ -32,6 +35,7 @@ import { ProfilingModule } from '../common/profiling/profiling.module';
       PortfolioAsset,
       PortfolioSnapshot,
       PortfolioMaterializedSnapshot,
+      PortfolioAnomaly,
       User,
     ]),
     MetricsModule,
@@ -40,9 +44,10 @@ import { ProfilingModule } from '../common/profiling/profiling.module';
     PriceModule,
     ProfilingModule,
   ],
-  controllers: [PortfolioController],
+  controllers: [PortfolioController, PortfolioAnomalyController],
   providers: [
     PortfolioService,
+    PortfolioAnomalyService,
     MaterializedSnapshotService,
     StellarBalanceService,
     PortfolioSnapshotProgressStore,
@@ -77,6 +82,7 @@ import { ProfilingModule } from '../common/profiling/profiling.module';
   ],
   exports: [
     PortfolioService,
+    PortfolioAnomalyService,
     MaterializedSnapshotService,
     PortfolioSnapshotQueueService,
     TypeOrmModule,


### PR DESCRIPTION
# feat(backend): add portfolio anomaly review API

## Summary
- add backend support for portfolio anomaly review tracking
- allow anomalies to be marked acknowledged or unresolved
- persist reviewer notes with review timestamps
- protect review actions with authentication and reviewer/admin role checks
- add regression tests for note persistence and concurrent update handling

## Testing
- pnpm exec jest src/portfolio/portfolio-anomaly.service.spec.ts --runInBand

Closes: #1043