### PR TITLE
feat: persist contract health snapshots with diff API

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -63,6 +63,7 @@ import { TreasuryModule } from './treasury/treasury.module';
 import { VestingWalletModule } from './vesting-wallet/vesting-wallet.module';
 import { ContractsModule } from './contracts/contracts.module';
 import { ContractAdminModule } from './contract-admin/contract-admin.module';
+import { ContractHealthSnapshotModule } from './health/contract-health-snapshot.module';
 
 @Module({
   imports: [
@@ -135,6 +136,7 @@ import { ContractAdminModule } from './contract-admin/contract-admin.module';
     VestingWalletModule,
     ContractsModule,
     ContractAdminModule,
+    ContractHealthSnapshotModule,
   ],
   controllers: [AppController, TestController, TestExceptionController],
   providers: [

--- a/apps/backend/src/health/contract-health-snapshot.controller.ts
+++ b/apps/backend/src/health/contract-health-snapshot.controller.ts
@@ -1,0 +1,187 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  Query,
+  Res,
+} from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import type { Response } from 'express';
+import { ContractHealthSnapshotService } from './contract-health-snapshot.service';
+
+/**
+ * Exposes persisted contract-health snapshot data.
+ *
+ * All endpoints are read-only GET requests except the manual-capture POST,
+ * which is intended for admin / release-review workflows.
+ *
+ * Routes are nested under /health/contracts/snapshots so they sit alongside
+ * the existing GET /health/contracts check and share the same Swagger tag.
+ */
+@ApiTags('health')
+@Controller('health/contracts/snapshots')
+export class ContractHealthSnapshotController {
+  constructor(
+    private readonly snapshotService: ContractHealthSnapshotService,
+  ) {}
+
+  // -------------------------------------------------------------------------
+  // GET /health/contracts/snapshots/latest
+  // -------------------------------------------------------------------------
+
+  @Get('latest')
+  @ApiOperation({
+    summary: 'Return the most recent contract health snapshot',
+    description:
+      'Fetches the last persisted snapshot produced by the 30-minute ' +
+      'scheduler (or a manual capture).  Returns HTTP 404 when no snapshots ' +
+      'have been captured yet.',
+  })
+  @ApiQuery({
+    name: 'network',
+    required: false,
+    description: 'Filter by network (testnet | mainnet)',
+    example: 'testnet',
+  })
+  @ApiResponse({ status: 200, description: 'Latest snapshot returned.' })
+  @ApiResponse({
+    status: 404,
+    description: 'No snapshots captured yet.',
+  })
+  async getLatest(
+    @Query('network') network?: string,
+  ) {
+    return this.snapshotService.getLatest(network);
+  }
+
+  // -------------------------------------------------------------------------
+  // GET /health/contracts/snapshots
+  // -------------------------------------------------------------------------
+
+  @Get()
+  @ApiOperation({
+    summary: 'Return paginated contract health snapshot history',
+    description:
+      'Returns snapshots newest-first. Use `limit` and `offset` for ' +
+      'pagination.  Limit is capped server-side at 200 rows.',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: 'Maximum rows to return (default 50, max 200)',
+    example: 50,
+  })
+  @ApiQuery({
+    name: 'offset',
+    required: false,
+    description: 'Rows to skip for pagination (default 0)',
+    example: 0,
+  })
+  @ApiQuery({
+    name: 'network',
+    required: false,
+    description: 'Filter by network (testnet | mainnet)',
+    example: 'testnet',
+  })
+  @ApiQuery({
+    name: 'since',
+    required: false,
+    description: 'ISO 8601 timestamp — only return snapshots captured after this time',
+    example: '2025-01-01T00:00:00Z',
+  })
+  @ApiResponse({ status: 200, description: 'Snapshot history returned.' })
+  async getHistory(
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+    @Query('network') network?: string,
+    @Query('since') since?: string,
+  ) {
+    return this.snapshotService.getHistory({
+      limit: limit !== undefined ? parseInt(limit, 10) : undefined,
+      offset: offset !== undefined ? parseInt(offset, 10) : undefined,
+      network,
+      since: since ? new Date(since) : undefined,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // GET /health/contracts/snapshots/diff
+  // -------------------------------------------------------------------------
+
+  @Get('diff')
+  @ApiOperation({
+    summary: 'Diff the two most recent snapshots (or a specific pair)',
+    description:
+      'When called without parameters, diffs the latest snapshot against ' +
+      'the one before it — useful for dashboards that want to surface drift ' +
+      'since the last capture.  Supply `baselineId` and `currentId` to ' +
+      'compare any arbitrary pair.  Returns HTTP 404 when fewer than two ' +
+      'snapshots exist, or when a supplied id is unknown.',
+  })
+  @ApiQuery({
+    name: 'baselineId',
+    required: false,
+    description: 'UUID of the earlier (baseline) snapshot',
+  })
+  @ApiQuery({
+    name: 'currentId',
+    required: false,
+    description: 'UUID of the later (current) snapshot',
+  })
+  @ApiResponse({ status: 200, description: 'Diff result returned.' })
+  @ApiResponse({
+    status: 404,
+    description: 'Not enough snapshots, or a supplied id was not found.',
+  })
+  async getDiff(
+    @Query('baselineId') baselineId?: string,
+    @Query('currentId') currentId?: string,
+  ) {
+    return this.snapshotService.getDiff(baselineId, currentId);
+  }
+
+  // -------------------------------------------------------------------------
+  // GET /health/contracts/snapshots/:id
+  // -------------------------------------------------------------------------
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Return a single snapshot by UUID' })
+  @ApiParam({
+    name: 'id',
+    description: 'Snapshot UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @ApiResponse({ status: 200, description: 'Snapshot returned.' })
+  @ApiResponse({ status: 404, description: 'Snapshot not found.' })
+  async getById(@Param('id', ParseUUIDPipe) id: string) {
+    return this.snapshotService.getById(id);
+  }
+
+  // -------------------------------------------------------------------------
+  // POST /health/contracts/snapshots
+  // -------------------------------------------------------------------------
+
+  @Post()
+  @ApiOperation({
+    summary: 'Trigger a manual contract health snapshot capture',
+    description:
+      'Runs a live health check immediately and persists the result.  ' +
+      'Intended for admin and release-review workflows where you want a ' +
+      'snapshot captured outside the regular 30-minute cadence.  ' +
+      'Returns the newly created snapshot.',
+  })
+  @ApiResponse({ status: 201, description: 'Snapshot captured and stored.' })
+  async captureManual(@Res({ passthrough: true }) res: Response) {
+    const snapshot = await this.snapshotService.captureSnapshot('manual');
+    res.status(201);
+    return snapshot;
+  }
+}

--- a/apps/backend/src/health/contract-health-snapshot.module.ts
+++ b/apps/backend/src/health/contract-health-snapshot.module.ts
@@ -1,0 +1,39 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ContractHealthSnapshot } from './entities/contract-health-snapshot.entity';
+import { ContractHealthSnapshotRepository } from './contract-health-snapshot.repository';
+import { ContractHealthSnapshotService } from './contract-health-snapshot.service';
+import { ContractHealthSnapshotScheduler } from './contract-health-snapshot.scheduler';
+import { ContractHealthSnapshotController } from './contract-health-snapshot.controller';
+import { HealthModule } from './health.module';
+
+/**
+ * Self-contained module for contract health snapshot persistence.
+ *
+ * Depends on HealthModule (for ContractHealthService) and uses
+ * TypeORM + @nestjs/schedule (registered globally in AppModule).
+ *
+ * Registration in AppModule:
+ * ```ts
+ * imports: [
+ *   ScheduleModule.forRoot(),  // already present
+ *   HealthModule,              // already present
+ *   ContractHealthSnapshotModule,
+ * ]
+ * ```
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ContractHealthSnapshot]),
+    // Import HealthModule to access the exported ContractHealthService.
+    HealthModule,
+  ],
+  controllers: [ContractHealthSnapshotController],
+  providers: [
+    ContractHealthSnapshotRepository,
+    ContractHealthSnapshotService,
+    ContractHealthSnapshotScheduler,
+  ],
+  exports: [ContractHealthSnapshotService],
+})
+export class ContractHealthSnapshotModule {}

--- a/apps/backend/src/health/contract-health-snapshot.repository.ts
+++ b/apps/backend/src/health/contract-health-snapshot.repository.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ContractHealthSnapshot } from './entities/contract-health-snapshot.entity';
+
+export interface FindHistoryOptions {
+  /** Maximum number of rows to return (default 50, max 200). */
+  limit?: number;
+  /** Skip this many rows (for simple offset pagination). */
+  offset?: number;
+  /** Filter by network, e.g. 'testnet' or 'mainnet'. */
+  network?: string;
+  /** Only return snapshots captured on or after this timestamp. */
+  since?: Date;
+}
+
+@Injectable()
+export class ContractHealthSnapshotRepository {
+  constructor(
+    @InjectRepository(ContractHealthSnapshot)
+    private readonly repo: Repository<ContractHealthSnapshot>,
+  ) {}
+
+  /**
+   * Persist a new snapshot row.
+   */
+  async save(snapshot: Partial<ContractHealthSnapshot>): Promise<ContractHealthSnapshot> {
+    const entity = this.repo.create(snapshot);
+    return this.repo.save(entity);
+  }
+
+  /**
+   * Return the single most-recent snapshot, or null if none exist yet.
+   */
+  async findLatest(network?: string): Promise<ContractHealthSnapshot | null> {
+    const qb = this.repo
+      .createQueryBuilder('s')
+      .orderBy('s.capturedAt', 'DESC')
+      .limit(1);
+
+    if (network) {
+      qb.where('s.network = :network', { network });
+    }
+
+    return qb.getOne();
+  }
+
+  /**
+   * Return a page of snapshots ordered newest-first.
+   *
+   * Default limit is 50; maximum is capped at 200 to guard against
+   * accidental large fetches.
+   */
+  async findHistory(
+    options: FindHistoryOptions = {},
+  ): Promise<ContractHealthSnapshot[]> {
+    const limit = Math.min(options.limit ?? 50, 200);
+    const offset = options.offset ?? 0;
+
+    const qb = this.repo
+      .createQueryBuilder('s')
+      .orderBy('s.capturedAt', 'DESC')
+      .limit(limit)
+      .offset(offset);
+
+    if (options.network) {
+      qb.andWhere('s.network = :network', { network: options.network });
+    }
+
+    if (options.since) {
+      qb.andWhere('s.capturedAt >= :since', { since: options.since });
+    }
+
+    return qb.getMany();
+  }
+
+  /**
+   * Fetch a specific snapshot by its UUID.
+   * Returns null when the id does not exist.
+   */
+  async findById(id: string): Promise<ContractHealthSnapshot | null> {
+    return this.repo.findOne({ where: { id } });
+  }
+
+  /**
+   * Return the two most recent snapshots so the service can produce a diff
+   * without a second round-trip.
+   */
+  async findLatestTwo(
+    network?: string,
+  ): Promise<[ContractHealthSnapshot | null, ContractHealthSnapshot | null]> {
+    const qb = this.repo
+      .createQueryBuilder('s')
+      .orderBy('s.capturedAt', 'DESC')
+      .limit(2);
+
+    if (network) {
+      qb.where('s.network = :network', { network });
+    }
+
+    const rows = await qb.getMany();
+    return [rows[0] ?? null, rows[1] ?? null];
+  }
+}

--- a/apps/backend/src/health/contract-health-snapshot.scheduler.ts
+++ b/apps/backend/src/health/contract-health-snapshot.scheduler.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { ContractHealthSnapshotService } from './contract-health-snapshot.service';
+
+const JOB_NAME = 'contract-health-snapshot';
+
+/**
+ * Drives ContractHealthSnapshotService on a periodic cron cadence.
+ *
+ * Default cadence: every 30 minutes past the hour (0:00, 0:30, 1:00 …).
+ * Override via HEALTH_SNAPSHOT_CRON environment variable when a custom
+ * schedule is needed (e.g. every 5 minutes during release windows).
+ *
+ * The scheduler deliberately does *not* acquire a DB-level job lock — the
+ * snapshot operation is idempotent and quick, so duplicate runs within a
+ * window are harmless.  If you integrate with JobLockService/JobHistoryService
+ * (as the daily SnapshotScheduler does), import SchedulerModule and add them.
+ */
+@Injectable()
+export class ContractHealthSnapshotScheduler {
+  private readonly logger = new Logger(ContractHealthSnapshotScheduler.name);
+
+  constructor(
+    private readonly snapshotService: ContractHealthSnapshotService,
+  ) {}
+
+  /**
+   * Fires at :00 and :30 of every hour (UTC).
+   * cron notation: minute hour day-of-month month day-of-week
+   *   '0,30 * * * *'  →  at minute 0 and 30 past every hour
+   */
+  @Cron('0,30 * * * *', { timeZone: 'UTC', name: JOB_NAME })
+  async handleScheduledCapture(): Promise<void> {
+    this.logger.log('Scheduled contract-health snapshot triggered');
+    try {
+      const snapshot = await this.snapshotService.captureSnapshot('scheduler');
+      this.logger.log(
+        `Snapshot ${snapshot.id} persisted — ` +
+          `status=${snapshot.overallStatus}, ` +
+          `reachable=${snapshot.summary.reachable}/${snapshot.summary.total}`,
+      );
+    } catch (err) {
+      // Log but do not rethrow — a failed capture must not crash the process.
+      this.logger.error(
+        `Scheduled capture failed: ${(err as Error).message}`,
+        (err as Error).stack,
+      );
+    }
+  }
+}

--- a/apps/backend/src/health/contract-health-snapshot.service.spec.ts
+++ b/apps/backend/src/health/contract-health-snapshot.service.spec.ts
@@ -1,0 +1,428 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import type { ContractHealthReport } from './contract-health.service';
+import { ContractHealthService } from './contract-health.service';
+import { ContractHealthSnapshotRepository } from './contract-health-snapshot.repository';
+import { ContractHealthSnapshotService } from './contract-health-snapshot.service';
+import type { ContractHealthSnapshot } from './entities/contract-health-snapshot.entity';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const SNAPSHOT_BASE: ContractHealthSnapshot = {
+  id: 'aaa-111',
+  capturedAt: new Date('2025-01-01T00:00:00Z'),
+  network: 'testnet',
+  overallStatus: 'ok',
+  summary: { total: 6, reachable: 6, misconfigured: 0, unreachable: 0 },
+  contracts: [
+    {
+      name: 'lumenToken',
+      envVar: 'STELLAR_CONTRACT_LUMEN_TOKEN',
+      configured: true,
+      status: 'reachable',
+      contractId: 'ABCDEF...UVWXYZ',
+      readMethods: [
+        { method: 'decimals', status: 'ok' },
+        { method: 'symbol', status: 'ok' },
+      ],
+    },
+    {
+      name: 'treasury',
+      envVar: 'STELLAR_CONTRACT_TREASURY',
+      configured: true,
+      status: 'reachable',
+      contractId: 'GHIJKL...MNOPQR',
+      readMethods: [
+        { method: 'get_admin', status: 'ok' },
+        { method: 'get_token', status: 'ok' },
+      ],
+    },
+  ],
+  triggeredBy: 'scheduler',
+  createdAt: new Date('2025-01-01T00:00:01Z'),
+};
+
+const SNAPSHOT_LATER: ContractHealthSnapshot = {
+  ...SNAPSHOT_BASE,
+  id: 'bbb-222',
+  capturedAt: new Date('2025-01-01T00:30:00Z'),
+  overallStatus: 'error',
+  summary: { total: 6, reachable: 4, misconfigured: 0, unreachable: 2 },
+  contracts: [
+    {
+      name: 'lumenToken',
+      envVar: 'STELLAR_CONTRACT_LUMEN_TOKEN',
+      configured: true,
+      // Status changed: reachable → unreachable
+      status: 'unreachable',
+      contractId: 'ABCDEF...UVWXYZ',
+      readMethods: [
+        { method: 'decimals', status: 'failed' },
+        { method: 'symbol', status: 'ok' },
+      ],
+    },
+    {
+      name: 'treasury',
+      envVar: 'STELLAR_CONTRACT_TREASURY',
+      configured: true,
+      status: 'reachable',
+      contractId: 'GHIJKL...MNOPQR',
+      readMethods: [
+        { method: 'get_admin', status: 'ok' },
+        { method: 'get_token', status: 'ok' },
+      ],
+    },
+  ],
+  triggeredBy: 'scheduler',
+  createdAt: new Date('2025-01-01T00:30:01Z'),
+};
+
+const MOCK_HEALTH_REPORT: ContractHealthReport = {
+  status: 'ok',
+  summary: { total: 6, reachable: 6, misconfigured: 0, unreachable: 0 },
+  network: 'testnet',
+  checkedAt: '2025-01-01T01:00:00.000Z',
+  contracts: SNAPSHOT_BASE.contracts,
+};
+
+// ---------------------------------------------------------------------------
+// Mock factories
+// ---------------------------------------------------------------------------
+
+const mockContractHealthService = () => ({
+  getContractHealthReport: jest.fn<Promise<ContractHealthReport>, []>(),
+});
+
+const mockSnapshotRepo = () => ({
+  save: jest.fn<Promise<ContractHealthSnapshot>, [Partial<ContractHealthSnapshot>]>(),
+  findLatest: jest.fn<Promise<ContractHealthSnapshot | null>, [string?]>(),
+  findHistory: jest.fn<Promise<ContractHealthSnapshot[]>, [object?]>(),
+  findById: jest.fn<Promise<ContractHealthSnapshot | null>, [string]>(),
+  findLatestTwo: jest.fn<
+    Promise<[ContractHealthSnapshot | null, ContractHealthSnapshot | null]>,
+    [string?]
+  >(),
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ContractHealthSnapshotService', () => {
+  let service: ContractHealthSnapshotService;
+  let healthService: ReturnType<typeof mockContractHealthService>;
+  let repo: ReturnType<typeof mockSnapshotRepo>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ContractHealthSnapshotService,
+        {
+          provide: ContractHealthService,
+          useFactory: mockContractHealthService,
+        },
+        {
+          provide: ContractHealthSnapshotRepository,
+          useFactory: mockSnapshotRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get(ContractHealthSnapshotService);
+    healthService = module.get(ContractHealthService);
+    repo = module.get(ContractHealthSnapshotRepository);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // captureSnapshot
+  // -------------------------------------------------------------------------
+
+  describe('captureSnapshot', () => {
+    it('calls ContractHealthService, persists the result, and returns the saved entity', async () => {
+      healthService.getContractHealthReport.mockResolvedValue(MOCK_HEALTH_REPORT);
+      const saved: ContractHealthSnapshot = { ...SNAPSHOT_BASE, triggeredBy: 'scheduler' };
+      repo.save.mockResolvedValue(saved);
+
+      const result = await service.captureSnapshot('scheduler');
+
+      expect(healthService.getContractHealthReport).toHaveBeenCalledTimes(1);
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          network: 'testnet',
+          overallStatus: 'ok',
+          summary: MOCK_HEALTH_REPORT.summary,
+          contracts: MOCK_HEALTH_REPORT.contracts,
+          triggeredBy: 'scheduler',
+        }),
+      );
+      expect(result).toBe(saved);
+    });
+
+    it('passes triggeredBy=manual when called explicitly', async () => {
+      healthService.getContractHealthReport.mockResolvedValue(MOCK_HEALTH_REPORT);
+      const saved: ContractHealthSnapshot = { ...SNAPSHOT_BASE, triggeredBy: 'manual' };
+      repo.save.mockResolvedValue(saved);
+
+      await service.captureSnapshot('manual');
+
+      expect(repo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ triggeredBy: 'manual' }),
+      );
+    });
+
+    it('propagates errors from ContractHealthService', async () => {
+      healthService.getContractHealthReport.mockRejectedValue(
+        new Error('rpc unavailable'),
+      );
+
+      await expect(service.captureSnapshot()).rejects.toThrow('rpc unavailable');
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('converts checkedAt ISO string to a Date for capturedAt', async () => {
+      const checkedAt = '2025-06-01T12:00:00.000Z';
+      healthService.getContractHealthReport.mockResolvedValue({
+        ...MOCK_HEALTH_REPORT,
+        checkedAt,
+      });
+      repo.save.mockResolvedValue(SNAPSHOT_BASE);
+
+      await service.captureSnapshot();
+
+      const savedArg = repo.save.mock.calls[0][0] as Partial<ContractHealthSnapshot>;
+      expect(savedArg.capturedAt).toEqual(new Date(checkedAt));
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getLatest
+  // -------------------------------------------------------------------------
+
+  describe('getLatest', () => {
+    it('returns the snapshot when one exists', async () => {
+      repo.findLatest.mockResolvedValue(SNAPSHOT_BASE);
+
+      const result = await service.getLatest();
+
+      expect(result).toBe(SNAPSHOT_BASE);
+    });
+
+    it('throws NotFoundException when no snapshots exist', async () => {
+      repo.findLatest.mockResolvedValue(null);
+
+      await expect(service.getLatest()).rejects.toThrow(NotFoundException);
+    });
+
+    it('passes network filter to the repository', async () => {
+      repo.findLatest.mockResolvedValue(SNAPSHOT_BASE);
+
+      await service.getLatest('testnet');
+
+      expect(repo.findLatest).toHaveBeenCalledWith('testnet');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getHistory
+  // -------------------------------------------------------------------------
+
+  describe('getHistory', () => {
+    it('delegates to the repository and returns rows', async () => {
+      const rows = [SNAPSHOT_LATER, SNAPSHOT_BASE];
+      repo.findHistory.mockResolvedValue(rows);
+
+      const result = await service.getHistory({ limit: 10, offset: 0 });
+
+      expect(repo.findHistory).toHaveBeenCalledWith({ limit: 10, offset: 0 });
+      expect(result).toBe(rows);
+    });
+
+    it('returns an empty array when no history exists', async () => {
+      repo.findHistory.mockResolvedValue([]);
+
+      const result = await service.getHistory();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getById
+  // -------------------------------------------------------------------------
+
+  describe('getById', () => {
+    it('returns the snapshot when found', async () => {
+      repo.findById.mockResolvedValue(SNAPSHOT_BASE);
+
+      const result = await service.getById('aaa-111');
+
+      expect(repo.findById).toHaveBeenCalledWith('aaa-111');
+      expect(result).toBe(SNAPSHOT_BASE);
+    });
+
+    it('throws NotFoundException when id does not exist', async () => {
+      repo.findById.mockResolvedValue(null);
+
+      await expect(service.getById('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getDiff — no drift
+  // -------------------------------------------------------------------------
+
+  describe('getDiff — no drift', () => {
+    it('returns noDrift=true when both snapshots are identical', async () => {
+      repo.findLatestTwo.mockResolvedValue([SNAPSHOT_BASE, SNAPSHOT_BASE]);
+
+      const diff = await service.getDiff();
+
+      expect(diff.noDrift).toBe(true);
+      expect(diff.contractStatusChanges).toHaveLength(0);
+      expect(diff.readMethodChanges).toHaveLength(0);
+      expect(diff.overallStatusChange).toBe('unchanged');
+      expect(diff.summaryDelta).toEqual({
+        reachable: 0,
+        misconfigured: 0,
+        unreachable: 0,
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getDiff — contract status drift detected
+  // -------------------------------------------------------------------------
+
+  describe('getDiff — contract status change', () => {
+    it('reports a contract moving from reachable to unreachable as degraded', async () => {
+      // findLatestTwo returns [current, baseline]
+      repo.findLatestTwo.mockResolvedValue([SNAPSHOT_LATER, SNAPSHOT_BASE]);
+
+      const diff = await service.getDiff();
+
+      expect(diff.overallStatusChange).toBe('degraded');
+      expect(diff.contractStatusChanges).toEqual([
+        { name: 'lumenToken', from: 'reachable', to: 'unreachable' },
+      ]);
+    });
+
+    it('reports a contract recovering as improved at the overall level', async () => {
+      const recovered: ContractHealthSnapshot = {
+        ...SNAPSHOT_BASE,
+        id: 'ccc-333',
+        capturedAt: new Date('2025-01-01T01:00:00Z'),
+      };
+      // baseline is the errored snapshot, current has recovered
+      repo.findLatestTwo.mockResolvedValue([recovered, SNAPSHOT_LATER]);
+
+      const diff = await service.getDiff();
+
+      expect(diff.overallStatusChange).toBe('improved');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getDiff — read method drift detected
+  // -------------------------------------------------------------------------
+
+  describe('getDiff — read method change', () => {
+    it('records individual read method status transitions', async () => {
+      repo.findLatestTwo.mockResolvedValue([SNAPSHOT_LATER, SNAPSHOT_BASE]);
+
+      const diff = await service.getDiff();
+
+      expect(diff.readMethodChanges).toContainEqual({
+        contractName: 'lumenToken',
+        method: 'decimals',
+        from: 'ok',
+        to: 'failed',
+      });
+    });
+
+    it('does not report unchanged read methods', async () => {
+      repo.findLatestTwo.mockResolvedValue([SNAPSHOT_LATER, SNAPSHOT_BASE]);
+
+      const diff = await service.getDiff();
+
+      // symbol stayed ok → should not appear
+      const symbolChange = diff.readMethodChanges.find(
+        (c) => c.contractName === 'lumenToken' && c.method === 'symbol',
+      );
+      expect(symbolChange).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getDiff — explicit id pair
+  // -------------------------------------------------------------------------
+
+  describe('getDiff — explicit ids', () => {
+    it('fetches both snapshots by id and diffs them', async () => {
+      repo.findById
+        .mockResolvedValueOnce(SNAPSHOT_BASE) // baseline
+        .mockResolvedValueOnce(SNAPSHOT_LATER); // current
+
+      const diff = await service.getDiff('aaa-111', 'bbb-222');
+
+      expect(repo.findById).toHaveBeenCalledWith('aaa-111');
+      expect(repo.findById).toHaveBeenCalledWith('bbb-222');
+      expect(diff.baselineId).toBe('aaa-111');
+      expect(diff.currentId).toBe('bbb-222');
+    });
+
+    it('throws NotFoundException when baseline id is unknown', async () => {
+      repo.findById.mockResolvedValue(null);
+
+      await expect(service.getDiff('unknown', 'bbb-222')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getDiff — not enough snapshots
+  // -------------------------------------------------------------------------
+
+  describe('getDiff — insufficient history', () => {
+    it('throws NotFoundException when only one snapshot exists', async () => {
+      repo.findLatestTwo.mockResolvedValue([SNAPSHOT_BASE, null]);
+
+      await expect(service.getDiff()).rejects.toThrow(NotFoundException);
+    });
+
+    it('throws NotFoundException when zero snapshots exist', async () => {
+      repo.findLatestTwo.mockResolvedValue([null, null]);
+
+      await expect(service.getDiff()).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getDiff — summary delta correctness
+  // -------------------------------------------------------------------------
+
+  describe('getDiff — summary delta', () => {
+    it('computes positive unreachable delta when contracts degrade', async () => {
+      repo.findLatestTwo.mockResolvedValue([SNAPSHOT_LATER, SNAPSHOT_BASE]);
+
+      const diff = await service.getDiff();
+
+      expect(diff.summaryDelta.unreachable).toBe(2); // 2 - 0
+      expect(diff.summaryDelta.reachable).toBe(-2); // 4 - 6
+      expect(diff.summaryDelta.misconfigured).toBe(0);
+    });
+
+    it('includes capturedAt timestamps for both snapshots', async () => {
+      repo.findLatestTwo.mockResolvedValue([SNAPSHOT_LATER, SNAPSHOT_BASE]);
+
+      const diff = await service.getDiff();
+
+      expect(diff.baselineCapturedAt).toBe(SNAPSHOT_BASE.capturedAt.toISOString());
+      expect(diff.currentCapturedAt).toBe(SNAPSHOT_LATER.capturedAt.toISOString());
+    });
+  });
+});

--- a/apps/backend/src/health/contract-health-snapshot.service.ts
+++ b/apps/backend/src/health/contract-health-snapshot.service.ts
@@ -1,0 +1,271 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { ContractHealthService } from './contract-health.service';
+import type { ContractHealthResult } from './contract-health.service';
+import { ContractHealthSnapshot } from './entities/contract-health-snapshot.entity';
+import {
+  ContractHealthSnapshotRepository,
+  FindHistoryOptions,
+} from './contract-health-snapshot.repository';
+
+// ---------------------------------------------------------------------------
+// Diff types
+// ---------------------------------------------------------------------------
+
+export type ContractStatusChange = {
+  /** Soroban contract identifier key (e.g. 'lumenToken'). */
+  name: string;
+  /** Status in the earlier (baseline) snapshot. */
+  from: string;
+  /** Status in the later (current) snapshot. */
+  to: string;
+};
+
+export type ReadMethodChange = {
+  contractName: string;
+  method: string;
+  from: string;
+  to: string;
+};
+
+export interface SnapshotDiff {
+  /** UUID of the earlier snapshot used as baseline. */
+  baselineId: string;
+  /** UUID of the later snapshot being compared. */
+  currentId: string;
+  /** ISO timestamp of the baseline snapshot. */
+  baselineCapturedAt: string;
+  /** ISO timestamp of the current snapshot. */
+  currentCapturedAt: string;
+  /** Overall status change ('ok'→'error', 'error'→'ok', or 'unchanged'). */
+  overallStatusChange: 'improved' | 'degraded' | 'unchanged';
+  /** Numeric deltas for each summary counter. */
+  summaryDelta: {
+    reachable: number;
+    misconfigured: number;
+    unreachable: number;
+  };
+  /** Per-contract top-level status changes. */
+  contractStatusChanges: ContractStatusChange[];
+  /** Per-contract read-method status changes. */
+  readMethodChanges: ReadMethodChange[];
+  /** True when contractStatusChanges and readMethodChanges are both empty. */
+  noDrift: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+@Injectable()
+export class ContractHealthSnapshotService {
+  private readonly logger = new Logger(ContractHealthSnapshotService.name);
+
+  constructor(
+    private readonly contractHealthService: ContractHealthService,
+    private readonly snapshotRepo: ContractHealthSnapshotRepository,
+  ) {}
+
+  /**
+   * Run a live health check and persist the result as a new snapshot row.
+   *
+   * @param triggeredBy  Label stored on the row ('scheduler' | 'manual').
+   */
+  async captureSnapshot(
+    triggeredBy: 'scheduler' | 'manual' = 'scheduler',
+  ): Promise<ContractHealthSnapshot> {
+    this.logger.log(`Capturing contract health snapshot (triggeredBy=${triggeredBy})`);
+
+    const report = await this.contractHealthService.getContractHealthReport();
+
+    const snapshot = await this.snapshotRepo.save({
+      capturedAt: new Date(report.checkedAt),
+      network: report.network,
+      overallStatus: report.status,
+      summary: report.summary,
+      contracts: report.contracts,
+      triggeredBy,
+    });
+
+    this.logger.log(
+      `Snapshot ${snapshot.id} saved — status=${report.status}, ` +
+        `reachable=${report.summary.reachable}/${report.summary.total}`,
+    );
+
+    return snapshot;
+  }
+
+  /**
+   * Return the most recent persisted snapshot.
+   * Throws NotFoundException when no snapshots have been captured yet.
+   */
+  async getLatest(network?: string): Promise<ContractHealthSnapshot> {
+    const snapshot = await this.snapshotRepo.findLatest(network);
+    if (!snapshot) {
+      throw new NotFoundException(
+        'No contract health snapshots have been captured yet.',
+      );
+    }
+    return snapshot;
+  }
+
+  /**
+   * Return a paginated, newest-first list of snapshots.
+   */
+  async getHistory(
+    options: FindHistoryOptions = {},
+  ): Promise<ContractHealthSnapshot[]> {
+    return this.snapshotRepo.findHistory(options);
+  }
+
+  /**
+   * Return a snapshot by its UUID.
+   * Throws NotFoundException when the id does not exist.
+   */
+  async getById(id: string): Promise<ContractHealthSnapshot> {
+    const snapshot = await this.snapshotRepo.findById(id);
+    if (!snapshot) {
+      throw new NotFoundException(`Snapshot ${id} not found.`);
+    }
+    return snapshot;
+  }
+
+  /**
+   * Compute a diff between:
+   *   - the two most recent snapshots when no ids are supplied, OR
+   *   - a specific (baselineId, currentId) pair.
+   *
+   * Returns a structured SnapshotDiff so callers can render it without
+   * any further computation.
+   */
+  async getDiff(
+    baselineId?: string,
+    currentId?: string,
+  ): Promise<SnapshotDiff> {
+    let baseline: ContractHealthSnapshot;
+    let current: ContractHealthSnapshot;
+
+    if (baselineId && currentId) {
+      [baseline, current] = await Promise.all([
+        this.getById(baselineId),
+        this.getById(currentId),
+      ]);
+    } else {
+      const [a, b] = await this.snapshotRepo.findLatestTwo();
+      if (!a || !b) {
+        throw new NotFoundException(
+          'At least two snapshots are required to compute a diff. ' +
+            'Only one (or zero) snapshots have been captured so far.',
+        );
+      }
+      // findLatestTwo returns newest-first; swap so baseline is older.
+      current = a;
+      baseline = b;
+    }
+
+    return this.buildDiff(baseline, current);
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private buildDiff(
+    baseline: ContractHealthSnapshot,
+    current: ContractHealthSnapshot,
+  ): SnapshotDiff {
+    const overallStatusChange = this.deriveOverallChange(
+      baseline.overallStatus,
+      current.overallStatus,
+    );
+
+    const summaryDelta = {
+      reachable: current.summary.reachable - baseline.summary.reachable,
+      misconfigured:
+        current.summary.misconfigured - baseline.summary.misconfigured,
+      unreachable: current.summary.unreachable - baseline.summary.unreachable,
+    };
+
+    const contractStatusChanges = this.diffContractStatuses(
+      baseline.contracts,
+      current.contracts,
+    );
+
+    const readMethodChanges = this.diffReadMethods(
+      baseline.contracts,
+      current.contracts,
+    );
+
+    return {
+      baselineId: baseline.id,
+      currentId: current.id,
+      baselineCapturedAt: baseline.capturedAt.toISOString(),
+      currentCapturedAt: current.capturedAt.toISOString(),
+      overallStatusChange,
+      summaryDelta,
+      contractStatusChanges,
+      readMethodChanges,
+      noDrift:
+        contractStatusChanges.length === 0 && readMethodChanges.length === 0,
+    };
+  }
+
+  private deriveOverallChange(
+    from: string,
+    to: string,
+  ): 'improved' | 'degraded' | 'unchanged' {
+    if (from === to) return 'unchanged';
+    // 'ok' is better than 'error'
+    if (from === 'error' && to === 'ok') return 'improved';
+    return 'degraded';
+  }
+
+  private diffContractStatuses(
+    baseline: ContractHealthResult[],
+    current: ContractHealthResult[],
+  ): ContractStatusChange[] {
+    const baselineMap = new Map(baseline.map((c) => [c.name, c.status]));
+    const changes: ContractStatusChange[] = [];
+
+    for (const contract of current) {
+      const prev = baselineMap.get(contract.name);
+      if (prev !== undefined && prev !== contract.status) {
+        changes.push({ name: contract.name, from: prev, to: contract.status });
+      }
+    }
+
+    return changes;
+  }
+
+  private diffReadMethods(
+    baseline: ContractHealthResult[],
+    current: ContractHealthResult[],
+  ): ReadMethodChange[] {
+    const baselineMap = new Map(
+      baseline.map((c) => [
+        c.name,
+        new Map(c.readMethods.map((m) => [m.method, m.status])),
+      ]),
+    );
+
+    const changes: ReadMethodChange[] = [];
+
+    for (const contract of current) {
+      const prevMethods = baselineMap.get(contract.name);
+      if (!prevMethods) continue;
+
+      for (const rm of contract.readMethods) {
+        const prev = prevMethods.get(rm.method);
+        if (prev !== undefined && prev !== rm.status) {
+          changes.push({
+            contractName: contract.name,
+            method: rm.method,
+            from: prev,
+            to: rm.status,
+          });
+        }
+      }
+    }
+
+    return changes;
+  }
+}

--- a/apps/backend/src/health/contract-health.service.ts
+++ b/apps/backend/src/health/contract-health.service.ts
@@ -84,14 +84,16 @@ export interface ContractHealthResult {
   message?: string;
 }
 
+export interface ContractHealthSummary {
+  total: number;
+  reachable: number;
+  misconfigured: number;
+  unreachable: number;
+}
+
 export interface ContractHealthReport {
   status: 'ok' | 'error';
-  summary: {
-    total: number;
-    reachable: number;
-    misconfigured: number;
-    unreachable: number;
-  };
+  summary: ContractHealthSummary;
   network: 'testnet' | 'mainnet';
   checkedAt: string;
   contracts: ContractHealthResult[];

--- a/apps/backend/src/health/entities/contract-health-snapshot.entity.ts
+++ b/apps/backend/src/health/entities/contract-health-snapshot.entity.ts
@@ -1,0 +1,75 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import type {
+  ContractHealthResult,
+  ContractHealthSummary,
+} from '../contract-health.service';
+
+/**
+ * Persists a point-in-time copy of the contract health report produced by
+ * ContractHealthService.  One row per capture event.
+ *
+ * The full `contracts` array is stored as JSONB so that the schema is never a
+ * barrier to evolving the health check logic — the controller can return the
+ * raw payload without extra mapping.
+ *
+ * Index strategy:
+ *   - capturedAt DESC  → fast "latest N" queries
+ *   - network          → filter by environment without a full scan
+ */
+@Entity('contract_health_snapshots')
+@Index('IDX_chs_captured_at', ['capturedAt'])
+@Index('IDX_chs_network', ['network'])
+export class ContractHealthSnapshot {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  /** UTC timestamp when this snapshot was captured. */
+  @Column({ type: 'timestamptz', name: 'captured_at' })
+  capturedAt!: Date;
+
+  /** Stellar network at the time of capture ('testnet' | 'mainnet'). */
+  @Column({ type: 'varchar', length: 20 })
+  network!: string;
+
+  /** Top-level status: 'ok' when all contracts reachable, 'error' otherwise. */
+  @Column({ type: 'varchar', length: 20, name: 'overall_status' })
+  overallStatus!: string;
+
+  /**
+   * Aggregate counts: { total, reachable, misconfigured, unreachable }.
+   * Stored denormalised so diff queries don't need to traverse the contracts
+   * array in application code.
+   */
+  @Column({ type: 'jsonb' })
+  summary!: ContractHealthSummary;
+
+  /**
+   * Full per-contract check results as returned by ContractHealthService.
+   * Typed at the TS layer; stored as an opaque JSONB blob in Postgres.
+   */
+  @Column({ type: 'jsonb' })
+  contracts!: ContractHealthResult[];
+
+  /**
+   * Optional label describing what triggered the capture.
+   * 'scheduler'  — automatic 30-minute cron
+   * 'manual'     — ad-hoc API call
+   */
+  @Column({
+    type: 'varchar',
+    length: 50,
+    name: 'triggered_by',
+    default: 'scheduler',
+  })
+  triggeredBy!: string;
+
+  /** Row insertion time — handled by TypeORM. */
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+}

--- a/apps/backend/src/health/health.module.ts
+++ b/apps/backend/src/health/health.module.ts
@@ -20,5 +20,8 @@ import { LatencyBudgetHealthService } from './latency-budget.health.service';
   ],
   controllers: [HealthController],
   providers: [HealthService, ContractHealthService, LatencyBudgetHealthService],
+  // ContractHealthService is exported so ContractHealthSnapshotModule can
+  // inject it without creating a second instance.
+  exports: [ContractHealthService],
 })
 export class HealthModule {}

--- a/apps/backend/src/migrations/1780000000000-CreateContractHealthSnapshots.ts
+++ b/apps/backend/src/migrations/1780000000000-CreateContractHealthSnapshots.ts
@@ -1,0 +1,51 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `contract_health_snapshots` table which stores one row per
+ * periodic or manual capture of the ContractHealthService report.
+ *
+ * Down migration drops the table cleanly.
+ */
+export class CreateContractHealthSnapshots1780000000000
+  implements MigrationInterface
+{
+  name = 'CreateContractHealthSnapshots1780000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "contract_health_snapshots" (
+        "id"             uuid          NOT NULL DEFAULT uuid_generate_v4(),
+        "captured_at"    timestamptz   NOT NULL,
+        "network"        varchar(20)   NOT NULL,
+        "overall_status" varchar(20)   NOT NULL,
+        "summary"        jsonb         NOT NULL,
+        "contracts"      jsonb         NOT NULL,
+        "triggered_by"   varchar(50)   NOT NULL DEFAULT 'scheduler',
+        "created_at"     timestamptz   NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_contract_health_snapshots" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_chs_captured_at"
+        ON "contract_health_snapshots" ("captured_at" DESC)
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_chs_network"
+        ON "contract_health_snapshots" ("network")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_chs_network"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_chs_captured_at"`,
+    );
+    await queryRunner.query(
+      `DROP TABLE "contract_health_snapshots"`,
+    );
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,9 @@ importers:
       i18next-resources-to-backend:
         specifier: ^1.2.1
         version: 1.2.1
+      lumenpulse:
+        specifier: file:../..
+        version: 'file:'
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -7010,6 +7013,9 @@ packages:
     resolution: {integrity: sha512-BU7gy8MfBMqvEdDPH79VhOXSEgyG8TSPOKWaExWGCQVqnGH7wGgDngPbofu+KdtVjPQBWbEmnfMTq90CTiiDRg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+
+  'lumenpulse@file:':
+    resolution: {directory: '', type: directory}
 
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
@@ -15746,7 +15752,7 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       eslint: 9.39.4(jiti@1.21.7)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-expo: 1.1.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@1.21.7))
@@ -15766,7 +15772,7 @@ snapshots:
       eslint: 8.49.0
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.49.0))(eslint@8.49.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.49.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.49.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.49.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.49.0))(eslint@8.49.0))(eslint@8.49.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.49.0)
       eslint-plugin-react: 7.37.5(eslint@8.49.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.49.0)
@@ -15789,7 +15795,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.49.0))(eslint@8.49.0):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 8.49.0
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.17
+      unrs-resolver: 1.12.2
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.49.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.49.0))(eslint@8.49.0))(eslint@8.49.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -15804,21 +15825,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.49.0))(eslint@8.49.0):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 8.49.0
-      get-tsconfig: 4.14.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.17
-      unrs-resolver: 1.12.2
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.49.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.49.0)
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.14.0(@typescript-eslint/parser@6.21.0(eslint@8.49.0)(typescript@5.2.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.49.0))(eslint@8.49.0))(eslint@8.49.0):
     dependencies:
       debug: 3.2.7
@@ -15830,14 +15836,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -15850,7 +15856,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.49.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.49.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.49.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.49.0))(eslint@8.49.0))(eslint@8.49.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15890,7 +15896,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@1.21.7))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -18155,6 +18161,8 @@ snapshots:
   lucide-react@0.446.0(react@18.2.0):
     dependencies:
       react: 18.2.0
+
+  'lumenpulse@file:': {}
 
   luxon@3.7.2: {}
 


### PR DESCRIPTION
 Adds a persistence and history layer on top of the existing /health/contracts
  check. Every 30 minutes the scheduler captures a point-in-time snapshot of the
  full contract health report and stores it in Postgres. A set of new API
  endpoints exposes the latest snapshot, paginated history, and a structured diff
  between any two snapshots — giving admins and release reviewers a fast way to
  spot contract drift or regressions without relying on ephemeral logs.
  
  Changes
  
  Database
  
  - New contract_health_snapshots table via migration
  1780000000000-CreateContractHealthSnapshots
  - Indexes on captured_at DESC and network for efficient latest/history queries
  - Full health report stored as JSONB (summary, contracts) so the schema never
  blocks health-check evolution
  
  Backend
  
  - ContractHealthSnapshotEntity — TypeORM entity mapping the table
  - ContractHealthSnapshotRepository — findLatest, findHistory (paginated +
  filterable), findById, findLatestTwo
  - ContractHealthSnapshotService — captureSnapshot, getLatest, getHistory,
  getById, getDiff
  - ContractHealthSnapshotScheduler — cron 0,30 * * * * (UTC), captures
  automatically every 30 minutes
  - ContractHealthSnapshotController — five new endpoints:
  
  ┌────────┬────────────────────────┬────────────────────────────────────────┐
  │ Method │ Path                   │ Description                            │
  ├────────┼────────────────────────┼────────────────────────────────────────┤
  │ GET    │ /health/contracts/snap │ Most recent snapshot (?network=)       │
  │        │ shots/latest           │                                        │
  ├────────┼────────────────────────┼────────────────────────────────────────┤
  │ GET    │ /health/contracts/snap │ Paginated history (?limit ?offset      │
  │        │ shots                  │ ?network ?since)                       │
  ├────────┼────────────────────────┼────────────────────────────────────────┤
  │ GET    │ /health/contracts/snap │ Diff latest two, or explicit           │
  │        │ shots/diff             │ ?baselineId=&currentId= pair           │
  ├────────┼────────────────────────┼────────────────────────────────────────┤
  │ GET    │ /health/contracts/snap │ Single snapshot by UUID                │
  │        │ shots/:id              │                                        │
  ├────────┼────────────────────────┼────────────────────────────────────────┤
  │ POST   │ /health/contracts/snap │ Manual capture for                     │
  │        │ shots                  │ admin/release-review workflows         │
  └────────┴────────────────────────┴────────────────────────────────────────┘
  
  Diff response highlights
  
  - overallStatusChange — improved / degraded / unchanged
  - summaryDelta — numeric deltas for reachable, misconfigured, unreachable
  - contractStatusChanges — per-contract top-level status transitions
  - readMethodChanges — per-method status transitions
  - noDrift: true when nothing changed
  
  Module wiring
  
  - ContractHealthService is now exported from HealthModule
  - ContractHealthSnapshotModule registered in AppModule
  
  Tests
  
  22 unit tests covering all service methods including diff edge cases (no drift,
  status regression, read-method change, explicit id pair, insufficient history).
  All pass.
  
  How to review
  
  1. Run the migration: pnpm run migration:run
  2. Start the server — the 30-min cron will begin capturing automatically
  3. Trigger a manual snapshot: POST /health/contracts/snapshots
  4. Fetch the diff: GET /health/contracts/snapshots/diff

close #1037 