### PR TITLE
feat(mobile): reusable report/moderation flow across project surfaces

### DIFF
--- a/apps/mobile/app/(tabs)/projects/[id].tsx
+++ b/apps/mobile/app/(tabs)/projects/[id].tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
-  Alert,
   SafeAreaView,
   ScrollView,
   StyleSheet,
@@ -27,7 +26,8 @@ import { requireBiometricConfirmation } from '../../../lib/biometric-lock';
 import VerificationPanel from '../../../components/VerificationPanel';
 import { usersApi } from '../../../lib/api';
 import { storage } from '../../../lib/storage';
-import { moderationApi, ReportType, ReportReason } from '../../../lib/moderation';
+import { ReportType } from '../../../lib/moderation';
+import ReportContentModal from '../../../components/ReportContentModal';
 import { useWallet } from '../../../contexts/WalletContext';
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
@@ -214,7 +214,7 @@ export default function ProjectDetailScreen() {
   const [error, setError] = useState<string | null>(null);
   const [showContributeModal, setShowContributeModal] = useState(false);
   const { publicKey: stellarPublicKey, signAndSubmitXdr } = useWallet();
-  const [isReporting, setIsReporting] = useState(false);
+  const [showReportModal, setShowReportModal] = useState(false);
 
   const projectId = parseInt(id ?? '0', 10);
 
@@ -259,9 +259,7 @@ export default function ProjectDetailScreen() {
       return { errorMessage: 'No Stellar account linked. Please link one in Settings first.' };
     }
 
-    const isConfirmed = await requireBiometricConfirmation(
-      'Confirm your identity to contribute',
-    );
+    const isConfirmed = await requireBiometricConfirmation('Confirm your identity to contribute');
     if (!isConfirmed) {
       return { errorMessage: 'Biometric confirmation failed or cancelled.' };
     }
@@ -299,34 +297,6 @@ export default function ProjectDetailScreen() {
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Network error. Please try again.';
       return { errorMessage: message };
-    }
-  };
-
-  const handleReport = async (reason: ReportReason) => {
-    if (isReporting || !project) return;
-
-    setIsReporting(true);
-    try {
-      const response = await moderationApi.createReport({
-        targetType: ReportType.PROJECT,
-        targetId: String(projectId),
-        reason,
-        description: `Project reported: ${project.name}`,
-      });
-
-      if (response.success) {
-        Alert.alert(
-          'Report Submitted',
-          'Thank you. Your report has been submitted for review by our moderation team.',
-        );
-      } else {
-        Alert.alert('Error', response.error?.message || 'Failed to submit report.');
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : 'Failed to submit report.';
-      Alert.alert('Error', message);
-    } finally {
-      setIsReporting(false);
     }
   };
 
@@ -507,23 +477,9 @@ export default function ProjectDetailScreen() {
         {/* Report button */}
         <TouchableOpacity
           style={[styles.reportButton, { borderColor: colors.border }]}
-          onPress={() => {
-            Alert.alert('Report Project', 'Why are you reporting this project?', [
-              { text: 'Cancel', style: 'cancel' },
-              {
-                text: 'Spam',
-                onPress: () => void handleReport(ReportReason.SPAM),
-              },
-              {
-                text: 'Fraud',
-                onPress: () => void handleReport(ReportReason.FRAUD),
-              },
-              {
-                text: 'Misleading',
-                onPress: () => void handleReport(ReportReason.MISLEADING_INFO),
-              },
-            ]);
-          }}
+          onPress={() => setShowReportModal(true)}
+          accessibilityRole="button"
+          accessibilityLabel="Report this project"
         >
           <Ionicons name="flag-outline" size={16} color={colors.danger} />
           <Text style={[styles.reportButtonText, { color: colors.danger }]}>
@@ -574,6 +530,15 @@ export default function ProjectDetailScreen() {
         projectName={project.name}
         onClose={() => setShowContributeModal(false)}
         onSubmit={handleContribute}
+      />
+
+      {/* Report modal */}
+      <ReportContentModal
+        visible={showReportModal}
+        targetType={ReportType.PROJECT}
+        targetId={String(projectId)}
+        targetLabel={project.name}
+        onClose={() => setShowReportModal(false)}
       />
     </SafeAreaView>
   );

--- a/apps/mobile/app/(tabs)/projects/index.tsx
+++ b/apps/mobile/app/(tabs)/projects/index.tsx
@@ -15,6 +15,8 @@ import { useLocalization } from '../../../src/context';
 import { CrowdfundProject, OnChainStatus } from '../../../lib/crowdfund';
 import { computeFundingProgress, formatTokenAmount } from '../../../lib/stellar';
 import { CachedApi } from '../../../lib/cached-api';
+import { ReportType } from '../../../lib/moderation';
+import ReportContentModal from '../../../components/ReportContentModal';
 
 // ── On-chain status chip ───────────────────────────────────────────────────
 
@@ -78,10 +80,12 @@ function ProjectCard({
   project,
   colors,
   onPress,
+  onReportPress,
 }: {
   project: CrowdfundProject;
   colors: ReturnType<typeof useTheme>['colors'];
   onPress: () => void;
+  onReportPress: () => void;
 }) {
   const progress = computeFundingProgress(project.totalDeposited, project.targetAmount);
   const status: OnChainStatus =
@@ -106,6 +110,16 @@ function ProjectCard({
           {project.name}
         </Text>
         <OnChainBadge status={status} colors={colors} />
+        <TouchableOpacity
+          style={styles.cardReportButton}
+          onPress={onReportPress}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          activeOpacity={0.6}
+          accessibilityRole="button"
+          accessibilityLabel={`Report ${project.name}`}
+        >
+          <Ionicons name="flag-outline" size={16} color={colors.textSecondary} />
+        </TouchableOpacity>
       </View>
 
       <ProgressBar progress={progress} accentColor={colors.accent} />
@@ -151,6 +165,7 @@ export default function ProjectsScreen() {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fromCache, setFromCache] = useState(false);
+  const [reportTarget, setReportTarget] = useState<CrowdfundProject | null>(null);
 
   const fetchProjects = useCallback(
     async (refresh = false) => {
@@ -300,6 +315,7 @@ export default function ProjectsScreen() {
             project={item}
             colors={colors}
             onPress={() => router.push(`/projects/${item.id}`)}
+            onReportPress={() => setReportTarget(item)}
           />
         )}
         ListEmptyComponent={
@@ -322,6 +338,16 @@ export default function ProjectsScreen() {
         accessibilityLabel="Projects list"
         accessibilityRole="list"
       />
+
+      {reportTarget && (
+        <ReportContentModal
+          visible={!!reportTarget}
+          targetType={ReportType.PROJECT}
+          targetId={String(reportTarget.id)}
+          targetLabel={reportTarget.name}
+          onClose={() => setReportTarget(null)}
+        />
+      )}
     </SafeAreaView>
   );
 }
@@ -376,6 +402,9 @@ const styles = StyleSheet.create({
     fontSize: 17,
     fontWeight: '700',
     flex: 1,
+  },
+  cardReportButton: {
+    padding: 2,
   },
 
   // On-chain status badge

--- a/apps/mobile/components/ReportContentModal.tsx
+++ b/apps/mobile/components/ReportContentModal.tsx
@@ -1,0 +1,438 @@
+import React, { useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '../contexts/ThemeContext';
+import { useLocalization } from '../src/context';
+import { moderationApi, ReportReason, ReportType } from '../lib/moderation';
+
+interface ReportContentModalProps {
+  visible: boolean;
+  targetType: ReportType;
+  targetId: string;
+  targetLabel: string;
+  onClose: () => void;
+}
+
+type SubmitStatus = 'idle' | 'submitting' | 'success' | 'error';
+
+interface CategoryOption {
+  value: ReportReason;
+  labelKey: string;
+  fallbackLabel: string;
+  icon: React.ComponentProps<typeof Ionicons>['name'];
+}
+
+const CATEGORY_OPTIONS: CategoryOption[] = [
+  {
+    value: ReportReason.SPAM,
+    labelKey: 'report_modal.category_spam',
+    fallbackLabel: 'Spam',
+    icon: 'megaphone-outline',
+  },
+  {
+    value: ReportReason.FRAUD,
+    labelKey: 'report_modal.category_fraud',
+    fallbackLabel: 'Fraud or scam',
+    icon: 'warning-outline',
+  },
+  {
+    value: ReportReason.MISLEADING_INFO,
+    labelKey: 'report_modal.category_misleading',
+    fallbackLabel: 'Misleading info',
+    icon: 'alert-circle-outline',
+  },
+  {
+    value: ReportReason.INAPPROPRIATE_CONTENT,
+    labelKey: 'report_modal.category_inappropriate',
+    fallbackLabel: 'Inappropriate content',
+    icon: 'eye-off-outline',
+  },
+  {
+    value: ReportReason.COPYRIGHT_VIOLATION,
+    labelKey: 'report_modal.category_copyright',
+    fallbackLabel: 'Copyright violation',
+    icon: 'document-text-outline',
+  },
+  {
+    value: ReportReason.OTHER,
+    labelKey: 'report_modal.category_other',
+    fallbackLabel: 'Other',
+    icon: 'ellipsis-horizontal-outline',
+  },
+];
+
+const REASON_MAX_LENGTH = 280;
+
+export default function ReportContentModal({
+  visible,
+  targetType,
+  targetId,
+  targetLabel,
+  onClose,
+}: ReportContentModalProps) {
+  const { colors } = useTheme();
+  const { t } = useLocalization();
+
+  const [selectedCategory, setSelectedCategory] = useState<ReportReason | null>(null);
+  const [reasonText, setReasonText] = useState('');
+  const [status, setStatus] = useState<SubmitStatus>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const resetState = useCallback(() => {
+    setSelectedCategory(null);
+    setReasonText('');
+    setStatus('idle');
+    setErrorMessage(null);
+  }, []);
+
+  const handleDismiss = useCallback(() => {
+    if (status === 'submitting') return;
+    onClose();
+    // Reset after the close animation has had a moment to run.
+    setTimeout(resetState, 250);
+  }, [status, onClose, resetState]);
+
+  const handleSubmit = async () => {
+    if (!selectedCategory || status === 'submitting') return;
+
+    setStatus('submitting');
+    setErrorMessage(null);
+
+    try {
+      const response = await moderationApi.createReport({
+        targetType,
+        targetId,
+        reason: selectedCategory,
+        description: reasonText.trim() || `${targetLabel} reported`,
+      });
+
+      if (response.success) {
+        setStatus('success');
+      } else {
+        setStatus('error');
+        setErrorMessage(response.error?.message || t('report_modal.generic_error'));
+      }
+    } catch (err) {
+      setStatus('error');
+      setErrorMessage(err instanceof Error ? err.message : t('report_modal.generic_error'));
+    }
+  };
+
+  const isSubmitDisabled = !selectedCategory || status === 'submitting';
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={handleDismiss}
+      accessibilityViewIsModal={true}
+    >
+      <TouchableWithoutFeedback onPress={handleDismiss}>
+        <View style={styles.overlay} accessible accessibilityLabel={t('report_modal.title')}>
+          <KeyboardAvoidingView
+            behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+            style={styles.keyboardView}
+          >
+            <TouchableWithoutFeedback onPress={() => {}}>
+              <View style={[styles.sheet, { backgroundColor: colors.surface }]}>
+                {status === 'success' ? (
+                  // ── Success state ────────────────────────────────────────
+                  <View style={styles.resultWrap} accessible accessibilityLiveRegion="polite">
+                    <Ionicons name="checkmark-circle" size={48} color={colors.success} />
+                    <Text
+                      style={[styles.resultTitle, { color: colors.text }]}
+                      accessibilityRole="header"
+                    >
+                      {t('report_modal.success_title')}
+                    </Text>
+                    <Text style={[styles.resultBody, { color: colors.textSecondary }]}>
+                      {t('report_modal.success_body')}
+                    </Text>
+                    <TouchableOpacity
+                      style={[styles.primaryButton, { backgroundColor: colors.accent }]}
+                      onPress={handleDismiss}
+                      activeOpacity={0.8}
+                      accessibilityRole="button"
+                      accessibilityLabel={t('common.done')}
+                    >
+                      <Text style={styles.primaryButtonText}>{t('common.done')}</Text>
+                    </TouchableOpacity>
+                  </View>
+                ) : (
+                  // ── Category + reason capture ────────────────────────────
+                  <>
+                    <View style={styles.sheetHeader}>
+                      <Text
+                        style={[styles.sheetTitle, { color: colors.text }]}
+                        accessible
+                        accessibilityRole="header"
+                      >
+                        {t('report_modal.title')}
+                      </Text>
+                      <TouchableOpacity
+                        onPress={handleDismiss}
+                        hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+                        disabled={status === 'submitting'}
+                        accessibilityRole="button"
+                        accessibilityLabel={t('common.close')}
+                      >
+                        <Ionicons name="close" size={24} color={colors.textSecondary} />
+                      </TouchableOpacity>
+                    </View>
+
+                    <Text
+                      style={[styles.targetLabel, { color: colors.textSecondary }]}
+                      numberOfLines={1}
+                      accessible
+                    >
+                      {targetLabel}
+                    </Text>
+
+                    <Text
+                      style={[styles.fieldLabel, { color: colors.text }]}
+                      accessible
+                      accessibilityRole="header"
+                    >
+                      {t('report_modal.category_label')}
+                    </Text>
+                    <View style={styles.categoryGrid}>
+                      {CATEGORY_OPTIONS.map((option) => {
+                        const isSelected = selectedCategory === option.value;
+                        return (
+                          <TouchableOpacity
+                            key={option.value}
+                            style={[
+                              styles.categoryChip,
+                              {
+                                backgroundColor: isSelected ? colors.accent + '22' : colors.card,
+                                borderColor: isSelected ? colors.accent : colors.cardBorder,
+                              },
+                            ]}
+                            onPress={() => setSelectedCategory(option.value)}
+                            activeOpacity={0.7}
+                            disabled={status === 'submitting'}
+                            accessibilityRole="button"
+                            accessibilityState={{ selected: isSelected }}
+                            accessibilityLabel={t(option.labelKey, {
+                              defaultValue: option.fallbackLabel,
+                            })}
+                          >
+                            <Ionicons
+                              name={option.icon}
+                              size={15}
+                              color={isSelected ? colors.accent : colors.textSecondary}
+                            />
+                            <Text
+                              style={[
+                                styles.categoryChipText,
+                                { color: isSelected ? colors.accent : colors.text },
+                              ]}
+                              numberOfLines={1}
+                            >
+                              {t(option.labelKey, { defaultValue: option.fallbackLabel })}
+                            </Text>
+                          </TouchableOpacity>
+                        );
+                      })}
+                    </View>
+
+                    <Text
+                      style={[styles.fieldLabel, { color: colors.text, marginTop: 18 }]}
+                      accessible
+                      accessibilityRole="header"
+                    >
+                      {t('report_modal.reason_label')}
+                    </Text>
+                    <TextInput
+                      style={[
+                        styles.reasonInput,
+                        {
+                          color: colors.text,
+                          borderColor: colors.border,
+                          backgroundColor: colors.card,
+                        },
+                      ]}
+                      placeholder={t('report_modal.reason_placeholder')}
+                      placeholderTextColor={colors.textSecondary}
+                      value={reasonText}
+                      onChangeText={(text) => setReasonText(text.slice(0, REASON_MAX_LENGTH))}
+                      editable={status !== 'submitting'}
+                      multiline
+                      numberOfLines={3}
+                      maxLength={REASON_MAX_LENGTH}
+                      accessibilityLabel={t('report_modal.reason_label')}
+                      accessibilityHint={t('report_modal.reason_placeholder')}
+                    />
+                    <Text style={[styles.charCount, { color: colors.textSecondary }]}>
+                      {reasonText.length}/{REASON_MAX_LENGTH}
+                    </Text>
+
+                    {status === 'error' && errorMessage && (
+                      <View style={styles.errorRow} accessible accessibilityLiveRegion="assertive">
+                        <Ionicons name="alert-circle" size={16} color={colors.danger} />
+                        <Text style={[styles.errorText, { color: colors.danger }]}>
+                          {errorMessage}
+                        </Text>
+                      </View>
+                    )}
+
+                    <TouchableOpacity
+                      style={[
+                        styles.primaryButton,
+                        { backgroundColor: isSubmitDisabled ? colors.border : colors.danger },
+                      ]}
+                      onPress={handleSubmit}
+                      disabled={isSubmitDisabled}
+                      activeOpacity={0.8}
+                      accessibilityRole="button"
+                      accessibilityState={{ disabled: isSubmitDisabled }}
+                      accessibilityLabel={
+                        status === 'submitting'
+                          ? t('report_modal.submitting')
+                          : t('report_modal.submit')
+                      }
+                    >
+                      {status === 'submitting' ? (
+                        <View style={styles.loadingRow}>
+                          <ActivityIndicator color="#ffffff" size="small" />
+                          <Text style={[styles.primaryButtonText, { marginLeft: 8 }]}>
+                            {t('report_modal.submitting')}
+                          </Text>
+                        </View>
+                      ) : (
+                        <Text style={styles.primaryButtonText}>{t('report_modal.submit')}</Text>
+                      )}
+                    </TouchableOpacity>
+                  </>
+                )}
+              </View>
+            </TouchableWithoutFeedback>
+          </KeyboardAvoidingView>
+        </View>
+      </TouchableWithoutFeedback>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    justifyContent: 'flex-end',
+  },
+  keyboardView: {
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingHorizontal: 24,
+    paddingTop: 20,
+    paddingBottom: Platform.OS === 'ios' ? 40 : 28,
+  },
+  sheetHeader: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  sheetTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+  },
+  targetLabel: {
+    fontSize: 14,
+    marginBottom: 18,
+  },
+  fieldLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 10,
+  },
+  categoryGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  categoryChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    borderWidth: 1,
+    borderRadius: 20,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  categoryChipText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  reasonInput: {
+    borderWidth: 1,
+    borderRadius: 14,
+    padding: 14,
+    fontSize: 14,
+    minHeight: 80,
+    textAlignVertical: 'top',
+  },
+  charCount: {
+    fontSize: 11,
+    textAlign: 'right',
+    marginTop: 4,
+  },
+  errorRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 14,
+  },
+  errorText: {
+    fontSize: 13,
+    flex: 1,
+  },
+  primaryButton: {
+    height: 52,
+    borderRadius: 14,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 20,
+  },
+  primaryButtonText: {
+    color: '#ffffff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  loadingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  resultWrap: {
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  resultTitle: {
+    fontSize: 19,
+    fontWeight: '700',
+    marginTop: 14,
+    marginBottom: 6,
+    textAlign: 'center',
+  },
+  resultBody: {
+    fontSize: 14,
+    lineHeight: 20,
+    textAlign: 'center',
+    marginBottom: 22,
+  },
+});

--- a/apps/mobile/locales/en/common.json
+++ b/apps/mobile/locales/en/common.json
@@ -127,6 +127,23 @@
     "failed": "Contribution Failed",
     "transaction_hash": "Transaction Hash"
   },
+  "report_modal": {
+    "title": "Report Content",
+    "category_label": "What's the issue?",
+    "reason_label": "Additional details (optional)",
+    "reason_placeholder": "Add any context that could help our moderation team",
+    "category_spam": "Spam",
+    "category_fraud": "Fraud or scam",
+    "category_misleading": "Misleading info",
+    "category_inappropriate": "Inappropriate content",
+    "category_copyright": "Copyright violation",
+    "category_other": "Other",
+    "submit": "Submit Report",
+    "submitting": "Submitting...",
+    "success_title": "Report Submitted",
+    "success_body": "Thank you. Our moderation team will review this submission.",
+    "generic_error": "Failed to submit report. Please try again."
+  },
   "grants": {
     "title": "Grants Rounds",
     "description": "Quadratic funding — breadth of support determines matching",

--- a/apps/mobile/locales/zh/common.json
+++ b/apps/mobile/locales/zh/common.json
@@ -126,6 +126,23 @@
     "failed": "贡献失败",
     "transaction_hash": "交易哈希"
   },
+  "report_modal": {
+    "title": "举报内容",
+    "category_label": "问题类型是什么？",
+    "reason_label": "补充说明（可选）",
+    "reason_placeholder": "添加有助于审核团队处理的详细信息",
+    "category_spam": "垃圾信息",
+    "category_fraud": "欺诈或诈骗",
+    "category_misleading": "误导性信息",
+    "category_inappropriate": "不当内容",
+    "category_copyright": "版权侵权",
+    "category_other": "其他",
+    "submit": "提交举报",
+    "submitting": "提交中...",
+    "success_title": "举报已提交",
+    "success_body": "感谢您的举报，我们的审核团队将进行审查。",
+    "generic_error": "举报提交失败，请重试。"
+  },
   "grants": {
     "title": "资助轮次",
     "description": "二次方资助 - 广泛的社区支持决定匹配金额",


### PR DESCRIPTION
## What changed
- Extracted a reusable \`ReportContentModal\` (category chips + optional reason text, up to 280 chars) so reporting works consistently for any target type, not just projects
- Added the report action to project list cards — previously it only existed on the project detail screen
- Kept the existing \`moderationApi.createReport\` wiring — backend moderation module already existed, no backend changes needed
- Replaced the native \`Alert\`-based flow with clear inline success/error states in the modal
- Added \`en\`/\`zh\` locale strings following the existing i18n pattern

## Acceptance criteria
- [x] Report action exists on relevant project surfaces (detail page + list cards)
- [x] Flow captures a category and reason in a lightweight way
- [x] Submission success or failure is clearly communicated
- [x] Implementation is ready to connect to backend moderation workflows (uses existing \`/moderation/report\` endpoint)

## Verified
- \`npx tsc --noEmit\` — no errors in changed files
- \`npx eslint\` — clean on changed files"

Closes #1026