### PR TITLE
Add round lifecycle invariant test suite for vault and matching pool

### DIFF
--- a/apps/onchain/Cargo.lock
+++ b/apps/onchain/Cargo.lock
@@ -999,6 +999,7 @@ dependencies = [
 name = "matching_pool"
 version = "0.0.0"
 dependencies = [
+ "proptest",
  "reentrancy-guard",
  "soroban-sdk",
 ]

--- a/apps/onchain/contracts/ROUND_LIFECYCLE_INVARIANTS.md
+++ b/apps/onchain/contracts/ROUND_LIFECYCLE_INVARIANTS.md
@@ -1,0 +1,85 @@
+# Round Lifecycle Invariants — `crowdfund_vault` & `matching_pool`
+
+This document is the single source of truth for the state-machine and
+funds-conservation invariants that the round/project lifecycle test suites
+enforce in:
+
+- `crowdfund_vault/src/tests/round_lifecycle.rs`
+- `matching_pool/src/tests/invariants.rs`
+
+Both contracts implement a distinct concrete state machine, but they follow
+the same shape — **open → contribute → finalize → refund/close** — and are
+expected to uphold the same class of invariants. Keeping the description
+here (rather than duplicated per-file) means a contributor only has to
+learn the vocabulary once, and a fix to one contract's suite can be checked
+against the same list for the other.
+
+## Lifecycle mapping
+
+| Phase        | `crowdfund_vault` (per project)                          | `matching_pool` (per round)              |
+|--------------|-----------------------------------------------------------|-------------------------------------------|
+| open         | `create_project`                                           | `create_round`                             |
+| contribute   | `deposit`                                                   | `record_contribution` (+ `fund_pool`)      |
+| finalize     | `approve_milestone` → `withdraw`                            | `finalize_round`                           |
+| close-style  | `distribute_match` (quadratic match payout)                 | `distribute_matching_funds` (QF payout)    |
+| refund       | `cancel_project` → `refund_contributors` / `clawback_contribution` | *(no direct equivalent; a round that never finalizes has no payout path)* |
+
+## Shared invariants
+
+Each invariant below is tagged `INV-<n>` and referenced by that tag in the
+test code and test names so a failing test can be traced back to exactly
+one rule.
+
+1. **INV-1 State-machine monotonicity.** A round/project only moves forward
+   through its states (`ACTIVE → FINALIZED → DISTRIBUTED` for a round;
+   `ACTIVE → CANCELED/EXPIRED` for a project). No operation may move state
+   backward, and no operation may re-enter a state it already left
+   (e.g. `finalize_round` twice, `distribute_matching_funds` twice,
+   `refund_contributors` after the contributor list has been drained).
+
+2. **INV-2 Contribution window enforcement.** Contributions
+   (`deposit` / `record_contribution`) must only succeed while the
+   round/project is open: before `finalize_round`/`cancel_project`, and —
+   for rounds — only inside `[start_time, end_time]`.
+
+3. **INV-3 Conservation of funds.** Tokens are never created or destroyed by
+   the contracts. At every step, `pool_or_project_balance_after ==
+   pool_or_project_balance_before ± amount_moved`. Distribution never pays
+   out more than was held (`distributed <= pool_before`,
+   `sum(match payouts) <= matching pool balance`).
+
+4. **INV-4 No double payout.** A given unit of value is claimable/payable
+   exactly once: `refund_contributors`/`clawback_contribution` cannot pay a
+   contributor twice, and `distribute_matching_funds` cannot distribute the
+   same round's pool twice (`MatchAlreadyDistributed` / pool zeroed after
+   distribution).
+
+5. **INV-5 Authorization.** State-changing admin operations
+   (`create_round`, `finalize_round`, `distribute_matching_funds`,
+   `approve_milestone`, `fund_matching_pool`, `pause`) reject non-admin
+   callers with the contract's `Unauthorized` error and never mutate state
+   on rejection.
+
+6. **INV-6 Pause halts state transitions.** While a contract is paused, no
+   operation that would move a round/project through the lifecycle may
+   succeed (deposits, contributions, round creation, finalization).
+
+7. **INV-7 Non-existent target is rejected, not silently defaulted.**
+   Operating on a round/project id that was never created returns
+   `RoundNotFound` / `ProjectNotFound`; it must never be treated as valid
+   with zeroed defaults.
+
+## Debugging a failing invariant
+
+- Tests use `proptest`; on failure it prints the *minimal* shrunk input in
+  the panic message plus a `proptest-regressions/<file>.txt` entry. Re-run
+  the single test (`cargo test <test_name>`) — the regression file pins the
+  same input deterministically.
+- Every `prop_assert!`/`prop_assert_eq!` in these suites carries a message
+  naming the `INV-<n>` it checks and the concrete before/after values, so
+  the panic output alone should identify which rule broke and with what
+  numbers, without needing to step through the test in a debugger.
+- Each test module is named after the phase it stresses
+  (`open_phase`, `contribute_phase`, `finalize_phase`, `refund_phase`,
+  `close_phase`) so a failing module name narrows down which lifecycle
+  transition regressed.

--- a/apps/onchain/contracts/crowdfund_vault/src/tests/mod.rs
+++ b/apps/onchain/contracts/crowdfund_vault/src/tests/mod.rs
@@ -1,1 +1,2 @@
 pub mod invariants;
+pub mod round_lifecycle;

--- a/apps/onchain/contracts/crowdfund_vault/src/tests/round_lifecycle.rs
+++ b/apps/onchain/contracts/crowdfund_vault/src/tests/round_lifecycle.rs
@@ -1,0 +1,415 @@
+//! Round-lifecycle invariant suite for `crowdfund_vault`.
+//!
+//! Covers the open → contribute → finalize → refund/close flow for a
+//! project (`create_project` → `deposit` → `approve_milestone`/`withdraw`
+//! → `cancel_project` → `refund_contributors`/`clawback_contribution`).
+//! The invariants asserted here (`INV-1` .. `INV-7`) are the ones
+//! documented in `apps/onchain/contracts/ROUND_LIFECYCLE_INVARIANTS.md`,
+//! which also explains the shared vocabulary this suite uses with the
+//! equivalent `matching_pool` suite
+//! (`matching_pool/src/tests/invariants.rs`).
+//!
+//! `prop4`..`prop12` in `tests::invariants` already cover TVL tracking,
+//! admin-only ops, pause behavior, and quadratic matching; this module
+//! focuses on the parts of the lifecycle those don't reach: cancellation,
+//! refunds, and clawback.
+
+extern crate std;
+
+use crate::errors::CrowdfundError;
+use crate::tests::invariants::{deposit_sequence, do_deposit, setup_vault, valid_amount};
+use proptest::prelude::*;
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    Address, Env,
+};
+
+const REFUND_WINDOW_SECONDS: u64 = 14 * 24 * 60 * 60;
+
+// ─── open + contribute phase (INV-1, INV-2, INV-5) ───────────────────────────
+
+#[cfg(test)]
+mod contribute_phase {
+    use super::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        // INV-2: deposits are rejected once a project has been canceled.
+        #[test]
+        fn deposit_rejected_after_cancel(amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (client, admin, token_client, token_admin) = setup_vault(&env);
+            let owner = Address::generate(&env);
+            let user = Address::generate(&env);
+
+            let project_id = client.create_project(
+                &owner,
+                &symbol_short!("proj"),
+                &1_000_000_000_000i128,
+                &token_client.address,
+            );
+
+            client.cancel_project(&owner, &project_id);
+
+            token_admin.mint(&user, &amount);
+            let result = client.try_deposit(&user, &project_id, &amount);
+            prop_assert_eq!(
+                result,
+                Err(Ok(CrowdfundError::ProjectNotActive)),
+                "INV-2: deposit must be rejected once the project is canceled"
+            );
+
+            let _ = admin;
+        }
+
+        // INV-5: only the admin or the project owner may cancel.
+        #[test]
+        fn cancel_rejects_non_owner_non_admin(_seed in 0u64..u64::MAX) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (client, _admin, token_client, _token_admin) = setup_vault(&env);
+            let owner = Address::generate(&env);
+            let intruder = Address::generate(&env);
+
+            let project_id = client.create_project(
+                &owner,
+                &symbol_short!("proj"),
+                &1_000_000_000_000i128,
+                &token_client.address,
+            );
+
+            let result = client.try_cancel_project(&intruder, &project_id);
+            prop_assert_eq!(
+                result,
+                Err(Ok(CrowdfundError::Unauthorized)),
+                "INV-5: only admin or owner may cancel a project"
+            );
+        }
+
+        // INV-1/INV-4: a project cannot be canceled twice.
+        #[test]
+        fn cancel_twice_rejected(_seed in 0u64..u64::MAX) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (client, _admin, token_client, _token_admin) = setup_vault(&env);
+            let owner = Address::generate(&env);
+
+            let project_id = client.create_project(
+                &owner,
+                &symbol_short!("proj"),
+                &1_000_000_000_000i128,
+                &token_client.address,
+            );
+
+            client.cancel_project(&owner, &project_id);
+            let result = client.try_cancel_project(&owner, &project_id);
+            prop_assert_eq!(
+                result,
+                Err(Ok(CrowdfundError::ProjectNotActive)),
+                "INV-1/INV-4: cancel_project must not succeed a second time"
+            );
+        }
+    }
+}
+
+// ─── finalize phase (INV-2) ───────────────────────────────────────────────────
+
+#[cfg(test)]
+mod finalize_phase {
+    use super::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        // INV-2: a canceled project cannot be withdrawn from even with an
+        // already-approved milestone.
+        #[test]
+        fn withdraw_rejected_after_cancel(amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (client, admin, token_client, token_admin) = setup_vault(&env);
+            let owner = Address::generate(&env);
+            let user = Address::generate(&env);
+
+            let project_id = client.create_project(
+                &owner,
+                &symbol_short!("proj"),
+                &1_000_000_000_000i128,
+                &token_client.address,
+            );
+            do_deposit(&env, &client, &token_admin, &user, project_id, amount);
+            client.approve_milestone(&admin, &project_id, &0u32);
+
+            client.cancel_project(&owner, &project_id);
+
+            let result = client.try_withdraw(&project_id, &0u32, &1i128);
+            prop_assert_eq!(
+                result,
+                Err(Ok(CrowdfundError::ProjectNotActive)),
+                "INV-2: withdraw must be rejected once the project is canceled, \
+                 even with an approved milestone"
+            );
+        }
+    }
+}
+
+// ─── refund phase (INV-1, INV-2, INV-3, INV-4) ───────────────────────────────
+
+#[cfg(test)]
+mod refund_phase {
+    use super::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        // INV-1: refund_contributors requires the project to be canceled (or
+        // expired) first — it cannot run against a still-active project.
+        #[test]
+        fn refund_rejected_before_cancel(amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (client, _admin, token_client, token_admin) = setup_vault(&env);
+            let owner = Address::generate(&env);
+            let user = Address::generate(&env);
+
+            let project_id = client.create_project(
+                &owner,
+                &symbol_short!("proj"),
+                &1_000_000_000_000i128,
+                &token_client.address,
+            );
+            do_deposit(&env, &client, &token_admin, &user, project_id, amount);
+
+            let result = client.try_refund_contributors(&project_id, &owner);
+            prop_assert_eq!(
+                result,
+                Err(Ok(CrowdfundError::ProjectNotCancellable)),
+                "INV-1: refund_contributors must require cancellation/expiry first"
+            );
+        }
+
+        // INV-3: refund_contributors pays back exactly what was deposited and
+        // drains the tracked project balance to zero.
+        #[test]
+        fn refund_pays_back_deposits_exactly(amounts in deposit_sequence()) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (client, _admin, token_client, token_admin) = setup_vault(&env);
+            let owner = Address::generate(&env);
+            let user = Address::generate(&env);
+
+            let project_id = client.create_project(
+                &owner,
+                &symbol_short!("proj"),
+                &1_000_000_000_000i128,
+                &token_client.address,
+            );
+
+            let mut expected_total: i128 = 0;
+            for amount in &amounts {
+                do_deposit(&env, &client, &token_admin, &user, project_id, *amount);
+                expected_total += amount;
+            }
+
+            let balance_before_cancel = client.get_balance(&project_id);
+            prop_assert_eq!(
+                balance_before_cancel,
+                expected_total,
+                "sanity check: pre-cancel balance must equal total deposited"
+            );
+
+            client.cancel_project(&owner, &project_id);
+            let user_balance_before_refund = token_client.balance(&user);
+
+            client.refund_contributors(&project_id, &owner);
+
+            prop_assert_eq!(
+                token_client.balance(&user),
+                user_balance_before_refund + expected_total,
+                "INV-3: refund must return exactly the total amount deposited"
+            );
+            prop_assert_eq!(
+                client.get_balance(&project_id),
+                0i128,
+                "INV-3: project balance must be fully drained after refund"
+            );
+        }
+
+        // INV-1/INV-4: refund_contributors cannot pay out a second time.
+        #[test]
+        fn refund_twice_rejected(amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (client, _admin, token_client, token_admin) = setup_vault(&env);
+            let owner = Address::generate(&env);
+            let user = Address::generate(&env);
+
+            let project_id = client.create_project(
+                &owner,
+                &symbol_short!("proj"),
+                &1_000_000_000_000i128,
+                &token_client.address,
+            );
+            do_deposit(&env, &client, &token_admin, &user, project_id, amount);
+            client.cancel_project(&owner, &project_id);
+            client.refund_contributors(&project_id, &owner);
+
+            let result = client.try_refund_contributors(&project_id, &owner);
+            prop_assert!(
+                result.is_err(),
+                "INV-1/INV-4: refund_contributors must not succeed a second time \
+                 (got {:?})",
+                result
+            );
+        }
+
+        // INV-2: clawback is only available once a project is canceled/expired.
+        #[test]
+        fn clawback_rejected_before_cancel(amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (client, _admin, token_client, token_admin) = setup_vault(&env);
+            let owner = Address::generate(&env);
+            let user = Address::generate(&env);
+
+            let project_id = client.create_project(
+                &owner,
+                &symbol_short!("proj"),
+                &1_000_000_000_000i128,
+                &token_client.address,
+            );
+            do_deposit(&env, &client, &token_admin, &user, project_id, amount);
+
+            let result = client.try_clawback_contribution(&project_id, &user);
+            prop_assert_eq!(
+                result,
+                Err(Ok(CrowdfundError::RefundWindowNotOpen)),
+                "INV-2: clawback must be rejected before the project is canceled"
+            );
+        }
+
+        // INV-3: clawback pays a contributor back exactly their own contribution,
+        // and INV-4: a second clawback for the same contributor fails.
+        #[test]
+        fn clawback_pays_exact_amount_once(amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (client, _admin, token_client, token_admin) = setup_vault(&env);
+            let owner = Address::generate(&env);
+            let user = Address::generate(&env);
+
+            let project_id = client.create_project(
+                &owner,
+                &symbol_short!("proj"),
+                &1_000_000_000_000i128,
+                &token_client.address,
+            );
+            do_deposit(&env, &client, &token_admin, &user, project_id, amount);
+            client.cancel_project(&owner, &project_id);
+
+            let user_balance_before = token_client.balance(&user);
+            let clawed_back = client.clawback_contribution(&project_id, &user);
+
+            prop_assert_eq!(
+                clawed_back,
+                amount,
+                "INV-3: clawback must return exactly the contributor's own deposit"
+            );
+            prop_assert_eq!(
+                token_client.balance(&user),
+                user_balance_before + amount,
+                "INV-3: contributor's token balance must increase by exactly the clawed-back amount"
+            );
+
+            let result = client.try_clawback_contribution(&project_id, &user);
+            prop_assert!(
+                result.is_err(),
+                "INV-4: a second clawback for the same contributor must be rejected (got {:?})",
+                result
+            );
+        }
+
+        // INV-2: clawback closes after the refund window elapses.
+        #[test]
+        fn clawback_rejected_after_window_closes(amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (client, _admin, token_client, token_admin) = setup_vault(&env);
+            let owner = Address::generate(&env);
+            let user = Address::generate(&env);
+
+            let project_id = client.create_project(
+                &owner,
+                &symbol_short!("proj"),
+                &1_000_000_000_000i128,
+                &token_client.address,
+            );
+            do_deposit(&env, &client, &token_admin, &user, project_id, amount);
+            client.cancel_project(&owner, &project_id);
+
+            env.ledger()
+                .set_timestamp(env.ledger().timestamp() + REFUND_WINDOW_SECONDS + 1);
+
+            let result = client.try_clawback_contribution(&project_id, &user);
+            prop_assert_eq!(
+                result,
+                Err(Ok(CrowdfundError::RefundWindowClosed)),
+                "INV-2: clawback must be rejected once the refund window has closed"
+            );
+        }
+    }
+}
+
+// ─── close phase (INV-3) ──────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod close_phase {
+    use super::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        // INV-3: once a project is fully refunded, no further deposits are
+        // possible — the project stays permanently closed.
+        #[test]
+        fn closed_project_rejects_further_deposits(amount in valid_amount(), retry_amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+
+            let (client, _admin, token_client, token_admin) = setup_vault(&env);
+            let owner = Address::generate(&env);
+            let user = Address::generate(&env);
+
+            let project_id = client.create_project(
+                &owner,
+                &symbol_short!("proj"),
+                &1_000_000_000_000i128,
+                &token_client.address,
+            );
+            do_deposit(&env, &client, &token_admin, &user, project_id, amount);
+            client.cancel_project(&owner, &project_id);
+            client.refund_contributors(&project_id, &owner);
+
+            token_admin.mint(&user, &retry_amount);
+            let result = client.try_deposit(&user, &project_id, &retry_amount);
+            prop_assert_eq!(
+                result,
+                Err(Ok(CrowdfundError::ProjectNotActive)),
+                "INV-3: a closed (refunded) project must permanently reject deposits"
+            );
+        }
+    }
+}

--- a/apps/onchain/contracts/matching_pool/Cargo.toml
+++ b/apps/onchain/contracts/matching_pool/Cargo.toml
@@ -14,6 +14,7 @@ reentrancy-guard = { path = "../reentrancy-guard" }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+proptest = "1"
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/apps/onchain/contracts/matching_pool/src/lib.rs
+++ b/apps/onchain/contracts/matching_pool/src/lib.rs
@@ -715,3 +715,5 @@ impl MatchingPoolContract {
 
 #[cfg(test)]
 mod test;
+#[cfg(test)]
+mod tests;

--- a/apps/onchain/contracts/matching_pool/src/tests/invariants.rs
+++ b/apps/onchain/contracts/matching_pool/src/tests/invariants.rs
@@ -1,0 +1,551 @@
+//! Round-lifecycle invariant suite for `matching_pool`.
+//!
+//! Covers the open → contribute → finalize → close-style flow
+//! (`create_round` → `record_contribution`/`fund_pool` → `finalize_round` →
+//! `distribute_matching_funds`). The invariants asserted here (`INV-1`
+//! .. `INV-7`) are the ones documented in
+//! `apps/onchain/contracts/ROUND_LIFECYCLE_INVARIANTS.md`, which also
+//! explains the shared vocabulary this suite uses with the equivalent
+//! `crowdfund_vault` suite (`crowdfund_vault/src/tests/round_lifecycle.rs`).
+//!
+//! Every assertion message names the `INV-<n>` it checks plus the concrete
+//! values involved, so a proptest failure's shrunk counterexample and panic
+//! message are enough to diagnose the break without re-running under a
+//! debugger.
+
+extern crate std;
+
+use crate::errors::MatchingPoolError;
+use crate::{MatchingPoolContract, MatchingPoolContractClient};
+use proptest::prelude::*;
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger},
+    token::{StellarAssetClient, TokenClient},
+    vec, Address, Env, Symbol,
+};
+
+// ─── Shared helpers ──────────────────────────────────────────────────────────
+
+const START: u64 = 1_000;
+const END: u64 = 100_000;
+
+fn create_token<'a>(env: &Env, admin: &Address) -> (TokenClient<'a>, StellarAssetClient<'a>) {
+    let addr = env.register_stellar_asset_contract_v2(admin.clone());
+    (
+        TokenClient::new(env, &addr.address()),
+        StellarAssetClient::new(env, &addr.address()),
+    )
+}
+
+/// Fresh Env + initialized contract + token, admin set as `Address`.
+fn setup<'a>(
+    env: &Env,
+) -> (
+    MatchingPoolContractClient<'a>,
+    Address,
+    TokenClient<'a>,
+    StellarAssetClient<'a>,
+) {
+    let admin = Address::generate(env);
+    let (token, token_admin) = create_token(env, &admin);
+    let contract_id = env.register(MatchingPoolContract, ());
+    let client = MatchingPoolContractClient::new(env, &contract_id);
+    client.initialize(&admin);
+    (client, admin, token, token_admin)
+}
+
+/// Open a round with the fixed [START, END] window and move the ledger to
+/// START so contributions are immediately valid.
+fn open_round(
+    env: &Env,
+    client: &MatchingPoolContractClient,
+    admin: &Address,
+    token: &TokenClient,
+) -> u64 {
+    env.ledger().set_timestamp(START);
+    client.create_round(admin, &symbol_short!("Round"), &token.address, &START, &END)
+}
+
+/// Mint `amount` to `funder` and fund `round_id`'s matching pool with it.
+fn do_fund_pool(
+    client: &MatchingPoolContractClient,
+    token_admin: &StellarAssetClient,
+    funder: &Address,
+    round_id: u64,
+    amount: i128,
+) {
+    token_admin.mint(funder, &amount);
+    client.fund_pool(funder, &round_id, &amount);
+}
+
+fn valid_amount() -> impl Strategy<Value = i128> {
+    1i128..=1_000_000_000i128
+}
+
+// ─── open phase (INV-1, INV-5, INV-6, INV-7) ─────────────────────────────────
+
+#[cfg(test)]
+mod open_phase {
+    use super::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        // INV-2, INV-7: a round can only be opened with start < end.
+        #[test]
+        fn create_round_rejects_inverted_dates(start in 1u64..=1_000_000u64, extra in 0u64..=1_000_000u64) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+
+            let end = start.saturating_sub(extra);
+            // Only exercise the invalid case (end <= start); skip otherwise.
+            prop_assume!(end <= start);
+
+            let result = client.try_create_round(
+                &admin,
+                &symbol_short!("Round"),
+                &token.address,
+                &start,
+                &end,
+            );
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::InvalidRoundDates)),
+                "INV-2/INV-7: create_round(start={}, end={}) should be rejected",
+                start,
+                end
+            );
+        }
+
+        // INV-5: only the admin may open a round.
+        #[test]
+        fn create_round_rejects_non_admin(_seed in 0u64..u64::MAX) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, _admin, token, _) = setup(&env);
+            let intruder = Address::generate(&env);
+
+            let result = client.try_create_round(
+                &intruder,
+                &symbol_short!("Round"),
+                &token.address,
+                &START,
+                &END,
+            );
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::Unauthorized)),
+                "INV-5: non-admin must not be able to open a round"
+            );
+        }
+
+        // INV-6: a paused contract must reject new rounds.
+        #[test]
+        fn create_round_rejects_while_paused(_seed in 0u64..u64::MAX) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            client.pause(&admin);
+
+            let result = client.try_create_round(
+                &admin,
+                &symbol_short!("Round"),
+                &token.address,
+                &START,
+                &END,
+            );
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::ContractPaused)),
+                "INV-6: paused contract must reject create_round"
+            );
+        }
+
+        // INV-1: a freshly opened round starts ACTIVE with an empty pool.
+        #[test]
+        fn new_round_starts_active_and_empty(_seed in 0u64..u64::MAX) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+
+            let round_id = open_round(&env, &client, &admin, &token);
+
+            prop_assert_eq!(
+                client.get_round_status(&round_id),
+                Symbol::new(&env, "ACTIVE"),
+                "INV-1: new round must start ACTIVE"
+            );
+            prop_assert_eq!(
+                client.get_pool_balance(&round_id),
+                0i128,
+                "INV-1: new round must start with an empty pool"
+            );
+        }
+    }
+}
+
+// ─── contribute phase (INV-2, INV-3, INV-6) ──────────────────────────────────
+
+#[cfg(test)]
+mod contribute_phase {
+    use super::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        // INV-2: contributions before start_time or after end_time are rejected.
+        #[test]
+        fn contribution_outside_window_rejected(before_start in any::<bool>(), amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+            client.approve_project(&admin, &round_id, &1u64);
+
+            env.ledger().set_timestamp(if before_start { START - 1 } else { END + 1 });
+
+            let contributor = Address::generate(&env);
+            let result = client.try_record_contribution(&round_id, &1u64, &contributor, &amount);
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::RoundNotActive)),
+                "INV-2: contribution outside [{}, {}] must be rejected",
+                START,
+                END
+            );
+        }
+
+        // INV-2: contributions to a project that was never approved are rejected.
+        #[test]
+        fn contribution_to_ineligible_project_rejected(amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+
+            let contributor = Address::generate(&env);
+            let result = client.try_record_contribution(&round_id, &1u64, &contributor, &amount);
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::ProjectNotEligible)),
+                "INV-2: contribution to a non-approved project must be rejected"
+            );
+        }
+
+        // INV-2/INV-1: contributions after finalize are rejected, even inside the
+        // original window.
+        #[test]
+        fn contribution_after_finalize_rejected(amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+            client.approve_project(&admin, &round_id, &1u64);
+
+            env.ledger().set_timestamp(END + 1);
+            client.finalize_round(&admin, &round_id);
+
+            let contributor = Address::generate(&env);
+            let result = client.try_record_contribution(&round_id, &1u64, &contributor, &amount);
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::RoundAlreadyFinalized)),
+                "INV-1: contributions must not be accepted once a round is finalized"
+            );
+        }
+
+        // INV-3: recorded per-project contributions equal the exact sum of amounts.
+        #[test]
+        fn contribution_totals_are_exact(amounts in proptest::collection::vec(valid_amount(), 1..=6)) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+            client.approve_project(&admin, &round_id, &1u64);
+
+            let mut expected_total: i128 = 0;
+            for amount in &amounts {
+                let contributor = Address::generate(&env);
+                client.record_contribution(&round_id, &1u64, &contributor, amount);
+                expected_total += amount;
+
+                prop_assert_eq!(
+                    client.get_project_contributions(&round_id, &1u64),
+                    expected_total,
+                    "INV-3: cumulative contributions must equal the exact sum of deposits so far"
+                );
+            }
+            prop_assert_eq!(
+                client.get_contributor_count(&round_id, &1u64) as usize,
+                amounts.len(),
+                "INV-3: one unique contributor per amount must be counted exactly once"
+            );
+        }
+
+        // INV-6: paused contract rejects fund_pool.
+        #[test]
+        fn fund_pool_rejected_while_paused(amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, token_admin) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+            client.pause(&admin);
+
+            token_admin.mint(&admin, &amount);
+            let result = client.try_fund_pool(&admin, &round_id, &amount);
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::ContractPaused)),
+                "INV-6: paused contract must reject fund_pool"
+            );
+        }
+
+        // INV-3: fund_pool increases the round pool by exactly the funded amount.
+        #[test]
+        fn fund_pool_increases_pool_exactly(amounts in proptest::collection::vec(valid_amount(), 1..=6)) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, token_admin) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+
+            let mut expected: i128 = 0;
+            for amount in &amounts {
+                do_fund_pool(&client, &token_admin, &admin, round_id, *amount);
+                expected += amount;
+                prop_assert_eq!(
+                    client.get_pool_balance(&round_id),
+                    expected,
+                    "INV-3: pool balance must track funded amounts exactly"
+                );
+            }
+        }
+    }
+}
+
+// ─── finalize phase (INV-1, INV-2, INV-4, INV-5) ─────────────────────────────
+
+#[cfg(test)]
+mod finalize_phase {
+    use super::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        // INV-2: a round cannot be finalized before its end_time.
+        #[test]
+        fn finalize_before_end_rejected(offset in 0u64..=(END - START)) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+
+            env.ledger().set_timestamp(START + offset);
+            let result = client.try_finalize_round(&admin, &round_id);
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::RoundStillOpen)),
+                "INV-2: finalize_round before end_time ({}) must be rejected, tried at {}",
+                END,
+                START + offset
+            );
+        }
+
+        // INV-5: only the admin may finalize a round.
+        #[test]
+        fn finalize_rejects_non_admin(_seed in 0u64..u64::MAX) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+            let intruder = Address::generate(&env);
+
+            env.ledger().set_timestamp(END + 1);
+            let result = client.try_finalize_round(&intruder, &round_id);
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::Unauthorized)),
+                "INV-5: non-admin must not be able to finalize a round"
+            );
+        }
+
+        // INV-1/INV-4: a round cannot be finalized twice.
+        #[test]
+        fn finalize_twice_rejected(_seed in 0u64..u64::MAX) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+
+            env.ledger().set_timestamp(END + 1);
+            client.finalize_round(&admin, &round_id);
+
+            let result = client.try_finalize_round(&admin, &round_id);
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::RoundAlreadyFinalized)),
+                "INV-1/INV-4: finalize_round must not succeed a second time"
+            );
+        }
+
+        // INV-1: finalize_round transitions status to FINALIZED and stamps finalized_at.
+        #[test]
+        fn finalize_sets_status_and_timestamp(end_offset in 1u64..=10_000u64) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+
+            let finalize_at = END + end_offset;
+            env.ledger().set_timestamp(finalize_at);
+            client.finalize_round(&admin, &round_id);
+
+            prop_assert_eq!(
+                client.get_round_status(&round_id),
+                Symbol::new(&env, "FINALIZED"),
+                "INV-1: status must be FINALIZED after finalize_round"
+            );
+            prop_assert_eq!(
+                client.get_finalized_at(&round_id),
+                finalize_at,
+                "INV-1: finalized_at must record the ledger time finalize_round was called at"
+            );
+        }
+    }
+}
+
+// ─── close phase — distribute_matching_funds (INV-1, INV-3, INV-4, INV-5) ───
+
+#[cfg(test)]
+mod close_phase {
+    use super::*;
+
+    /// Bring a round to FINALIZED with `n` approved+contributing projects and a
+    /// funded pool, returning (round_id, project_owners) ready for
+    /// distribute_matching_funds.
+    fn setup_finalized_round(
+        env: &Env,
+        client: &MatchingPoolContractClient,
+        admin: &Address,
+        token: &TokenClient,
+        token_admin: &StellarAssetClient,
+        contributions: &[i128],
+        pool_amount: i128,
+    ) -> (u64, soroban_sdk::Vec<Address>) {
+        let round_id = open_round(env, client, admin, token);
+        let mut owners = vec![env];
+
+        for (idx, amount) in contributions.iter().enumerate() {
+            let project_id = idx as u64;
+            client.approve_project(admin, &round_id, &project_id);
+            let contributor = Address::generate(env);
+            client.record_contribution(&round_id, &project_id, &contributor, amount);
+            owners.push_back(Address::generate(env));
+        }
+
+        if pool_amount > 0 {
+            do_fund_pool(client, token_admin, admin, round_id, pool_amount);
+        }
+
+        env.ledger().set_timestamp(END + 1);
+        client.finalize_round(admin, &round_id);
+
+        (round_id, owners)
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        // INV-1: distribute_matching_funds requires a finalized round.
+        #[test]
+        fn distribute_before_finalize_rejected(_seed in 0u64..u64::MAX) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+            client.approve_project(&admin, &round_id, &0u64);
+
+            let result = client.try_distribute_matching_funds(&admin, &round_id, &vec![&env]);
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::RoundNotFinalized)),
+                "INV-1: distribute_matching_funds must require the round to be finalized"
+            );
+        }
+
+        // INV-5: only the admin may trigger distribution.
+        #[test]
+        fn distribute_rejects_non_admin(
+            contributions in proptest::collection::vec(valid_amount(), 1..=3),
+            pool_amount in valid_amount(),
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, token_admin) = setup(&env);
+            let (round_id, owners) = setup_finalized_round(
+                &env, &client, &admin, &token, &token_admin, &contributions, pool_amount,
+            );
+            let intruder = Address::generate(&env);
+
+            let result = client.try_distribute_matching_funds(&intruder, &round_id, &owners);
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::Unauthorized)),
+                "INV-5: non-admin must not be able to distribute matching funds"
+            );
+        }
+
+        // INV-3/INV-4: distribution never exceeds the funded pool, and the pool
+        // is exhausted (never left with leftover dust that's still claimable).
+        #[test]
+        fn distribution_respects_pool_and_zeroes_it(
+            contributions in proptest::collection::vec(valid_amount(), 1..=4),
+            pool_amount in valid_amount(),
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, token_admin) = setup(&env);
+            let (round_id, owners) = setup_finalized_round(
+                &env, &client, &admin, &token, &token_admin, &contributions, pool_amount,
+            );
+
+            let pool_before = client.get_pool_balance(&round_id);
+            let distributed = client.distribute_matching_funds(&admin, &round_id, &owners);
+
+            prop_assert!(
+                distributed <= pool_before,
+                "INV-3: distributed ({}) must never exceed the pool balance before distribution ({})",
+                distributed,
+                pool_before
+            );
+            prop_assert_eq!(
+                client.get_pool_balance(&round_id),
+                0i128,
+                "INV-3/INV-4: round pool must be fully drained after distribution"
+            );
+        }
+
+        // INV-1/INV-4: distribution can never happen twice for the same round.
+        #[test]
+        fn distribute_twice_rejected(
+            contributions in proptest::collection::vec(valid_amount(), 1..=3),
+            pool_amount in valid_amount(),
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, token_admin) = setup(&env);
+            let (round_id, owners) = setup_finalized_round(
+                &env, &client, &admin, &token, &token_admin, &contributions, pool_amount,
+            );
+
+            client.distribute_matching_funds(&admin, &round_id, &owners);
+            let result = client.try_distribute_matching_funds(&admin, &round_id, &owners);
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::MatchAlreadyDistributed)),
+                "INV-1/INV-4: distribute_matching_funds must not succeed a second time"
+            );
+        }
+    }
+}

--- a/apps/onchain/contracts/matching_pool/src/tests/mod.rs
+++ b/apps/onchain/contracts/matching_pool/src/tests/mod.rs
@@ -1,0 +1,1 @@
+pub mod invariants;


### PR DESCRIPTION
Adds proptest-based invariant suites covering the open -> contribute -> finalize -> refund/close flow for crowdfund_vault (create_project -> deposit -> approve_milestone/withdraw -> cancel_project -> refund_contributors/clawback_contribution) and matching_pool (create_round -> record_contribution/fund_pool -> finalize_round -> distribute_matching_funds).

Shared invariants (state-machine monotonicity, contribution window enforcement, conservation of funds, no double payout, authorization, pause enforcement, not-found handling) are documented once in apps/onchain/contracts/ROUND_LIFECYCLE_INVARIANTS.md and referenced by INV-<n> tags in both suites' assertion messages so failures are easy to trace back to a single rule. Both suites live in their contract's own workspace-member crate so they run under the existing `cargo test` CI step.

Closes #1044 

