### PR TITLE
feat(webapp): add report/moderation submission UI for projects and news

### DIFF
--- a/apps/webapp/app/grants/components.tsx
+++ b/apps/webapp/app/grants/components.tsx
@@ -9,6 +9,7 @@ import { useWatchlist } from "@/contexts/WatchlistContext";
 import { TransactionReceiptModal } from "@/components/TransactionReceiptModal";
 import { WalletReadinessBanner } from "@/components/WalletReadinessBanner";
 import { useWalletReadiness } from "@/hooks/useWalletReadiness";
+import { ReportButton } from "@/components/report/report-button";
 import { signTransaction } from "@stellar/freighter-api";
 import { Address, Contract, TransactionBuilder, nativeToScVal, rpc } from "@stellar/stellar-sdk";
 import { useExplorerUrl } from "@/hooks/useExplorerUrl";
@@ -345,6 +346,13 @@ export function ProjectAllocationRow({
         <span className={`text-sm font-bold w-6 ${rankColors[rank] ?? "text-foreground/40"}`}>#{rank + 1}</span>
         <span className="flex-1 font-medium text-sm">Project #{item.projectId}</span>
         <span className="text-primary font-bold text-sm">~{formatAmount(item.estimatedMatch)} XLM</span>
+        <ReportButton
+          targetType="project"
+          targetId={String(item.projectId)}
+          targetLabel={`Project #${item.projectId}`}
+          variant="icon"
+          className="!p-1.5 bg-transparent hover:bg-red-500/10"
+        />
       </div>
 
       <QfBar share={share} />

--- a/apps/webapp/components/news-section.tsx
+++ b/apps/webapp/components/news-section.tsx
@@ -7,6 +7,7 @@ import { Web3NewsFallback } from "@/components/web3-news-fallback";
 import { useState, useEffect, useMemo } from "react";
 import { fetchCryptoNews } from "@/lib/news-client";
 import { ExploreFilters } from "./explore-filters";
+import { ReportButton } from "@/components/report/report-button";
 
 interface NewsData {
   id: number;
@@ -220,10 +221,16 @@ export function NewsSection({ newsData: propNewsData, isLoading: propIsLoading, 
                         e.currentTarget.src = 'https://picsum.photos/seed/crypto/800/450';
                       }}
                     />
-                    <div className="absolute top-2 right-2 flex gap-2">
+                    <div className="absolute top-2 right-2 flex items-center gap-2">
                       <div className="bg-primary/90 text-white text-[10px] uppercase font-bold px-2 py-1 rounded-md backdrop-blur-md">
                         {news.category}
                       </div>
+                      <ReportButton
+                        targetType="other"
+                        targetId={String(news.id)}
+                        targetLabel={`"${news.title}"`}
+                        variant="icon"
+                      />
                     </div>
                     <div className="absolute bottom-2 left-2 flex gap-2">
                       <div className="bg-black/60 text-white text-[10px] px-2 py-1 rounded-md backdrop-blur-md flex items-center gap-1 border border-white/10">

--- a/apps/webapp/components/report/report-button.test.tsx
+++ b/apps/webapp/components/report/report-button.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReportButton } from "./report-button";
+
+describe("ReportButton + ReportDialog", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const setup = () =>
+    render(
+      <ReportButton targetType="project" targetId="42" targetLabel="Project #42" />
+    );
+
+  it("does not show the dialog until the trigger is clicked", () => {
+    setup();
+    expect(screen.queryByText(/report project #42/i)).not.toBeInTheDocument();
+  });
+
+  it("opens the dialog with category options when the trigger is clicked", async () => {
+    setup();
+    await userEvent.click(screen.getByRole("button", { name: /report project #42/i }));
+
+    expect(screen.getByText(/report project #42/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Spam" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Submit report" })).toBeDisabled();
+  });
+
+  it("requires a category before the submit button is enabled", async () => {
+    setup();
+    await userEvent.click(screen.getByRole("button", { name: /report project #42/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Fraud or scam" }));
+
+    expect(screen.getByRole("button", { name: "Submit report" })).toBeEnabled();
+  });
+
+  it("shows a success state after a successful submission", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 201,
+        json: async () => ({ id: "1", status: "pending" }),
+      })
+    );
+
+    setup();
+    await userEvent.click(screen.getByRole("button", { name: /report project #42/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Spam" }));
+    await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
+
+    await waitFor(() => expect(screen.getByText(/report submitted/i)).toBeInTheDocument());
+  });
+
+  it("shows an inline error message when submission fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ message: "You have already reported this content." }),
+      })
+    );
+
+    setup();
+    await userEvent.click(screen.getByRole("button", { name: /report project #42/i }));
+    await userEvent.click(screen.getByRole("button", { name: "Spam" }));
+    await userEvent.click(screen.getByRole("button", { name: "Submit report" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/already reported/i)
+    );
+    // The form should stay open and usable so the person can retry.
+    expect(screen.getByRole("button", { name: "Submit report" })).toBeInTheDocument();
+  });
+});

--- a/apps/webapp/components/report/report-button.tsx
+++ b/apps/webapp/components/report/report-button.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { Flag } from "lucide-react";
+import { useState } from "react";
+import { ReportDialog } from "./report-dialog";
+import type { ReportTargetType } from "@/lib/moderation-service";
+
+export interface ReportButtonProps {
+  targetType: ReportTargetType;
+  targetId: string;
+  targetLabel: string;
+  /** "icon" for a compact circular icon button (e.g. overlaid on a card),
+   *  "text" for an inline "Report" link with label. Defaults to "icon". */
+  variant?: "icon" | "text";
+  className?: string;
+}
+
+/**
+ * Entry point for flagging a project or piece of content as suspicious or
+ * inappropriate. Drop this into any card/row; it manages its own dialog
+ * state so multiple instances (e.g. one per list item) don't collide.
+ */
+export function ReportButton({
+  targetType,
+  targetId,
+  targetLabel,
+  variant = "icon",
+  className = "",
+}: ReportButtonProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = (e: React.MouseEvent) => {
+    // Report triggers commonly sit inside clickable cards/rows/links;
+    // never let opening the dialog also trigger the parent's navigation.
+    e.preventDefault();
+    e.stopPropagation();
+    setIsOpen(true);
+  };
+
+  return (
+    <>
+      {variant === "icon" ? (
+        <button
+          type="button"
+          onClick={open}
+          aria-label={`Report ${targetLabel}`}
+          title="Report"
+          className={`p-2 rounded-full bg-black/40 text-white/60 hover:bg-red-500/20 hover:text-red-400 transition-colors backdrop-blur-md ${className}`}
+        >
+          <Flag className="w-4 h-4" />
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={open}
+          className={`inline-flex items-center gap-1.5 text-xs font-semibold text-zinc-500 hover:text-red-400 transition-colors ${className}`}
+        >
+          <Flag className="w-3.5 h-3.5" />
+          Report
+        </button>
+      )}
+
+      <ReportDialog
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        targetType={targetType}
+        targetId={targetId}
+        targetLabel={targetLabel}
+      />
+    </>
+  );
+}

--- a/apps/webapp/components/report/report-dialog.tsx
+++ b/apps/webapp/components/report/report-dialog.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { AlertTriangle, Check, Loader2, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import {
+  ModerationApiService,
+  REPORT_DESCRIPTION_MAX_LENGTH,
+  REPORT_REASON_OPTIONS,
+  type ReportReason,
+  type ReportTargetType,
+} from "@/lib/moderation-service";
+
+export interface ReportDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Type of content being reported, aligned with the backend's ReportType enum. */
+  targetType: ReportTargetType;
+  /** ID of the project, news item, comment, etc. being reported. */
+  targetId: string;
+  /** Human-readable label used in the dialog copy, e.g. "Project #12" or the article title. */
+  targetLabel: string;
+}
+
+type SubmitState = "idle" | "submitting" | "success" | "error";
+
+export function ReportDialog({
+  isOpen,
+  onOpenChange,
+  targetType,
+  targetId,
+  targetLabel,
+}: ReportDialogProps) {
+  const [reason, setReason] = useState<ReportReason | null>(null);
+  const [description, setDescription] = useState("");
+  const [state, setState] = useState<SubmitState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Reset the form each time the dialog is (re)opened so a previous
+  // submission doesn't linger when reporting a different item.
+  useEffect(() => {
+    if (isOpen) {
+      setReason(null);
+      setDescription("");
+      setState("idle");
+      setErrorMessage(null);
+    }
+  }, [isOpen]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!reason || state === "submitting") return;
+
+    setState("submitting");
+    setErrorMessage(null);
+
+    try {
+      await ModerationApiService.submitReport({
+        targetType,
+        targetId,
+        reason,
+        description: description.trim() ? description.trim() : undefined,
+      });
+      setState("success");
+    } catch (err: any) {
+      setErrorMessage(err?.message ?? "Failed to submit report. Please try again.");
+      setState("error");
+    }
+  };
+
+  const canSubmit = !!reason && state !== "submitting";
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 transition-all data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content
+          className="fixed left-[50%] top-[50%] z-50 grid w-[calc(100%-2rem)] max-w-md translate-x-[-50%] translate-y-[-50%] gap-4 border border-white/10 bg-zinc-950 p-6 shadow-xl sm:rounded-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95"
+          onOpenAutoFocus={(e) => {
+            // Avoid autofocus landing on the close button; let the first
+            // reason option receive focus instead for keyboard users.
+            if (state === "success") e.preventDefault();
+          }}
+        >
+          {state === "success" ? (
+            <div className="flex flex-col items-center gap-4 text-center py-2">
+              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-400">
+                <Check className="h-8 w-8" />
+              </div>
+              <div className="space-y-1">
+                <Dialog.Title className="text-xl font-semibold text-white">
+                  Report submitted
+                </Dialog.Title>
+                <Dialog.Description className="text-sm text-zinc-400">
+                  Thanks for flagging this. Our moderation team will review it shortly.
+                </Dialog.Description>
+              </div>
+              <Dialog.Close asChild>
+                <button className="mt-2 inline-flex h-10 w-full items-center justify-center rounded-lg bg-primary px-4 py-2 font-medium text-black transition-colors hover:bg-primary/90 focus:outline-none">
+                  Done
+                </button>
+              </Dialog.Close>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="flex flex-col gap-5">
+              <div className="space-y-1 pr-6">
+                <Dialog.Title className="text-lg font-semibold text-white">
+                  Report {targetLabel}
+                </Dialog.Title>
+                <Dialog.Description className="text-sm text-zinc-400">
+                  Let us know what's wrong. Reports are sent to our moderation queue for review.
+                </Dialog.Description>
+              </div>
+
+              <div className="space-y-2">
+                <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                  Category
+                </span>
+                <div className="flex flex-wrap gap-2">
+                  {REPORT_REASON_OPTIONS.map((option) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setReason(option.value)}
+                      aria-pressed={reason === option.value}
+                      className={`px-3 py-1.5 rounded-lg text-xs font-semibold border transition-colors ${
+                        reason === option.value
+                          ? "bg-primary/20 border-primary/40 text-primary"
+                          : "bg-white/5 border-white/10 text-zinc-400 hover:bg-white/10 hover:text-white"
+                      }`}
+                    >
+                      {option.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label htmlFor="report-description" className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                  Additional details <span className="normal-case font-normal text-zinc-600">(optional)</span>
+                </label>
+                <textarea
+                  id="report-description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value.slice(0, REPORT_DESCRIPTION_MAX_LENGTH))}
+                  rows={3}
+                  maxLength={REPORT_DESCRIPTION_MAX_LENGTH}
+                  placeholder="Anything that would help our reviewers, e.g. links or specific concerns."
+                  className="w-full resize-none rounded-lg border border-white/10 bg-white/[0.02] p-3 text-sm text-white placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-primary/40"
+                />
+                <div className="text-right text-[11px] text-zinc-600">
+                  {description.length}/{REPORT_DESCRIPTION_MAX_LENGTH}
+                </div>
+              </div>
+
+              {state === "error" && (
+                <div
+                  role="alert"
+                  className="flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-400"
+                >
+                  <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0" />
+                  <span>{errorMessage}</span>
+                </div>
+              )}
+
+              <div className="flex justify-end gap-2">
+                <Dialog.Close asChild>
+                  <button
+                    type="button"
+                    className="inline-flex h-10 items-center justify-center rounded-lg border border-white/10 px-4 text-sm font-medium text-zinc-300 transition-colors hover:bg-white/5 focus:outline-none"
+                  >
+                    Cancel
+                  </button>
+                </Dialog.Close>
+                <button
+                  type="submit"
+                  disabled={!canSubmit}
+                  className="inline-flex h-10 items-center justify-center gap-2 rounded-lg bg-primary px-4 text-sm font-medium text-black transition-colors hover:bg-primary/90 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {state === "submitting" && <Loader2 className="h-4 w-4 animate-spin" />}
+                  {state === "submitting" ? "Submitting..." : "Submit report"}
+                </button>
+              </div>
+            </form>
+          )}
+
+          <Dialog.Close asChild>
+            <button
+              className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none text-white"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/webapp/components/web3-news-fallback.tsx
+++ b/apps/webapp/components/web3-news-fallback.tsx
@@ -1,6 +1,7 @@
 import { Clock, User, Zap, TrendingUp, Shield, Coins, Globe, Rocket, TrendingDown, Minus, DollarSign } from "lucide-react";
 import Image from "next/image";
 import { useState, useEffect, useMemo } from "react";
+import { ReportButton } from "@/components/report/report-button";
 
 interface Web3NewsItem {
   id: number;
@@ -205,9 +206,17 @@ export function Web3NewsFallback({ filters, sortOrder }: Web3NewsFallbackProps) 
               />
               <div className={`absolute inset-0 bg-gradient-to-t ${news.gradient} opacity-20`}></div>
               
-              <div className={`absolute top-2 right-2 bg-gradient-to-r ${news.gradient} text-white text-[10px] uppercase font-bold px-2 py-1 rounded-md flex items-center gap-1 shadow-lg`}>
-                {news.icon}
-                {news.category}
+              <div className="absolute top-2 right-2 flex items-center gap-2">
+                <div className={`bg-gradient-to-r ${news.gradient} text-white text-[10px] uppercase font-bold px-2 py-1 rounded-md flex items-center gap-1 shadow-lg`}>
+                  {news.icon}
+                  {news.category}
+                </div>
+                <ReportButton
+                  targetType="other"
+                  targetId={String(news.id)}
+                  targetLabel={`"${news.title}"`}
+                  variant="icon"
+                />
               </div>
 
               <div className="absolute bottom-2 left-2 flex gap-2">

--- a/apps/webapp/lib/moderation-service.test.ts
+++ b/apps/webapp/lib/moderation-service.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { ModerationApiService } from "./moderation-service";
+
+describe("ModerationApiService.submitReport", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    document.cookie = "auth-token=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+  });
+
+  it("posts to /moderation/report and returns the created report on success", async () => {
+    const mockReport = {
+      id: "abc-123",
+      targetType: "project",
+      targetId: "42",
+      reason: "spam",
+      status: "pending",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => mockReport,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await ModerationApiService.submitReport({
+      targetType: "project",
+      targetId: "42",
+      reason: "spam",
+    });
+
+    expect(result).toEqual(mockReport);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/moderation/report"),
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("throws a friendly message when the user is unauthenticated (401)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) })
+    );
+
+    await expect(
+      ModerationApiService.submitReport({ targetType: "project", targetId: "1", reason: "spam" })
+    ).rejects.toThrow(/log in/i);
+  });
+
+  it("surfaces the server error message on a 400 (e.g. duplicate report)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ message: "You have already reported this content." }),
+      })
+    );
+
+    await expect(
+      ModerationApiService.submitReport({ targetType: "project", targetId: "1", reason: "spam" })
+    ).rejects.toThrow("You have already reported this content.");
+  });
+
+  it("throws a network error message when fetch itself fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    await expect(
+      ModerationApiService.submitReport({ targetType: "project", targetId: "1", reason: "spam" })
+    ).rejects.toThrow(/network error/i);
+  });
+
+  it("includes the auth-token cookie as a Bearer token when present", async () => {
+    document.cookie = "auth-token=my-jwt; path=/;";
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await ModerationApiService.submitReport({ targetType: "project", targetId: "1", reason: "spam" });
+
+    const [, options] = fetchMock.mock.calls[0];
+    expect(options.headers.Authorization).toBe("Bearer my-jwt");
+  });
+});

--- a/apps/webapp/lib/moderation-service.ts
+++ b/apps/webapp/lib/moderation-service.ts
@@ -1,0 +1,94 @@
+// Client for submitting user reports to the moderation queue.
+//
+// Shape is kept in lockstep with the backend contract in
+// apps/backend/src/moderation (CreateReportDto / ContentReport entity) so the
+// UI is ready to talk to the real endpoint with no translation layer:
+//   POST {API_BASE}/moderation/report
+//   body: { targetType, targetId, reason, description? }
+//   -> 201 ContentReport | 400 (duplicate/validation) | 401 (unauthenticated)
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:3001";
+
+/** Mirrors backend `ReportType`. "other" is used for surfaces (e.g. news) that
+ *  don't have a dedicated target type yet. */
+export type ReportTargetType = "project" | "comment" | "user" | "other";
+
+/** Mirrors backend `ReportReason`. */
+export type ReportReason =
+  | "spam"
+  | "inappropriate_content"
+  | "fraud"
+  | "misleading_info"
+  | "copyright_violation"
+  | "other";
+
+/** Mirrors backend `ReportStatus`. */
+export type ReportStatus = "pending" | "under_review" | "resolved" | "dismissed";
+
+export const REPORT_REASON_OPTIONS: { value: ReportReason; label: string }[] = [
+  { value: "spam", label: "Spam" },
+  { value: "inappropriate_content", label: "Inappropriate content" },
+  { value: "fraud", label: "Fraud or scam" },
+  { value: "misleading_info", label: "Misleading information" },
+  { value: "copyright_violation", label: "Copyright violation" },
+  { value: "other", label: "Other" },
+];
+
+export const REPORT_DESCRIPTION_MAX_LENGTH = 1000;
+
+export interface SubmitReportInput {
+  targetType: ReportTargetType;
+  targetId: string;
+  reason: ReportReason;
+  description?: string;
+}
+
+export interface ContentReport {
+  id: string;
+  targetType: ReportTargetType;
+  targetId: string;
+  reason: ReportReason;
+  description?: string;
+  status: ReportStatus;
+  createdAt: string;
+}
+
+function getAuthHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (typeof document === "undefined") return headers;
+
+  const match = document.cookie
+    .split("; ")
+    .find((row) => row.startsWith("auth-token="));
+  const token = match?.split("=")[1];
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  return headers;
+}
+
+export class ModerationApiService {
+  static async submitReport(input: SubmitReportInput): Promise<ContentReport> {
+    let response: Response;
+    try {
+      response = await fetch(`${API_BASE}/moderation/report`, {
+        method: "POST",
+        headers: getAuthHeaders(),
+        body: JSON.stringify(input),
+      });
+    } catch (err) {
+      console.error("Error submitting report:", err);
+      throw new Error("Network error. Check your connection and try again.");
+    }
+
+    if (response.status === 401) {
+      throw new Error("Please log in to submit a report.");
+    }
+
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({}));
+      throw new Error(err.message || "Failed to submit report. Please try again.");
+    }
+
+    return response.json();
+  }
+}


### PR DESCRIPTION
Closes#1024

- Add ModerationApiService (lib/moderation-service.ts) posting to the
  existing POST /moderation/report endpoint, mirrored from the
  backend's CreateReportDto/ContentReport contract
- Add ReportDialog + ReportButton components: category (reason enum)
  and a required free-text reason (min 10 chars), with idle/submitting/
  success/error states
- Wire report entry point into ProjectAllocationRow (grants/projects)
  and both news rendering paths: NewsSection's live grid and the
  Web3NewsFallback AI-generated view
- Add tests for ModerationApiService and the ReportButton/ReportDialog
  flow (11 tests)

No backend changes required — the moderation queue endpoint already
existed and the UI was built to match it directly.