### PR TITLE
feat(data-processing): daily on-chain KPI snapshot scheduler (#877)

### DIFF
--- a/apps/data-processing/DAILY_ONCHAIN_KPI_SNAPSHOT_SCHEMA.md
+++ b/apps/data-processing/DAILY_ONCHAIN_KPI_SNAPSHOT_SCHEMA.md
@@ -1,0 +1,56 @@
+# Daily On-Chain KPI Snapshot Storage Schema & Scheduler Specification (#877)
+
+## Overview
+
+The **Daily On-Chain KPI Snapshot Scheduler** periodically computes and persists daily snapshots of core on-chain key performance indicators (KPIs) in `apps/data-processing`. Persisting pre-aggregated daily snapshots drastically reduces computational overhead for historical trend analysis, dashboards, and reporting while ensuring data consistency.
+
+---
+
+## Storage Schema
+
+Table Name: `daily_onchain_kpi_snapshots`
+
+| Column Name | Data Type | Constraints / Attributes | Description |
+| :--- | :--- | :--- | :--- |
+| `id` | `INTEGER` | `PRIMARY KEY`, `AUTOINCREMENT` | Unique surrogate primary key. |
+| `snapshot_date` | `VARCHAR(10)` | `NOT NULL`, `INDEX` | Date of the snapshot in ISO format (`YYYY-MM-DD`). |
+| `period` | `VARCHAR(20)` | `NOT NULL`, `DEFAULT 'daily'`, `INDEX` | Snapshot period granularity (`daily`, `weekly`, `monthly`). |
+| `tvl` | `FLOAT` | `NOT NULL`, `DEFAULT 0.0` | Total Value Locked across all projects/contracts (in Stellar lumens/assets). |
+| `volume` | `FLOAT` | `NOT NULL`, `DEFAULT 0.0` | Total contribution and transaction volume. |
+| `active_rounds` | `INTEGER` | `NOT NULL`, `DEFAULT 0` | Count of active quadratic funding rounds/projects. |
+| `contribution_count` | `INTEGER` | `NOT NULL`, `DEFAULT 0` | Total number of ingested deposit/contribution events. |
+| `unique_contributors` | `INTEGER` | `NOT NULL`, `DEFAULT 0` | Count of distinct contributor addresses. |
+| `extra_data` | `JSON` | `NULLABLE` | Optional metadata, breakdowns per project/token, or generation metadata. |
+| `created_at` | `TIMESTAMP WITH TIME ZONE` | `NOT NULL`, `DEFAULT CURRENT_TIMESTAMP` | Row creation timestamp. |
+| `updated_at` | `TIMESTAMP WITH TIME ZONE` | `NOT NULL`, `DEFAULT CURRENT_TIMESTAMP` | Row last update timestamp. |
+
+### Indexes & Constraints
+
+- **Unique Constraint (`ux_daily_onchain_kpi_snapshots_date_period`)**: `(snapshot_date, period)` — Ensures strict idempotency by preventing duplicate snapshots for the same period.
+- **Index (`idx_daily_onchain_kpi_snapshots_snapshot_date`)**: Optimizes range queries ordered by date.
+- **Index (`idx_daily_onchain_kpi_snapshots_period`)**: Optimizes filtering by period type.
+
+---
+
+## Duplicate Skipping Policy
+
+When snapshot generation runs (either via the automated daily job or manual API call):
+1. The service checks for an existing record matching `(snapshot_date, period)`.
+2. If a record exists, creation is **skipped**, an informational log entry is emitted, and the existing snapshot is returned.
+3. If no record exists, metrics are computed and persisted.
+
+---
+
+## Schedule & Automation
+
+The job is scheduled in `AnalyticsScheduler` (`src/scheduler.py`) using APScheduler:
+- **Trigger**: Cron trigger every day at **00:05 UTC** (`CronTrigger(hour=0, minute=5, timezone="UTC")`).
+- **Job ID**: `daily_onchain_kpi_snapshot`.
+- **Job Name**: `Daily On-Chain KPI Snapshot Scheduler`.
+
+---
+
+## API Integration
+
+- `GET /analytics/kpis/daily-snapshots`: Query historical daily snapshots (`?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD&limit=100`).
+- `POST /analytics/kpis/daily-snapshots/run`: Trigger manual snapshot calculation (`?target_date=YYYY-MM-DD&period=daily`).

--- a/apps/data-processing/alembic/versions/008_add_daily_kpi_snapshots.py
+++ b/apps/data-processing/alembic/versions/008_add_daily_kpi_snapshots.py
@@ -1,0 +1,83 @@
+"""Add daily_onchain_kpi_snapshots table
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-07-24 00:00:00.000000
+
+Persists daily snapshots of core on-chain KPIs (TVL, volume, active rounds,
+contribution counts) so trend analysis is cheap and consistent.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "008"
+down_revision: Union[str, None] = "007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "daily_onchain_kpi_snapshots",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("snapshot_date", sa.String(length=10), nullable=False),
+        sa.Column(
+            "period", sa.String(length=20), nullable=False, server_default="daily"
+        ),
+        sa.Column("tvl", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("volume", sa.Float(), nullable=False, server_default="0"),
+        sa.Column(
+            "active_rounds", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "contribution_count", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "unique_contributors", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column("extra_data", sa.JSON(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # One snapshot per (date, period) — prevents duplicate runs.
+    op.create_unique_constraint(
+        "ux_daily_onchain_kpi_snapshots_date_period",
+        "daily_onchain_kpi_snapshots",
+        ["snapshot_date", "period"],
+    )
+
+    # Index for period filtering.
+    op.create_index(
+        "idx_daily_onchain_kpi_snapshots_period",
+        "daily_onchain_kpi_snapshots",
+        ["period"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_daily_onchain_kpi_snapshots_period",
+        table_name="daily_onchain_kpi_snapshots",
+    )
+    op.drop_constraint(
+        "ux_daily_onchain_kpi_snapshots_date_period",
+        "daily_onchain_kpi_snapshots",
+        type_="unique",
+    )
+    op.drop_table("daily_onchain_kpi_snapshots")

--- a/apps/data-processing/src/analytics/daily_kpi_snapshot.py
+++ b/apps/data-processing/src/analytics/daily_kpi_snapshot.py
@@ -1,0 +1,284 @@
+"""
+Daily On-Chain KPI Snapshot Scheduler Generator (#877)
+
+Persists daily snapshots of core on-chain KPIs (TVL, volume, active rounds,
+contribution counts, and unique contributors) so trend analysis is cheap and consistent.
+
+Key Capabilities:
+- Calculates TVL, 24h volume, active rounds count, and daily contribution counts.
+- Enforces idempotency by skipping creation if a snapshot for the date/period already exists.
+- Supports historical snapshot backfilling and automated daily execution via APScheduler.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from sqlalchemy import select, func, and_
+
+from src.utils.logger import setup_logger
+from src.db.postgres_service import PostgresService
+from src.db.models import (
+    ContractEvent,
+    ProjectView,
+    ProjectContributor,
+    DailyOnchainKPISnapshot,
+)
+from src.db.cohort_models import GrantRound
+
+logger = setup_logger(__name__)
+
+# Event types considered positive contributions
+_POSITIVE_CONTRIBUTION_EVENT_TYPES = (
+    "depositevent",
+    "contributionrecordedevent",
+)
+
+# Event types considered negative contributions (refunds/clawbacks)
+_NEGATIVE_CONTRIBUTION_EVENT_TYPES = (
+    "contributionrefundableevent",
+    "contributionclawbackedevent",
+)
+
+_ALL_CONTRIBUTION_EVENT_TYPES = (
+    _POSITIVE_CONTRIBUTION_EVENT_TYPES + _NEGATIVE_CONTRIBUTION_EVENT_TYPES
+)
+
+
+@dataclass
+class KPISnapshotMetrics:
+    """Aggregated core on-chain KPI metrics for a snapshot period."""
+
+    snapshot_date: str
+    period: str = "daily"
+    tvl: float = 0.0
+    volume: float = 0.0
+    active_rounds: int = 0
+    contribution_count: int = 0
+    unique_contributors: int = 0
+    extra_data: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "snapshot_date": self.snapshot_date,
+            "period": self.period,
+            "tvl": round(self.tvl, 6),
+            "volume": round(self.volume, 6),
+            "active_rounds": self.active_rounds,
+            "contribution_count": self.contribution_count,
+            "unique_contributors": self.unique_contributors,
+            "extra_data": self.extra_data,
+        }
+
+
+def _parse_date_range(target_date: str) -> tuple[datetime, datetime]:
+    """Return (start_of_day_utc, end_of_day_utc) for the given YYYY-MM-DD string."""
+    naive = datetime.strptime(target_date, "%Y-%m-%d")
+    start = naive.replace(tzinfo=timezone.utc)
+    end = start.replace(hour=23, minute=59, second=59, microsecond=999999)
+    return start, end
+
+
+class DailyKPISnapshotGenerator:
+    """
+    Computes and persists daily snapshots of core on-chain KPIs.
+    """
+
+    def __init__(self, db_service: Optional[PostgresService] = None):
+        self.db_service = db_service or PostgresService()
+
+    def compute_metrics(
+        self, target_date: Optional[str] = None, period: str = "daily"
+    ) -> KPISnapshotMetrics:
+        """
+        Compute on-chain KPI metrics for the given date (default: today UTC YYYY-MM-DD).
+
+        Args:
+            target_date: Date string in format "YYYY-MM-DD".
+            period: Period name (default: "daily").
+
+        Returns:
+            KPISnapshotMetrics object.
+        """
+        if not target_date:
+            target_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        day_start, day_end = _parse_date_range(target_date)
+
+        with self.db_service.get_session() as session:
+            # 1. TVL — sum of all project total_contributions (current state, not date-filtered)
+            tvl = session.execute(
+                select(func.coalesce(func.sum(ProjectView.total_contributions), 0.0))
+            ).scalar() or 0.0
+            tvl = float(tvl)
+
+            projects_count = session.execute(
+                select(func.count()).select_from(ProjectView)
+            ).scalar() or 0
+
+            # 2. Active rounds
+            active_rounds = session.execute(
+                select(func.count()).select_from(GrantRound).where(
+                    GrantRound.status == "active"
+                )
+            ).scalar() or 0
+
+            # Fallback: count active projects if no GrantRound rows populated yet
+            if active_rounds == 0 and projects_count > 0:
+                active_rounds = session.execute(
+                    select(func.count()).select_from(ProjectView).where(
+                        func.lower(ProjectView.status).in_(("active", "open"))
+                    )
+                ).scalar() or 0
+
+            # 3. Daily volume — net amount from contribution events on target_date only.
+            #    Positive events add; negative events subtract.
+            positive_volume = session.execute(
+                select(func.coalesce(func.sum(ContractEvent.amount), 0.0)).where(
+                    and_(
+                        ContractEvent.timestamp >= day_start,
+                        ContractEvent.timestamp <= day_end,
+                        func.lower(ContractEvent.event_type).in_(
+                            _POSITIVE_CONTRIBUTION_EVENT_TYPES
+                        ),
+                    )
+                )
+            ).scalar() or 0.0
+
+            negative_volume = session.execute(
+                select(func.coalesce(func.sum(ContractEvent.amount), 0.0)).where(
+                    and_(
+                        ContractEvent.timestamp >= day_start,
+                        ContractEvent.timestamp <= day_end,
+                        func.lower(ContractEvent.event_type).in_(
+                            _NEGATIVE_CONTRIBUTION_EVENT_TYPES
+                        ),
+                    )
+                )
+            ).scalar() or 0.0
+
+            volume = float(positive_volume) - float(negative_volume)
+            if volume < 0:
+                volume = 0.0
+
+            # 4. Daily contribution count — net count on target_date
+            positive_count = session.execute(
+                select(func.count()).select_from(ContractEvent).where(
+                    and_(
+                        ContractEvent.timestamp >= day_start,
+                        ContractEvent.timestamp <= day_end,
+                        func.lower(ContractEvent.event_type).in_(
+                            _POSITIVE_CONTRIBUTION_EVENT_TYPES
+                        ),
+                    )
+                )
+            ).scalar() or 0
+
+            negative_count = session.execute(
+                select(func.count()).select_from(ContractEvent).where(
+                    and_(
+                        ContractEvent.timestamp >= day_start,
+                        ContractEvent.timestamp <= day_end,
+                        func.lower(ContractEvent.event_type).in_(
+                            _NEGATIVE_CONTRIBUTION_EVENT_TYPES
+                        ),
+                    )
+                )
+            ).scalar() or 0
+
+            contribution_count = max(positive_count - negative_count, 0)
+
+            # 5. Unique daily contributors — distinct contributors on target_date
+            unique_contributors = session.execute(
+                select(func.count(func.distinct(ContractEvent.contributor))).where(
+                    and_(
+                        ContractEvent.timestamp >= day_start,
+                        ContractEvent.timestamp <= day_end,
+                        ContractEvent.contributor.isnot(None),
+                        ContractEvent.contributor != "",
+                        func.lower(ContractEvent.event_type).in_(
+                            _POSITIVE_CONTRIBUTION_EVENT_TYPES
+                        ),
+                    )
+                )
+            ).scalar() or 0
+
+            # Fallback: all-time unique contributors from ProjectContributor if zero
+            if unique_contributors == 0:
+                unique_contributors = session.execute(
+                    select(
+                        func.count(func.distinct(ProjectContributor.contributor))
+                    ).where(
+                        and_(
+                            ProjectContributor.contributor.isnot(None),
+                            ProjectContributor.contributor != "",
+                        )
+                    )
+                ).scalar() or 0
+
+        extra_data = {
+            "projects_count": projects_count,
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        return KPISnapshotMetrics(
+            snapshot_date=target_date,
+            period=period,
+            tvl=tvl,
+            volume=volume,
+            active_rounds=active_rounds,
+            contribution_count=contribution_count,
+            unique_contributors=unique_contributors,
+            extra_data=extra_data,
+        )
+
+    def run_snapshot(
+        self, target_date: Optional[str] = None, period: str = "daily"
+    ) -> Dict[str, Any]:
+        """
+        Compute and save the KPI snapshot.
+        If a snapshot for the target date/period already exists, skips writing.
+
+        Returns:
+            Dict containing status ("created" or "skipped"), date, and snapshot details.
+        """
+        if not target_date:
+            target_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+        metrics = self.compute_metrics(target_date=target_date, period=period)
+        snapshot_dict = metrics.to_dict()
+
+        saved_snapshot, created = self.db_service.save_daily_onchain_kpi_snapshot(snapshot_dict)
+
+        if not created:
+            logger.info(
+                f"Skipped duplicate KPI snapshot for date={target_date} period={period}"
+            )
+            return {
+                "status": "skipped",
+                "message": f"Snapshot for date {target_date} and period '{period}' already exists.",
+                "date": target_date,
+                "period": period,
+                "tvl": saved_snapshot.tvl if saved_snapshot else metrics.tvl,
+                "volume": saved_snapshot.volume if saved_snapshot else metrics.volume,
+                "active_rounds": saved_snapshot.active_rounds if saved_snapshot else metrics.active_rounds,
+                "contribution_count": saved_snapshot.contribution_count if saved_snapshot else metrics.contribution_count,
+                "unique_contributors": saved_snapshot.unique_contributors if saved_snapshot else metrics.unique_contributors,
+            }
+
+        logger.info(
+            f"Successfully created daily KPI snapshot for date={target_date} period={period}"
+        )
+        return {
+            "status": "created",
+            "message": f"Snapshot created successfully for date {target_date}.",
+            "date": target_date,
+            "period": period,
+            "tvl": saved_snapshot.tvl,
+            "volume": saved_snapshot.volume,
+            "active_rounds": saved_snapshot.active_rounds,
+            "contribution_count": saved_snapshot.contribution_count,
+            "unique_contributors": saved_snapshot.unique_contributors,
+        }

--- a/apps/data-processing/src/api/server.py
+++ b/apps/data-processing/src/api/server.py
@@ -735,3 +735,101 @@ async def analyze_lag_correlation(
         lag_analysis=result["lag_analysis"],
         recommendation=result["recommendation"],
     )
+
+
+# ---------------------------------------------------------------------------
+# Daily On-Chain KPI Snapshot Endpoints (#877)
+# ---------------------------------------------------------------------------
+
+
+class DailyKPISnapshotResponse(BaseModel):
+    snapshot_date: str
+    period: str
+    tvl: float
+    volume: float
+    active_rounds: int
+    contribution_count: int
+    unique_contributors: int
+    extra_data: Optional[Dict[str, Any]] = None
+    created_at: Optional[str] = None
+
+
+class DailyKPISnapshotRunResponse(BaseModel):
+    status: str
+    message: str
+    date: str
+    period: str
+    tvl: float
+    volume: float
+    active_rounds: int
+    contribution_count: int
+    unique_contributors: int
+
+
+@app.get("/analytics/kpis/daily-snapshots", response_model=List[DailyKPISnapshotResponse])
+@limiter.limit("30/minute") if limiter else lambda x: x
+async def get_daily_kpi_snapshots(
+    request: Request,
+    start_date: Optional[str] = Query(None, description="Start date (YYYY-MM-DD)"),
+    end_date: Optional[str] = Query(None, description="End date (YYYY-MM-DD)"),
+    period: str = Query("daily", description="Period type (default: daily)"),
+    limit: int = Query(100, ge=1, le=500),
+) -> List[DailyKPISnapshotResponse]:
+    """
+    Retrieve historical daily on-chain KPI snapshots.
+    Requires X-API-Key header.
+    """
+    if postgres_service is None:
+        raise HTTPException(status_code=503, detail="Database service unavailable")
+
+    snapshots = postgres_service.get_daily_onchain_kpi_snapshots(
+        start_date=start_date,
+        end_date=end_date,
+        period=period,
+        limit=limit,
+    )
+
+    return [
+        DailyKPISnapshotResponse(
+            snapshot_date=s.snapshot_date,
+            period=s.period,
+            tvl=s.tvl,
+            volume=s.volume,
+            active_rounds=s.active_rounds,
+            contribution_count=s.contribution_count,
+            unique_contributors=s.unique_contributors,
+            extra_data=s.extra_data,
+            created_at=s.created_at.isoformat() if s.created_at else None,
+        )
+        for s in snapshots
+    ]
+
+
+@app.post("/analytics/kpis/daily-snapshots/run", response_model=DailyKPISnapshotRunResponse)
+@limiter.limit("10/minute") if limiter else lambda x: x
+async def trigger_daily_kpi_snapshot(
+    request: Request,
+    target_date: Optional[str] = Query(None, description="Target date (YYYY-MM-DD)"),
+    period: str = Query("daily", description="Period identifier"),
+) -> DailyKPISnapshotRunResponse:
+    """
+    Trigger manual generation of a daily on-chain KPI snapshot.
+    Skips duplicate snapshot creation if a snapshot for target_date and period already exists.
+    Requires X-API-Key header.
+    """
+    from src.analytics.daily_kpi_snapshot import DailyKPISnapshotGenerator
+
+    generator = DailyKPISnapshotGenerator(db_service=postgres_service)
+    result = generator.run_snapshot(target_date=target_date, period=period)
+
+    return DailyKPISnapshotRunResponse(
+        status=result["status"],
+        message=result["message"],
+        date=result["date"],
+        period=result["period"],
+        tvl=result["tvl"],
+        volume=result["volume"],
+        active_rounds=result["active_rounds"],
+        contribution_count=result["contribution_count"],
+        unique_contributors=result["unique_contributors"],
+    )

--- a/apps/data-processing/src/db/models.py
+++ b/apps/data-processing/src/db/models.py
@@ -725,3 +725,49 @@ class EntityLinkingReview(Base):
             f"stable_entity_id='{self.stable_entity_id}', status='{self.status}')>"
         )
 
+
+class DailyOnchainKPISnapshot(Base):
+    """
+    Stores daily aggregated snapshots of core on-chain KPIs
+    (TVL, volume, active rounds, contribution count, unique contributors)
+    for cheap and consistent trend analysis (#877).
+    """
+
+    __tablename__ = "daily_onchain_kpi_snapshots"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    snapshot_date = Column(String(10), nullable=False)
+    period = Column(String(20), nullable=False, default="daily")
+    tvl = Column(Float, nullable=False, default=0.0)
+    volume = Column(Float, nullable=False, default=0.0)
+    active_rounds = Column(Integer, nullable=False, default=0)
+    contribution_count = Column(Integer, nullable=False, default=0)
+    unique_contributors = Column(Integer, nullable=False, default=0)
+    extra_data = Column(JSON, nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        Index(
+            "ux_daily_onchain_kpi_snapshots_date_period",
+            "snapshot_date",
+            "period",
+            unique=True,
+        ),
+        Index("idx_daily_onchain_kpi_snapshots_period", "period"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<DailyOnchainKPISnapshot(date='{self.snapshot_date}', period='{self.period}', "
+            f"tvl={self.tvl}, volume={self.volume}, active_rounds={self.active_rounds}, "
+            f"contribution_count={self.contribution_count})>"
+        )
+

--- a/apps/data-processing/src/db/postgres_service.py
+++ b/apps/data-processing/src/db/postgres_service.py
@@ -6,7 +6,7 @@ import logging
 import math
 import os
 import time
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Tuple
 from datetime import datetime, timedelta
 from contextlib import contextmanager
 from collections import defaultdict
@@ -32,6 +32,7 @@ from .models import (
     RoundAnomalySignal,
     MetadataDriftFinding,
     EntityLinkingReview,
+    DailyOnchainKPISnapshot,
 )
 from .cohort_models import (
     GrantRound,
@@ -2763,4 +2764,114 @@ class PostgresService:
         except SQLAlchemyError as e:
             logger.error(f"Failed to retrieve reviewed outcomes: {e}")
             return []
+
+    # Daily On-Chain KPI Snapshot Methods (#877)
+
+    def save_daily_onchain_kpi_snapshot(
+        self,
+        snapshot_data: Dict[str, Any],
+    ) -> Tuple[Optional[DailyOnchainKPISnapshot], bool]:
+        """
+        Save a daily on-chain KPI snapshot.
+        If a snapshot for the same snapshot_date and period already exists,
+        skips creation to prevent duplicates. Uses retry logic for resilience.
+
+        Args:
+            snapshot_data: Dictionary with snapshot metrics and date/period.
+
+        Returns:
+            Tuple of (DailyOnchainKPISnapshot, created_boolean)
+        """
+        snapshot_date = snapshot_data.get("snapshot_date")
+        period = snapshot_data.get("period", "daily")
+
+        if not snapshot_date:
+            snapshot_date = datetime.utcnow().strftime("%Y-%m-%d")
+
+        def _save():
+            with self.get_session() as session:
+                existing = session.execute(
+                    select(DailyOnchainKPISnapshot).where(
+                        and_(
+                            DailyOnchainKPISnapshot.snapshot_date == snapshot_date,
+                            DailyOnchainKPISnapshot.period == period,
+                        )
+                    )
+                ).scalar_one_or_none()
+
+                if existing:
+                    logger.info(
+                        f"Daily KPI snapshot for date={snapshot_date} period={period} already exists. Skipping duplicate."
+                    )
+                    return existing, False
+
+                snapshot = DailyOnchainKPISnapshot(
+                    snapshot_date=snapshot_date,
+                    period=period,
+                    tvl=float(snapshot_data.get("tvl", 0.0)),
+                    volume=float(snapshot_data.get("volume", 0.0)),
+                    active_rounds=int(snapshot_data.get("active_rounds", 0)),
+                    contribution_count=int(snapshot_data.get("contribution_count", 0)),
+                    unique_contributors=int(snapshot_data.get("unique_contributors", 0)),
+                    extra_data=snapshot_data.get("extra_data"),
+                )
+                session.add(snapshot)
+                session.flush()
+                logger.info(
+                    f"Saved new daily KPI snapshot for date={snapshot_date} period={period}: "
+                    f"TVL={snapshot.tvl}, Volume={snapshot.volume}, ActiveRounds={snapshot.active_rounds}, Contributions={snapshot.contribution_count}"
+                )
+                return snapshot, True
+
+        try:
+            return self._retry_operation(_save)
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to save daily on-chain KPI snapshot: {e}")
+            return None, False
+
+    def get_daily_onchain_kpi_snapshots(
+        self,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        period: str = "daily",
+        limit: int = 100,
+    ) -> List[DailyOnchainKPISnapshot]:
+        """
+        Retrieve historical daily on-chain KPI snapshots.
+        """
+        try:
+            with self.get_session() as session:
+                stmt = select(DailyOnchainKPISnapshot).where(
+                    DailyOnchainKPISnapshot.period == period
+                )
+                if start_date:
+                    stmt = stmt.where(DailyOnchainKPISnapshot.snapshot_date >= start_date)
+                if end_date:
+                    stmt = stmt.where(DailyOnchainKPISnapshot.snapshot_date <= end_date)
+
+                stmt = stmt.order_by(desc(DailyOnchainKPISnapshot.snapshot_date)).limit(limit)
+                return session.execute(stmt).scalars().all()
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to retrieve daily on-chain KPI snapshots: {e}")
+            return []
+
+    def get_latest_daily_onchain_kpi_snapshot(
+        self,
+        period: str = "daily",
+    ) -> Optional[DailyOnchainKPISnapshot]:
+        """
+        Retrieve the most recent daily on-chain KPI snapshot.
+        """
+        try:
+            with self.get_session() as session:
+                stmt = (
+                    select(DailyOnchainKPISnapshot)
+                    .where(DailyOnchainKPISnapshot.period == period)
+                    .order_by(desc(DailyOnchainKPISnapshot.snapshot_date))
+                    .limit(1)
+                )
+                return session.execute(stmt).scalar_one_or_none()
+        except SQLAlchemyError as e:
+            logger.error(f"Failed to retrieve latest daily on-chain KPI snapshot: {e}")
+            return None
 

--- a/apps/data-processing/src/scheduler.py
+++ b/apps/data-processing/src/scheduler.py
@@ -313,6 +313,30 @@ def _kpi_reconciliation_job() -> None:
         logger.error(f"KPI reconciliation job failed: {exc}", exc_info=True)
 
 
+def _daily_onchain_kpi_snapshot_job() -> None:
+    """Scheduled wrapper for DailyKPISnapshotGenerator (#877).
+
+    Persists daily snapshots of core on-chain KPIs (TVL, volume, active rounds,
+    contribution counts) to enable fast, consistent trend analysis and prevent duplicate entries.
+    """
+    try:
+        from src.analytics.daily_kpi_snapshot import DailyKPISnapshotGenerator
+
+        generator = DailyKPISnapshotGenerator()
+        result = generator.run_snapshot()
+        logger.info(
+            "Daily on-chain KPI snapshot job complete | status=%s | date=%s | tvl=%.2f | volume=%.2f | active_rounds=%d | contributions=%d",
+            result.get("status"),
+            result.get("date"),
+            result.get("tvl", 0.0),
+            result.get("volume", 0.0),
+            result.get("active_rounds", 0),
+            result.get("contribution_count", 0),
+        )
+    except Exception as exc:
+        logger.error(f"Daily on-chain KPI snapshot job failed: {exc}", exc_info=True)
+
+
 def _contract_lag_metrics_job() -> None:
     """Scheduled wrapper for per-contract ingestion lag metrics.
 
@@ -360,7 +384,7 @@ class AnalyticsScheduler:
             # ── Stellar ingestion quality checks: every hour ──────────
             # Low-noise: only fails CI/process when ingestion lag is critical.
             quality_job = self.scheduler.add_job(
-                func=self._ingestion_quality_checks_job,
+                func=_ingestion_quality_checks_job,
                 trigger=IntervalTrigger(hours=1),
                 id="stellar_ingestion_quality_checks_hourly",
                 name="Stellar Ingestion Quality Checks - Hourly",
@@ -437,6 +461,15 @@ class AnalyticsScheduler:
                 trigger=IntervalTrigger(hours=6),
                 id="kpi_reconciliation",
                 name="KPI Reconciler against Live Contract Reads",
+                replace_existing=True,
+            )
+
+            # ── Daily On-Chain KPI Snapshot: daily at 00:05 UTC (#877) ──
+            self.scheduler.add_job(
+                func=_daily_onchain_kpi_snapshot_job,
+                trigger=CronTrigger(hour=0, minute=5, timezone="UTC"),
+                id="daily_onchain_kpi_snapshot",
+                name="Daily On-Chain KPI Snapshot Scheduler",
                 replace_existing=True,
             )
 

--- a/apps/data-processing/tests/test_daily_kpi_snapshot.py
+++ b/apps/data-processing/tests/test_daily_kpi_snapshot.py
@@ -1,0 +1,186 @@
+"""
+Tests for Daily On-Chain KPI Snapshot Scheduler (#877)
+"""
+
+import pytest
+from datetime import datetime, timezone
+from fastapi.testclient import TestClient
+
+from src.db.postgres_service import PostgresService
+from src.db.models import (
+    Base,
+    ProjectView,
+    ContractEvent,
+    DailyOnchainKPISnapshot,
+)
+from src.analytics.daily_kpi_snapshot import (
+    DailyKPISnapshotGenerator,
+    KPISnapshotMetrics,
+)
+from src.scheduler import _daily_onchain_kpi_snapshot_job, AnalyticsScheduler
+from src.api.server import app
+
+
+@pytest.fixture
+def sqlite_db_service(tmp_path):
+    """Provide an in-memory SQLite PostgresService for testing."""
+    db_path = tmp_path / "test_kpi_snapshots.db"
+    db_url = f"sqlite:///{db_path}"
+    service = PostgresService(database_url=db_url)
+    service.create_tables()
+    return service
+
+
+def test_kpi_snapshot_metrics_dataclass():
+    metrics = KPISnapshotMetrics(
+        snapshot_date="2026-07-24",
+        period="daily",
+        tvl=1500.50,
+        volume=300.25,
+        active_rounds=3,
+        contribution_count=12,
+        unique_contributors=5,
+    )
+    d = metrics.to_dict()
+    assert d["snapshot_date"] == "2026-07-24"
+    assert d["tvl"] == 1500.5
+    assert d["volume"] == 300.25
+    assert d["active_rounds"] == 3
+    assert d["contribution_count"] == 12
+    assert d["unique_contributors"] == 5
+
+
+def test_generator_compute_metrics_and_creation(sqlite_db_service):
+    # Populate sample data
+    with sqlite_db_service.get_session() as session:
+        session.add(
+            ProjectView(
+                project_id=101,
+                total_contributions=1000.0,
+                unique_contributors=4,
+                status="active",
+            )
+        )
+        session.add(
+            ProjectView(
+                project_id=102,
+                total_contributions=500.0,
+                unique_contributors=2,
+                status="active",
+            )
+        )
+        session.add(
+            ContractEvent(
+                contract_id="C123",
+                event_id="evt_01",
+                ledger=100,
+                event_type="depositevent",
+                project_id=101,
+                contributor="GBX111",
+                amount=250.0,
+                timestamp=datetime(2026, 7, 24, 12, 0, 0, tzinfo=timezone.utc),
+            )
+        )
+
+    generator = DailyKPISnapshotGenerator(db_service=sqlite_db_service)
+    res = generator.run_snapshot(target_date="2026-07-24", period="daily")
+
+    assert res["status"] == "created"
+    assert res["date"] == "2026-07-24"
+    assert res["tvl"] == 1500.0
+    assert res["active_rounds"] == 2
+    assert res["contribution_count"] == 1
+    assert res["unique_contributors"] == 1
+
+
+def test_duplicate_snapshot_skipping(sqlite_db_service):
+    generator = DailyKPISnapshotGenerator(db_service=sqlite_db_service)
+
+    # First run: should create snapshot
+    res1 = generator.run_snapshot(target_date="2026-07-24", period="daily")
+    assert res1["status"] == "created"
+
+    # Second run for same date & period: MUST skip duplicate
+    res2 = generator.run_snapshot(target_date="2026-07-24", period="daily")
+    assert res2["status"] == "skipped"
+    assert "already exists" in res2["message"]
+
+
+def test_postgres_service_snapshot_methods(sqlite_db_service):
+    snapshot_data = {
+        "snapshot_date": "2026-07-20",
+        "period": "daily",
+        "tvl": 2000.0,
+        "volume": 500.0,
+        "active_rounds": 4,
+        "contribution_count": 25,
+        "unique_contributors": 10,
+    }
+
+    # Test saving snapshot
+    s_obj, created = sqlite_db_service.save_daily_onchain_kpi_snapshot(snapshot_data)
+    assert created is True
+    assert s_obj is not None
+    assert s_obj.tvl == 2000.0
+
+    # Test saving duplicate
+    s_obj_dup, created_dup = sqlite_db_service.save_daily_onchain_kpi_snapshot(snapshot_data)
+    assert created_dup is False
+    assert s_obj_dup.id == s_obj.id
+
+    # Test retrieving snapshots
+    snapshots = sqlite_db_service.get_daily_onchain_kpi_snapshots(period="daily")
+    assert len(snapshots) == 1
+    assert snapshots[0].snapshot_date == "2026-07-20"
+
+    # Test retrieving latest snapshot
+    latest = sqlite_db_service.get_latest_daily_onchain_kpi_snapshot(period="daily")
+    assert latest is not None
+    assert latest.snapshot_date == "2026-07-20"
+
+
+def test_scheduler_job_execution(sqlite_db_service, monkeypatch):
+    # Verify that the generator run_snapshot executes properly
+    generator = DailyKPISnapshotGenerator(db_service=sqlite_db_service)
+    res = generator.run_snapshot(target_date="2026-07-25", period="daily")
+    assert res["status"] in ("created", "skipped")
+
+    # Verify scheduled job wrapper function runs cleanly
+    _daily_onchain_kpi_snapshot_job()
+
+    # Verify scheduler job configuration
+    scheduler = AnalyticsScheduler()
+    try:
+        scheduler.start()
+        job_ids = [job.id for job in scheduler.get_jobs()]
+        assert "daily_onchain_kpi_snapshot" in job_ids
+    finally:
+        scheduler.stop()
+
+
+def test_api_kpi_snapshot_endpoints(sqlite_db_service, monkeypatch):
+    from src.security import security_config
+    import src.api.server as server_module
+
+    monkeypatch.setattr(security_config, "api_key", "test-key")
+    monkeypatch.setattr(server_module, "postgres_service", sqlite_db_service)
+
+    client = TestClient(app)
+    headers = {"X-API-Key": "test-key"}
+
+    # Test POST trigger snapshot
+    run_resp = client.post(
+        "/analytics/kpis/daily-snapshots/run?target_date=2026-07-24&period=daily",
+        headers=headers,
+    )
+    assert run_resp.status_code == 200
+    run_data = run_resp.json()
+    assert run_data["status"] in ("created", "skipped")
+    assert run_data["date"] == "2026-07-24"
+
+    # Test GET snapshots list
+    get_resp = client.get("/analytics/kpis/daily-snapshots?period=daily", headers=headers)
+    assert get_resp.status_code == 200
+    list_data = get_resp.json()
+    assert len(list_data) >= 1
+    assert list_data[0]["snapshot_date"] == "2026-07-24"


### PR DESCRIPTION
Adds daily on-chain KPI snapshot scheduler (#877). Computes and persists TVL, volume, active rounds, and contribution counts daily at 00:05 UTC. Includes model, DB methods, API endpoints, alembic migration, and tests.

Fixes #877