### PR TITLE
feat(price-alert): Backend price alert rule evaluation and dispatch orchestration

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -63,6 +63,7 @@ import { TreasuryModule } from './treasury/treasury.module';
 import { VestingWalletModule } from './vesting-wallet/vesting-wallet.module';
 import { ContractsModule } from './contracts/contracts.module';
 import { ContractAdminModule } from './contract-admin/contract-admin.module';
+import { PriceAlertModule } from './price-alert/price-alert.module';
 
 @Module({
   imports: [
@@ -135,6 +136,7 @@ import { ContractAdminModule } from './contract-admin/contract-admin.module';
     VestingWalletModule,
     ContractsModule,
     ContractAdminModule,
+    PriceAlertModule,
   ],
   controllers: [AppController, TestController, TestExceptionController],
   providers: [

--- a/apps/backend/src/database/migrations/1810000000000-CreatePriceAlertRules.ts
+++ b/apps/backend/src/database/migrations/1810000000000-CreatePriceAlertRules.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreatePriceAlertRules1810000000000 implements MigrationInterface {
+  name = 'CreatePriceAlertRules1810000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "price_alert_condition_enum" AS ENUM ('above', 'below')`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "price_alert_rules" (
+        "id"               uuid                            NOT NULL DEFAULT uuid_generate_v4(),
+        "userId"           uuid                            NOT NULL,
+        "symbol"           character varying(50)           NOT NULL,
+        "targetPrice"      numeric(20,8)                   NOT NULL,
+        "condition"        "price_alert_condition_enum"    NOT NULL DEFAULT 'above',
+        "isActive"         boolean                         NOT NULL DEFAULT true,
+        "cooldownMinutes"  integer                         NOT NULL DEFAULT 60,
+        "lastTriggeredAt"  TIMESTAMP WITH TIME ZONE,
+        "createdAt"        TIMESTAMP WITH TIME ZONE        NOT NULL DEFAULT now(),
+        "updatedAt"        TIMESTAMP WITH TIME ZONE        NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_price_alert_rules" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_price_alert_rules_user_symbol" ON "price_alert_rules" ("userId", "symbol")`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_price_alert_rules_is_active" ON "price_alert_rules" ("isActive")`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_price_alert_rules_symbol_active" ON "price_alert_rules" ("symbol", "isActive")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_price_alert_rules_symbol_active"`);
+    await queryRunner.query(`DROP INDEX "IDX_price_alert_rules_is_active"`);
+    await queryRunner.query(`DROP INDEX "IDX_price_alert_rules_user_symbol"`);
+    await queryRunner.query(`DROP TABLE "price_alert_rules"`);
+    await queryRunner.query(`DROP TYPE "price_alert_condition_enum"`);
+  }
+}

--- a/apps/backend/src/database/migrations/1810000000001-CreatePriceAlertEvaluationLogs.ts
+++ b/apps/backend/src/database/migrations/1810000000001-CreatePriceAlertEvaluationLogs.ts
@@ -1,0 +1,42 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreatePriceAlertEvaluationLogs1810000000001
+  implements MigrationInterface
+{
+  name = 'CreatePriceAlertEvaluationLogs1810000000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "price_alert_evaluation_logs" (
+        "id"               uuid                            NOT NULL DEFAULT uuid_generate_v4(),
+        "ruleId"           uuid                            NOT NULL,
+        "userId"           uuid                            NOT NULL,
+        "symbol"           character varying(50)           NOT NULL,
+        "currentPrice"     numeric(20,8)                   NOT NULL,
+        "targetPrice"      numeric(20,8)                   NOT NULL,
+        "condition"        "price_alert_condition_enum"    NOT NULL,
+        "triggered"        boolean                         NOT NULL DEFAULT false,
+        "suppressedReason" character varying(100),
+        "notificationId"   uuid,
+        "evaluatedAt"      TIMESTAMP WITH TIME ZONE        NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_price_alert_evaluation_logs" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_price_alert_eval_logs_rule_evaluated" ON "price_alert_evaluation_logs" ("ruleId", "evaluatedAt" DESC)`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_price_alert_eval_logs_triggered" ON "price_alert_evaluation_logs" ("triggered")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_price_alert_eval_logs_triggered"`);
+    await queryRunner.query(
+      `DROP INDEX "IDX_price_alert_eval_logs_rule_evaluated"`,
+    );
+    await queryRunner.query(`DROP TABLE "price_alert_evaluation_logs"`);
+  }
+}

--- a/apps/backend/src/price-alert/dto/create-price-alert-rule.dto.ts
+++ b/apps/backend/src/price-alert/dto/create-price-alert-rule.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsInt,
+  Min,
+  MaxLength,
+  Min as MinValidator,
+} from 'class-validator';
+import { PriceAlertCondition } from '../entities/price-alert-rule.entity';
+
+export class CreatePriceAlertRuleDto {
+  @ApiProperty({
+    description: 'Asset symbol to monitor (e.g. XLM, USDC)',
+    example: 'XLM',
+  })
+  @IsString()
+  @MaxLength(50)
+  symbol: string;
+
+  @ApiProperty({
+    description: 'Target price that triggers the alert',
+    example: 0.15,
+  })
+  @IsNumber()
+  @MinValidator(0)
+  targetPrice: number;
+
+  @ApiProperty({
+    description: 'Condition that triggers the alert',
+    enum: PriceAlertCondition,
+    example: PriceAlertCondition.ABOVE,
+  })
+  @IsEnum(PriceAlertCondition)
+  condition: PriceAlertCondition;
+
+  @ApiPropertyOptional({
+    description: 'Minimum minutes between repeated firings (default 60)',
+    example: 60,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  cooldownMinutes?: number;
+}

--- a/apps/backend/src/price-alert/dto/update-price-alert-rule.dto.ts
+++ b/apps/backend/src/price-alert/dto/update-price-alert-rule.dto.ts
@@ -1,0 +1,47 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsInt,
+  IsBoolean,
+  Min,
+  Min as MinValidator,
+} from 'class-validator';
+import { PriceAlertCondition } from '../entities/price-alert-rule.entity';
+
+export class UpdatePriceAlertRuleDto {
+  @ApiPropertyOptional({
+    description: 'Updated target price',
+    example: 0.2,
+  })
+  @IsOptional()
+  @IsNumber()
+  @MinValidator(0)
+  targetPrice?: number;
+
+  @ApiPropertyOptional({
+    description: 'Updated trigger condition',
+    enum: PriceAlertCondition,
+  })
+  @IsOptional()
+  @IsEnum(PriceAlertCondition)
+  condition?: PriceAlertCondition;
+
+  @ApiPropertyOptional({
+    description: 'Enable or disable the alert rule',
+    example: true,
+  })
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Updated cooldown in minutes between firings',
+    example: 120,
+  })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  cooldownMinutes?: number;
+}

--- a/apps/backend/src/price-alert/entities/price-alert-evaluation-log.entity.ts
+++ b/apps/backend/src/price-alert/entities/price-alert-evaluation-log.entity.ts
@@ -1,0 +1,55 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { PriceAlertRule, PriceAlertCondition } from './price-alert-rule.entity';
+
+@Entity('price_alert_evaluation_logs')
+@Index(['ruleId', 'evaluatedAt'])
+@Index(['triggered'])
+export class PriceAlertEvaluationLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  ruleId: string;
+
+  @ManyToOne(() => PriceAlertRule, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'ruleId' })
+  rule: PriceAlertRule;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @Column({ type: 'varchar', length: 50 })
+  symbol: string;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8 })
+  currentPrice: number;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8 })
+  targetPrice: number;
+
+  @Column({
+    type: 'enum',
+    enum: PriceAlertCondition,
+  })
+  condition: PriceAlertCondition;
+
+  @Column({ type: 'boolean' })
+  triggered: boolean;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  suppressedReason: string | null;
+
+  @Column({ type: 'uuid', nullable: true })
+  notificationId: string | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  evaluatedAt: Date;
+}

--- a/apps/backend/src/price-alert/entities/price-alert-rule.entity.ts
+++ b/apps/backend/src/price-alert/entities/price-alert-rule.entity.ts
@@ -1,0 +1,60 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+export enum PriceAlertCondition {
+  ABOVE = 'above',
+  BELOW = 'below',
+}
+
+@Entity('price_alert_rules')
+@Index(['userId', 'symbol'])
+@Index(['isActive'])
+@Index(['symbol', 'isActive'])
+export class PriceAlertRule {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({ type: 'varchar', length: 50 })
+  symbol: string;
+
+  @Column({ type: 'decimal', precision: 20, scale: 8 })
+  targetPrice: number;
+
+  @Column({
+    type: 'enum',
+    enum: PriceAlertCondition,
+    default: PriceAlertCondition.ABOVE,
+  })
+  condition: PriceAlertCondition;
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
+
+  @Column({ type: 'int', default: 60 })
+  cooldownMinutes: number;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  lastTriggeredAt: Date | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+}

--- a/apps/backend/src/price-alert/price-alert-evaluation.service.ts
+++ b/apps/backend/src/price-alert/price-alert-evaluation.service.ts
@@ -1,0 +1,225 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  PriceAlertRule,
+  PriceAlertCondition,
+} from './entities/price-alert-rule.entity';
+import { PriceAlertEvaluationLog } from './entities/price-alert-evaluation-log.entity';
+import { PriceService } from '../price/price.service';
+import { NotificationFanoutService } from '../notification/notification-fanout.service';
+import { JobLockService } from '../scheduler/job-lock.service';
+import { JobHistoryService } from '../scheduler/job-history.service';
+import {
+  NotificationType,
+  NotificationSeverity,
+} from '../notification/notification.entity';
+import { EventCategory } from '../common/event-catalog';
+
+const JOB_NAME = 'price-alert-evaluation';
+
+@Injectable()
+export class PriceAlertEvaluationService {
+  private readonly logger = new Logger(PriceAlertEvaluationService.name);
+
+  constructor(
+    @InjectRepository(PriceAlertRule)
+    private readonly ruleRepository: Repository<PriceAlertRule>,
+    @InjectRepository(PriceAlertEvaluationLog)
+    private readonly evaluationLogRepository: Repository<PriceAlertEvaluationLog>,
+    private readonly priceService: PriceService,
+    private readonly fanoutService: NotificationFanoutService,
+    private readonly jobLockService: JobLockService,
+    private readonly jobHistoryService: JobHistoryService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async evaluateAlertRules(): Promise<void> {
+    const run = await this.jobHistoryService.start(JOB_NAME);
+
+    try {
+      const result = await this.jobLockService.withLock(JOB_NAME, () =>
+        this.doEvaluate(),
+      );
+
+      if (result === null) {
+        await this.jobHistoryService.markSkipped(JOB_NAME);
+        return;
+      }
+
+      await this.jobHistoryService.complete(run, result);
+    } catch (error) {
+      await this.jobHistoryService.fail(run, error);
+      this.logger.error(
+        `Price alert evaluation failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  }
+
+  private async doEvaluate(): Promise<Record<string, unknown>> {
+    const activeRules = await this.ruleRepository.find({
+      where: { isActive: true },
+    });
+
+    if (activeRules.length === 0) {
+      return { evaluated: 0, triggered: 0, suppressed: 0 };
+    }
+
+    this.logger.log(
+      `Evaluating ${activeRules.length} active price alert rules`,
+    );
+
+    const uniqueSymbols = [...new Set(activeRules.map((r) => r.symbol))];
+    const priceCache = new Map<string, number>();
+
+    for (const symbol of uniqueSymbols) {
+      try {
+        const price = await this.priceService.getCurrentPrice(symbol);
+        priceCache.set(symbol, price);
+      } catch (error) {
+        this.logger.warn(
+          `Failed to fetch price for ${symbol}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        );
+      }
+    }
+
+    let triggered = 0;
+    let suppressed = 0;
+
+    for (const rule of activeRules) {
+      const currentPrice = priceCache.get(rule.symbol);
+
+      if (currentPrice === undefined) {
+        await this.logEvaluation(rule, 0, false, 'price_unavailable');
+        suppressed++;
+        continue;
+      }
+
+      const conditionMet = this.isConditionMet(
+        rule.condition,
+        currentPrice,
+        rule.targetPrice,
+      );
+
+      if (!conditionMet) {
+        await this.logEvaluation(rule, currentPrice, false, null);
+        continue;
+      }
+
+      if (!this.isCooldownExpired(rule)) {
+        await this.logEvaluation(rule, currentPrice, false, 'cooldown_active');
+        suppressed++;
+        continue;
+      }
+
+      try {
+        const notificationResult = await this.fanoutService.fanout({
+          notification: {
+            type: NotificationType.PRICE,
+            title: `Price Alert: ${rule.symbol}`,
+            message: `${rule.symbol} has ${rule.condition === PriceAlertCondition.ABOVE ? 'risen above' : 'fallen below'} ${rule.targetPrice}. Current price: ${currentPrice}.`,
+            severity: NotificationSeverity.MEDIUM,
+            eventCategory: EventCategory.PRICE,
+            metadata: {
+              ruleId: rule.id,
+              symbol: rule.symbol,
+              targetPrice: rule.targetPrice,
+              currentPrice,
+              condition: rule.condition,
+            },
+          },
+          targetUserIds: [rule.userId],
+          symbols: [rule.symbol],
+        });
+
+        await this.ruleRepository.update(rule.id, {
+          lastTriggeredAt: new Date(),
+        });
+
+        await this.logEvaluation(
+          rule,
+          currentPrice,
+          true,
+          null,
+          notificationResult.notificationIds[0] ?? null,
+        );
+
+        triggered++;
+      } catch (error) {
+        this.logger.error(
+          `Failed to dispatch notification for rule ${rule.id}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        );
+        await this.logEvaluation(
+          rule,
+          currentPrice,
+          false,
+          'notification_failed',
+        );
+        suppressed++;
+      }
+    }
+
+    this.logger.log(
+      `Price alert evaluation complete: ${triggered} triggered, ${suppressed} suppressed out of ${activeRules.length}`,
+    );
+
+    return {
+      evaluated: activeRules.length,
+      triggered,
+      suppressed,
+    };
+  }
+
+  private isConditionMet(
+    condition: PriceAlertCondition,
+    currentPrice: number,
+    targetPrice: number,
+  ): boolean {
+    switch (condition) {
+      case PriceAlertCondition.ABOVE:
+        return currentPrice >= targetPrice;
+      case PriceAlertCondition.BELOW:
+        return currentPrice <= targetPrice;
+      default:
+        return false;
+    }
+  }
+
+  private isCooldownExpired(rule: PriceAlertRule): boolean {
+    if (!rule.lastTriggeredAt) return true;
+
+    const now = new Date();
+    const cooldownMs = rule.cooldownMinutes * 60 * 1000;
+    const elapsed = now.getTime() - rule.lastTriggeredAt.getTime();
+
+    return elapsed >= cooldownMs;
+  }
+
+  private async logEvaluation(
+    rule: PriceAlertRule,
+    currentPrice: number,
+    triggered: boolean,
+    suppressedReason: string | null,
+    notificationId?: string | null,
+  ): Promise<void> {
+    try {
+      const log = this.evaluationLogRepository.create({
+        ruleId: rule.id,
+        userId: rule.userId,
+        symbol: rule.symbol,
+        currentPrice,
+        targetPrice: rule.targetPrice,
+        condition: rule.condition,
+        triggered,
+        suppressedReason,
+        notificationId: notificationId ?? null,
+      });
+      await this.evaluationLogRepository.save(log);
+    } catch (error) {
+      this.logger.error(
+        `Failed to log evaluation for rule ${rule.id}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+    }
+  }
+}

--- a/apps/backend/src/price-alert/price-alert-rule.controller.ts
+++ b/apps/backend/src/price-alert/price-alert-rule.controller.ts
@@ -1,0 +1,129 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiResponse,
+} from '@nestjs/swagger';
+import { PriceAlertRuleService } from './price-alert-rule.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { CreatePriceAlertRuleDto } from './dto/create-price-alert-rule.dto';
+import { UpdatePriceAlertRuleDto } from './dto/update-price-alert-rule.dto';
+import { PriceAlertRule } from './entities/price-alert-rule.entity';
+
+@ApiTags('price-alerts')
+@ApiBearerAuth('JWT-auth')
+@Controller('price-alerts')
+@UseGuards(JwtAuthGuard)
+export class PriceAlertRuleController {
+  constructor(private readonly ruleService: PriceAlertRuleService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Get all price alert rules',
+    description: 'Returns all price alert rules for the authenticated user',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of price alert rules',
+    type: [PriceAlertRule],
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async findAll(@Request() req: any): Promise<PriceAlertRule[]> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const userId = req.user.sub as string;
+    return this.ruleService.findAllForUser(userId);
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Get a price alert rule by ID',
+    description:
+      'Returns a single price alert rule owned by the authenticated user',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Price alert rule',
+    type: PriceAlertRule,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Rule not found' })
+  async findOne(
+    @Request() req: any,
+    @Param('id') id: string,
+  ): Promise<PriceAlertRule> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const userId = req.user.sub as string;
+    return this.ruleService.findOneForUser(userId, id);
+  }
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary: 'Create a price alert rule',
+    description: 'Create a new price alert rule for the authenticated user',
+  })
+  @ApiResponse({
+    status: 201,
+    description: 'Price alert rule created',
+    type: PriceAlertRule,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async create(
+    @Request() req: any,
+    @Body() dto: CreatePriceAlertRuleDto,
+  ): Promise<PriceAlertRule> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const userId = req.user.sub as string;
+    return this.ruleService.create(userId, dto);
+  }
+
+  @Patch(':id')
+  @ApiOperation({
+    summary: 'Update a price alert rule',
+    description: 'Update an existing price alert rule',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Price alert rule updated',
+    type: PriceAlertRule,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Rule not found' })
+  async update(
+    @Request() req: any,
+    @Param('id') id: string,
+    @Body() dto: UpdatePriceAlertRuleDto,
+  ): Promise<PriceAlertRule> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const userId = req.user.sub as string;
+    return this.ruleService.update(userId, id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary: 'Delete a price alert rule',
+    description: 'Remove a price alert rule',
+  })
+  @ApiResponse({ status: 204, description: 'Rule deleted' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Rule not found' })
+  async remove(@Request() req: any, @Param('id') id: string): Promise<void> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const userId = req.user.sub as string;
+    return this.ruleService.remove(userId, id);
+  }
+}

--- a/apps/backend/src/price-alert/price-alert-rule.service.ts
+++ b/apps/backend/src/price-alert/price-alert-rule.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PriceAlertRule } from './entities/price-alert-rule.entity';
+import { CreatePriceAlertRuleDto } from './dto/create-price-alert-rule.dto';
+import { UpdatePriceAlertRuleDto } from './dto/update-price-alert-rule.dto';
+
+@Injectable()
+export class PriceAlertRuleService {
+  private readonly logger = new Logger(PriceAlertRuleService.name);
+
+  constructor(
+    @InjectRepository(PriceAlertRule)
+    private readonly ruleRepository: Repository<PriceAlertRule>,
+  ) {}
+
+  async create(
+    userId: string,
+    dto: CreatePriceAlertRuleDto,
+  ): Promise<PriceAlertRule> {
+    this.logger.log(
+      `Creating price alert for ${dto.symbol} ${dto.condition} ${dto.targetPrice} for user ${userId}`,
+    );
+
+    const rule = this.ruleRepository.create({
+      userId,
+      symbol: dto.symbol.toUpperCase(),
+      targetPrice: dto.targetPrice,
+      condition: dto.condition,
+      cooldownMinutes: dto.cooldownMinutes ?? 60,
+      isActive: true,
+    });
+
+    return this.ruleRepository.save(rule);
+  }
+
+  async findAllForUser(userId: string): Promise<PriceAlertRule[]> {
+    return this.ruleRepository.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findOneForUser(
+    userId: string,
+    ruleId: string,
+  ): Promise<PriceAlertRule> {
+    const rule = await this.ruleRepository.findOne({
+      where: { id: ruleId, userId },
+    });
+
+    if (!rule) {
+      throw new NotFoundException(`Price alert rule ${ruleId} not found`);
+    }
+
+    return rule;
+  }
+
+  async update(
+    userId: string,
+    ruleId: string,
+    dto: UpdatePriceAlertRuleDto,
+  ): Promise<PriceAlertRule> {
+    const rule = await this.findOneForUser(userId, ruleId);
+
+    if (dto.targetPrice !== undefined) rule.targetPrice = dto.targetPrice;
+    if (dto.condition !== undefined) rule.condition = dto.condition;
+    if (dto.isActive !== undefined) rule.isActive = dto.isActive;
+    if (dto.cooldownMinutes !== undefined) {
+      rule.cooldownMinutes = dto.cooldownMinutes;
+    }
+
+    this.logger.log(`Updating price alert rule ${ruleId} for user ${userId}`);
+
+    return this.ruleRepository.save(rule);
+  }
+
+  async remove(userId: string, ruleId: string): Promise<void> {
+    const rule = await this.findOneForUser(userId, ruleId);
+
+    this.logger.log(`Removing price alert rule ${ruleId} for user ${userId}`);
+
+    await this.ruleRepository.remove(rule);
+  }
+
+  async findAllActive(): Promise<PriceAlertRule[]> {
+    return this.ruleRepository.find({
+      where: { isActive: true },
+    });
+  }
+
+  async updateLastTriggered(ruleId: string): Promise<void> {
+    await this.ruleRepository.update(ruleId, {
+      lastTriggeredAt: new Date(),
+    });
+  }
+}

--- a/apps/backend/src/price-alert/price-alert.module.ts
+++ b/apps/backend/src/price-alert/price-alert.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PriceAlertRule } from './entities/price-alert-rule.entity';
+import { PriceAlertEvaluationLog } from './entities/price-alert-evaluation-log.entity';
+import { PriceAlertRuleService } from './price-alert-rule.service';
+import { PriceAlertEvaluationService } from './price-alert-evaluation.service';
+import { PriceAlertRuleController } from './price-alert-rule.controller';
+import { PriceModule } from '../price/price.module';
+import { NotificationModule } from '../notification/notification.module';
+import { SchedulerModule } from '../scheduler/scheduler.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([PriceAlertRule, PriceAlertEvaluationLog]),
+    PriceModule,
+    NotificationModule,
+    SchedulerModule,
+  ],
+  controllers: [PriceAlertRuleController],
+  providers: [PriceAlertRuleService, PriceAlertEvaluationService],
+  exports: [PriceAlertRuleService, PriceAlertEvaluationService],
+})
+export class PriceAlertModule {}


### PR DESCRIPTION
## Summary
This PR implements the backend orchestration for evaluating stored price-alert rules and dispatching notifications when conditions are met.

Closes #1034

## What's Included

### New Entity: \PriceAlertRule\
- \symbol\ — asset to monitor (e.g., XLM)
- \	argetPrice\ — threshold that triggers the alert
- \condition\ — \bove\ or \elow\
- \cooldownMinutes\ — minimum time between repeated firings (default 60)
- \lastTriggeredAt\ — tracks last fire time for duplicate control
- \isActive\ — toggle without deleting

### New Entity: \PriceAlertEvaluationLog\
- Per-rule audit trail recording every evaluation cycle
- Captures: current price, target price, condition, triggered status, suppression reason, linked notification ID

### Scheduled Evaluation Service (\PriceAlertEvaluationService\)
- Runs every 60 seconds via \@Cron(CronExpression.EVERY_MINUTE)\
- Uses \JobLockService\ (PostgreSQL advisory locks) for distributed locking across instances
- Uses \JobHistoryService\ for operational run logging (RUNNING → COMPLETED/FAILED/SKIPPED)
- Groups rules by symbol, fetches each price once via \PriceService.getCurrentPrice()\
- Evaluates conditions and checks cooldown before firing
- Dispatches notifications via \NotificationFanoutService\, which respects user preferences (quiet hours, severity thresholds, daily limits, disabled categories)
- Logs every evaluation attempt to \PriceAlertEvaluationLog\

### REST API (\PriceAlertRuleController\)
All endpoints are JWT-authenticated and scoped to the authenticated user:
- \GET /price-alerts\ — list all rules
- \GET /price-alerts/:id\ — get a specific rule
- \POST /price-alerts\ — create a new rule
- \PATCH /price-alerts/:id\ — update a rule
- \DELETE /price-alerts/:id\ — delete a rule

### Migrations
- \1810000000000-CreatePriceAlertRules\ — creates \price_alert_rules\ table with indexes
- \1810000000001-CreatePriceAlertEvaluationLogs\ — creates \price_alert_evaluation_logs\ table with indexes

## Acceptance Criteria
- [x] Alert rules can be evaluated on a schedule or trigger
- [x] Triggered alerts feed into notification delivery workflows
- [x] Duplicate or repeated firing behavior is controlled explicitly (cooldown mechanism)
- [x] Operational logs make alert evaluation debuggable (JobRun + PriceAlertEvaluationLog)

## CI Verification
- Lint: passed (zero new errors)
- Build: passed (\
est build\ succeeds)
- No new dependencies added
- No existing tests broken