### PR TITLE
Add configurable round-level contribution caps to matching_pool

### DIFF
--- a/apps/onchain/contracts/ROUND_LIFECYCLE_INVARIANTS.md
+++ b/apps/onchain/contracts/ROUND_LIFECYCLE_INVARIANTS.md
@@ -69,6 +69,20 @@ one rule.
    `RoundNotFound` / `ProjectNotFound`; it must never be treated as valid
    with zeroed defaults.
 
+8. **INV-8 Round contribution cap enforcement** (`matching_pool` only,
+   introduced for #867's anti-whale guardrails). When a round's
+   contribution cap (`RoundCap`, set via `set_round_cap`) is non-zero, a
+   contributor's cumulative recorded contributions to that round — summed
+   across every project in the round, via
+   `get_contributor_round_total(round_id, contributor)` — must never
+   exceed the cap. Any `record_contribution` call that would push the
+   cumulative total over the cap is rejected in full
+   (`ContributionCapExceeded`), with no partial acceptance and no state
+   mutation. A cap of `0` means uncapped. Setting or changing a cap only
+   affects future contributions — it never claws back or invalidates
+   contributions already recorded — and `set_round_cap` itself is subject
+   to `INV-5` (admin-only) and rejected once the round is finalized.
+
 ## Debugging a failing invariant
 
 - Tests use `proptest`; on failure it prints the *minimal* shrunk input in
@@ -81,5 +95,5 @@ one rule.
   numbers, without needing to step through the test in a debugger.
 - Each test module is named after the phase it stresses
   (`open_phase`, `contribute_phase`, `finalize_phase`, `refund_phase`,
-  `close_phase`) so a failing module name narrows down which lifecycle
-  transition regressed.
+  `close_phase`, `cap_phase`) so a failing module name narrows down which
+  lifecycle transition (or guardrail) regressed.

--- a/apps/onchain/contracts/matching_pool/src/errors.rs
+++ b/apps/onchain/contracts/matching_pool/src/errors.rs
@@ -21,4 +21,5 @@ pub enum MatchingPoolError {
     InvalidRoundDates = 15,
     ContractPaused = 16,
     Reentrancy = 17,
+    ContributionCapExceeded = 18,
 }

--- a/apps/onchain/contracts/matching_pool/src/events.rs
+++ b/apps/onchain/contracts/matching_pool/src/events.rs
@@ -70,3 +70,12 @@ pub struct AllMatchesDistributedEvent {
     pub round_id: u64,
     pub total_distributed: i128,
 }
+
+#[contractevent]
+pub struct RoundCapUpdatedEvent {
+    #[topic]
+    pub admin: Address,
+    #[topic]
+    pub round_id: u64,
+    pub cap: i128,
+}

--- a/apps/onchain/contracts/matching_pool/src/lib.rs
+++ b/apps/onchain/contracts/matching_pool/src/lib.rs
@@ -245,6 +245,41 @@ impl MatchingPoolContract {
         Ok(())
     }
 
+    /// Set (or update) the round-level contribution cap, i.e. the maximum a
+    /// single contributor may put into the round in total, summed across
+    /// every eligible project (admin only). A cap of 0 means uncapped.
+    /// Changing the cap only affects future contributions — it never claws
+    /// back or invalidates contributions already recorded.
+    pub fn set_round_cap(
+        env: Env,
+        admin: Address,
+        round_id: u64,
+        cap: i128,
+    ) -> Result<(), MatchingPoolError> {
+        Self::require_admin(&env, &admin)?;
+        if cap < 0 {
+            return Err(MatchingPoolError::InvalidAmount);
+        }
+        let round: RoundData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Round(round_id))
+            .ok_or(MatchingPoolError::RoundNotFound)?;
+        if round.is_finalized {
+            return Err(MatchingPoolError::RoundAlreadyFinalized);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::RoundCap(round_id), &cap);
+        events::RoundCapUpdatedEvent {
+            admin,
+            round_id,
+            cap,
+        }
+        .publish(&env);
+        Ok(())
+    }
+
     pub fn record_contribution(
         env: Env,
         round_id: u64,
@@ -276,6 +311,23 @@ impl MatchingPoolContract {
         {
             return Err(MatchingPoolError::ProjectNotEligible);
         }
+        let round_total_key = DataKey::ContributorRoundTotal(round_id, contributor.clone());
+        let prior_round_total: i128 = env
+            .storage()
+            .persistent()
+            .get(&round_total_key)
+            .unwrap_or(0);
+        let new_round_total = prior_round_total
+            .checked_add(amount)
+            .ok_or(MatchingPoolError::InvalidAmount)?;
+        let cap: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RoundCap(round_id))
+            .unwrap_or(0);
+        if cap > 0 && new_round_total > cap {
+            return Err(MatchingPoolError::ContributionCapExceeded);
+        }
         let contrib_key = DataKey::ContributorAmount(round_id, project_id, contributor.clone());
         let prev: i128 = env.storage().persistent().get(&contrib_key).unwrap_or(0);
         if prev == 0 {
@@ -295,6 +347,9 @@ impl MatchingPoolContract {
         env.storage()
             .persistent()
             .set(&total_key, &(total + amount));
+        env.storage()
+            .persistent()
+            .set(&round_total_key, &new_round_total);
         events::ContributionRecordedEvent {
             round_id,
             project_id,
@@ -647,6 +702,37 @@ impl MatchingPoolContract {
             .storage()
             .persistent()
             .get(&DataKey::ProjectContributorCount(round_id, project_id))
+            .unwrap_or(0))
+    }
+
+    /// The round-level contribution cap (0 means uncapped).
+    pub fn get_round_cap(env: Env, round_id: u64) -> Result<i128, MatchingPoolError> {
+        env.storage()
+            .persistent()
+            .get::<_, RoundData>(&DataKey::Round(round_id))
+            .ok_or(MatchingPoolError::RoundNotFound)?;
+        Ok(env
+            .storage()
+            .persistent()
+            .get(&DataKey::RoundCap(round_id))
+            .unwrap_or(0))
+    }
+
+    /// A contributor's cumulative recorded contributions to a round, summed
+    /// across every project in that round.
+    pub fn get_contributor_round_total(
+        env: Env,
+        round_id: u64,
+        contributor: Address,
+    ) -> Result<i128, MatchingPoolError> {
+        env.storage()
+            .persistent()
+            .get::<_, RoundData>(&DataKey::Round(round_id))
+            .ok_or(MatchingPoolError::RoundNotFound)?;
+        Ok(env
+            .storage()
+            .persistent()
+            .get(&DataKey::ContributorRoundTotal(round_id, contributor))
             .unwrap_or(0))
     }
 

--- a/apps/onchain/contracts/matching_pool/src/storage.rs
+++ b/apps/onchain/contracts/matching_pool/src/storage.rs
@@ -19,6 +19,8 @@ pub enum DataKey {
     MatchDistributed(u64),                // round_id -> bool
     RoundStatus(u64),                     // round_id -> Symbol ("ACTIVE"|"FINALIZED"|"DISTRIBUTED")
     FinalizedAt(u64),                     // round_id -> u64 (ledger timestamp when finalized)
+    RoundCap(u64),                        // round_id -> i128 (0 = uncapped)
+    ContributorRoundTotal(u64, Address), // (round_id, contributor) -> i128 (cumulative across all projects)
 }
 
 /// Core data for a funding round

--- a/apps/onchain/contracts/matching_pool/src/test.rs
+++ b/apps/onchain/contracts/matching_pool/src/test.rs
@@ -721,3 +721,311 @@ fn test_distribute_succeeds_after_unpause() {
     assert_eq!(total, 1_000_000);
     assert_eq!(token.balance(&owner1), 1_000_000);
 }
+
+// ── Round contribution caps (anti-whale guardrails) ──────────────────────────
+
+fn setup_round<'a>(
+    env: &Env,
+    client: &MatchingPoolContractClient<'a>,
+    admin: &Address,
+    token: &TokenClient<'a>,
+) -> u64 {
+    client.initialize(admin);
+    env.ledger().set_timestamp(500);
+    client.create_round(
+        admin,
+        &symbol_short!("R1"),
+        &token.address,
+        &1000u64,
+        &3000u64,
+    )
+}
+
+#[test]
+fn test_set_round_cap_and_get_round_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+
+    client.set_round_cap(&admin, &round_id, &500i128);
+    assert_eq!(client.get_round_cap(&round_id), 500i128);
+}
+
+#[test]
+fn test_get_round_cap_defaults_to_zero_when_unset() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+
+    assert_eq!(client.get_round_cap(&round_id), 0i128);
+}
+
+#[test]
+fn test_get_round_cap_nonexistent_round() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _) = setup(&env);
+    client.initialize(&admin);
+
+    assert_eq!(
+        client.try_get_round_cap(&9_999u64),
+        Err(Ok(MatchingPoolError::RoundNotFound))
+    );
+}
+
+#[test]
+fn test_get_contributor_round_total_nonexistent_round() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _) = setup(&env);
+    client.initialize(&admin);
+    let contributor = Address::generate(&env);
+
+    assert_eq!(
+        client.try_get_contributor_round_total(&9_999u64, &contributor),
+        Err(Ok(MatchingPoolError::RoundNotFound))
+    );
+}
+
+#[test]
+fn test_set_round_cap_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+    let intruder = Address::generate(&env);
+
+    assert_eq!(
+        client.try_set_round_cap(&intruder, &round_id, &500i128),
+        Err(Ok(MatchingPoolError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_set_round_cap_rejects_negative() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+
+    assert_eq!(
+        client.try_set_round_cap(&admin, &round_id, &-1i128),
+        Err(Ok(MatchingPoolError::InvalidAmount))
+    );
+}
+
+#[test]
+fn test_set_round_cap_rejects_on_finalized_round() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+
+    env.ledger().set_timestamp(4000);
+    client.finalize_round(&admin, &round_id);
+
+    assert_eq!(
+        client.try_set_round_cap(&admin, &round_id, &500i128),
+        Err(Ok(MatchingPoolError::RoundAlreadyFinalized))
+    );
+}
+
+#[test]
+fn test_set_round_cap_rejects_nonexistent_round() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _) = setup(&env);
+    client.initialize(&admin);
+
+    assert_eq!(
+        client.try_set_round_cap(&admin, &9_999u64, &500i128),
+        Err(Ok(MatchingPoolError::RoundNotFound))
+    );
+}
+
+#[test]
+fn test_contribution_exactly_at_cap_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+    client.approve_project(&admin, &round_id, &1u64);
+    client.set_round_cap(&admin, &round_id, &100i128);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &100i128);
+
+    assert_eq!(
+        client.get_contributor_round_total(&round_id, &contributor),
+        100i128
+    );
+}
+
+#[test]
+fn test_contribution_one_over_cap_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+    client.approve_project(&admin, &round_id, &1u64);
+    client.set_round_cap(&admin, &round_id, &100i128);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    assert_eq!(
+        client.try_record_contribution(&round_id, &1u64, &contributor, &101i128),
+        Err(Ok(MatchingPoolError::ContributionCapExceeded))
+    );
+
+    // No state must have been mutated by the rejected contribution.
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 0i128);
+    assert_eq!(client.get_contributor_count(&round_id, &1u64), 0u32);
+    assert_eq!(
+        client.get_contributor_round_total(&round_id, &contributor),
+        0i128
+    );
+}
+
+#[test]
+fn test_cumulative_contributions_same_project_hit_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+    client.approve_project(&admin, &round_id, &1u64);
+    client.set_round_cap(&admin, &round_id, &100i128);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &60i128);
+
+    assert_eq!(
+        client.try_record_contribution(&round_id, &1u64, &contributor, &50i128),
+        Err(Ok(MatchingPoolError::ContributionCapExceeded))
+    );
+
+    // The first, accepted contribution's state must be untouched by the
+    // second, rejected one.
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 60i128);
+    assert_eq!(
+        client.get_contributor_round_total(&round_id, &contributor),
+        60i128
+    );
+}
+
+#[test]
+fn test_cumulative_contributions_across_projects_hit_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+    client.approve_project(&admin, &round_id, &1u64);
+    client.approve_project(&admin, &round_id, &2u64);
+    client.set_round_cap(&admin, &round_id, &100i128);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &60i128);
+
+    // Spreading the remainder across a second project must still be capped
+    // by the round-level (not per-project) total.
+    assert_eq!(
+        client.try_record_contribution(&round_id, &2u64, &contributor, &50i128),
+        Err(Ok(MatchingPoolError::ContributionCapExceeded))
+    );
+
+    // Exactly filling the remaining headroom succeeds.
+    client.record_contribution(&round_id, &2u64, &contributor, &40i128);
+    assert_eq!(
+        client.get_contributor_round_total(&round_id, &contributor),
+        100i128
+    );
+}
+
+#[test]
+fn test_cap_zero_means_unlimited() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+    client.approve_project(&admin, &round_id, &1u64);
+    // No cap set (defaults to 0 == unlimited).
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &1_000_000_000i128);
+
+    assert_eq!(
+        client.get_contributor_round_total(&round_id, &contributor),
+        1_000_000_000i128
+    );
+}
+
+#[test]
+fn test_retroactive_cap_after_prior_contributions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+    client.approve_project(&admin, &round_id, &1u64);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &80i128);
+
+    // Cap set after the fact, at exactly the amount already contributed.
+    client.set_round_cap(&admin, &round_id, &80i128);
+
+    assert_eq!(
+        client.try_record_contribution(&round_id, &1u64, &contributor, &1i128),
+        Err(Ok(MatchingPoolError::ContributionCapExceeded))
+    );
+}
+
+#[test]
+fn test_retroactive_cap_set_below_existing_total_blocks_further_contributions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+    client.approve_project(&admin, &round_id, &1u64);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &80i128);
+
+    // Cap set below what's already been contributed — this doesn't claw
+    // back the past contribution, but blocks any further one.
+    client.set_round_cap(&admin, &round_id, &50i128);
+
+    assert_eq!(
+        client.get_contributor_round_total(&round_id, &contributor),
+        80i128
+    );
+    assert_eq!(
+        client.try_record_contribution(&round_id, &1u64, &contributor, &1i128),
+        Err(Ok(MatchingPoolError::ContributionCapExceeded))
+    );
+}
+
+#[test]
+fn test_qf_score_unaffected_by_cap_bookkeeping() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+    client.approve_project(&admin, &round_id, &1u64);
+    client.set_round_cap(&admin, &round_id, &1_000_000i128);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &100i128);
+
+    // Same score as test_qf_score_single_contributor, which never sets a cap
+    // — proves the cap bookkeeping doesn't perturb QF scoring.
+    let score = client.get_project_qf_score(&round_id, &1u64);
+    assert!(score > 0);
+}

--- a/apps/onchain/contracts/matching_pool/src/tests/invariants.rs
+++ b/apps/onchain/contracts/matching_pool/src/tests/invariants.rs
@@ -549,3 +549,116 @@ mod close_phase {
         }
     }
 }
+
+// ─── cap phase — round contribution caps (INV-8) ─────────────────────────────
+
+#[cfg(test)]
+mod cap_phase {
+    use super::*;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        // INV-8: any single contribution at or below the round's remaining
+        // headroom must succeed.
+        #[test]
+        fn contribution_within_cap_succeeds(cap in valid_amount(), amount in valid_amount()) {
+            prop_assume!(amount <= cap);
+
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+            client.approve_project(&admin, &round_id, &1u64);
+            client.set_round_cap(&admin, &round_id, &cap);
+
+            let contributor = Address::generate(&env);
+            client.record_contribution(&round_id, &1u64, &contributor, &amount);
+
+            prop_assert_eq!(
+                client.get_contributor_round_total(&round_id, &contributor),
+                amount,
+                "INV-8: a contribution within the cap must be recorded in full"
+            );
+        }
+
+        // INV-8: a single contribution that would push the contributor's
+        // round total over a non-zero cap must be rejected in full, with no
+        // state mutated.
+        #[test]
+        fn contribution_exceeding_cap_rejected(cap in valid_amount(), excess in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+            client.approve_project(&admin, &round_id, &1u64);
+            client.set_round_cap(&admin, &round_id, &cap);
+
+            let contributor = Address::generate(&env);
+            let over_amount = cap + excess;
+            let result = client.try_record_contribution(&round_id, &1u64, &contributor, &over_amount);
+
+            prop_assert_eq!(
+                result,
+                Err(Ok(MatchingPoolError::ContributionCapExceeded)),
+                "INV-8: contributing {} against a cap of {} must be rejected",
+                over_amount,
+                cap
+            );
+            prop_assert_eq!(
+                client.get_contributor_round_total(&round_id, &contributor),
+                0i128,
+                "INV-8: a rejected over-cap contribution must not mutate the contributor's round total"
+            );
+        }
+
+        // INV-8: no matter how a contributor's amounts are split across
+        // multiple projects in the same round, their cumulative round total
+        // must never exceed a non-zero cap.
+        #[test]
+        fn cumulative_total_never_exceeds_cap_across_projects(
+            cap in valid_amount(),
+            amounts in proptest::collection::vec(valid_amount(), 1..=6),
+        ) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+            client.approve_project(&admin, &round_id, &1u64);
+            client.approve_project(&admin, &round_id, &2u64);
+            client.set_round_cap(&admin, &round_id, &cap);
+
+            let contributor = Address::generate(&env);
+            for (idx, amount) in amounts.iter().enumerate() {
+                let project_id = (idx % 2) as u64 + 1;
+                let _ = client.try_record_contribution(&round_id, &project_id, &contributor, amount);
+
+                prop_assert!(
+                    client.get_contributor_round_total(&round_id, &contributor) <= cap,
+                    "INV-8: cumulative round total must never exceed the cap ({})",
+                    cap
+                );
+            }
+        }
+
+        // INV-8: a cap of 0 means unlimited — any amount succeeds.
+        #[test]
+        fn zero_cap_means_unlimited(amount in valid_amount()) {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (client, admin, token, _) = setup(&env);
+            let round_id = open_round(&env, &client, &admin, &token);
+            client.approve_project(&admin, &round_id, &1u64);
+            // No cap set — defaults to 0 (uncapped).
+
+            let contributor = Address::generate(&env);
+            client.record_contribution(&round_id, &1u64, &contributor, &amount);
+
+            prop_assert_eq!(
+                client.get_contributor_round_total(&round_id, &contributor),
+                amount,
+                "INV-8: an uncapped round (cap == 0) must accept any positive amount"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Introduces an opt-in, admin-configurable per-round contribution cap to reduce whale skew during testnet quadratic-funding experiments.

- set_round_cap(admin, round_id, cap) lets an admin set/update a round's cap at any point before finalization (0 = uncapped, the default for every existing round so no prior call sites break).
- record_contribution now tracks a contributor's cumulative total across every project in the round (ContributorRoundTotal) and rejects, in full with no state mutation, any contribution that would push that total over a non-zero cap (ContributionCapExceeded). The cap applies round-wide rather than per-project so it can't be bypassed by spreading contributions across multiple approved projects.
- get_round_cap and get_contributor_round_total make cap state and remaining headroom queryable.
- Cap bookkeeping is additive only; QF scoring and distribution are unaffected.

Adds INV-8 to ROUND_LIFECYCLE_INVARIANTS.md and a new cap_phase proptest module (tests/invariants.rs) alongside unit tests in test.rs covering boundary values: exact-cap success, one-over-cap rejection, cumulative caps across multiple projects, zero-cap-is-unlimited, and retroactive cap changes against already-recorded contributions.
Closes #867