### PR TITLE
Add staleness windows and invalidation flags to pricing_adapter

### DIFF
--- a/apps/onchain/contracts/pricing_adapter/src/errors.rs
+++ b/apps/onchain/contracts/pricing_adapter/src/errors.rs
@@ -9,4 +9,6 @@ pub enum PricingAdapterError {
     Unauthorized = 3,
     PriceNotFound = 4,
     InvalidPrice = 5,
+    StalePrice = 6,
+    PriceInvalidated = 7,
 }

--- a/apps/onchain/contracts/pricing_adapter/src/events.rs
+++ b/apps/onchain/contracts/pricing_adapter/src/events.rs
@@ -21,3 +21,17 @@ pub struct OracleUpdatedEvent {
     pub admin: Address,
     pub oracle: Address,
 }
+
+#[contractevent]
+pub struct PriceInvalidatedEvent {
+    #[topic]
+    pub asset: Address,
+    pub admin: Address,
+}
+
+#[contractevent]
+pub struct StalenessWindowUpdatedEvent {
+    #[topic]
+    pub admin: Address,
+    pub max_age_seconds: u64,
+}

--- a/apps/onchain/contracts/pricing_adapter/src/lib.rs
+++ b/apps/onchain/contracts/pricing_adapter/src/lib.rs
@@ -6,9 +6,12 @@ mod storage;
 
 use errors::PricingAdapterError;
 use soroban_sdk::{contract, contractimpl, Address, Env};
-use storage::DataKey;
+use storage::{DataKey, PriceState};
 
 pub const BASE_DECIMALS: u32 = 7;
+/// Default staleness window (seconds) used when no admin-configured value
+/// has been set via `set_staleness_window`.
+pub const DEFAULT_MAX_PRICE_AGE: u64 = 3600;
 
 #[contract]
 pub struct PricingAdapterContract;
@@ -48,6 +51,15 @@ impl PricingAdapterContract {
         env.storage()
             .persistent()
             .set(&DataKey::AssetDecimals(asset.clone()), &asset_decimals);
+        env.storage().persistent().set(
+            &DataKey::AssetPriceTimestamp(asset.clone()),
+            &env.ledger().timestamp(),
+        );
+        // A freshly admin-provided price always supersedes any prior
+        // invalidation.
+        env.storage()
+            .persistent()
+            .set(&DataKey::AssetPriceInvalidated(asset.clone()), &false);
 
         let event = events::PriceUpdatedEvent {
             admin,
@@ -58,12 +70,129 @@ impl PricingAdapterContract {
         Ok(())
     }
 
-    /// Get the current configured price of an asset
+    /// Get the current configured price of an asset. Rejects deterministically
+    /// if the price has been explicitly invalidated or has aged past the
+    /// configured staleness window — this is the entry point consumers
+    /// (including `normalize_amount`, which calls this internally) rely on
+    /// to reject unsafe prices.
     pub fn get_price(env: Env, asset: Address) -> Result<i128, PricingAdapterError> {
+        let price: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AssetPrice(asset.clone()))
+            .ok_or(PricingAdapterError::PriceNotFound)?;
+
+        match Self::price_state(&env, &asset) {
+            PriceState::Invalidated => return Err(PricingAdapterError::PriceInvalidated),
+            PriceState::Stale => return Err(PricingAdapterError::StalePrice),
+            PriceState::Fresh => {}
+        }
+
+        Ok(price)
+    }
+
+    /// Explicitly flag an asset's currently stored price as invalid (admin
+    /// only), e.g. after detecting an oracle malfunction. The next
+    /// successful `set_price` call for the asset clears the flag.
+    pub fn invalidate_price(
+        env: Env,
+        admin: Address,
+        asset: Address,
+    ) -> Result<(), PricingAdapterError> {
+        Self::require_admin(&env, &admin)?;
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::AssetPrice(asset.clone()))
+        {
+            return Err(PricingAdapterError::PriceNotFound);
+        }
         env.storage()
             .persistent()
-            .get(&DataKey::AssetPrice(asset))
+            .set(&DataKey::AssetPriceInvalidated(asset.clone()), &true);
+
+        let event = events::PriceInvalidatedEvent { admin, asset };
+        event.publish(&env);
+        Ok(())
+    }
+
+    /// Set (or update) the global staleness window, in seconds (admin only).
+    pub fn set_staleness_window(
+        env: Env,
+        admin: Address,
+        max_age_seconds: u64,
+    ) -> Result<(), PricingAdapterError> {
+        Self::require_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxPriceAge, &max_age_seconds);
+
+        let event = events::StalenessWindowUpdatedEvent {
+            admin,
+            max_age_seconds,
+        };
+        event.publish(&env);
+        Ok(())
+    }
+
+    /// The currently configured staleness window, in seconds (defaults to
+    /// `DEFAULT_MAX_PRICE_AGE` until an admin sets one explicitly).
+    pub fn get_staleness_window(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&DataKey::MaxPriceAge)
+            .unwrap_or(DEFAULT_MAX_PRICE_AGE)
+    }
+
+    /// Freshness classification of an asset's stored price, without
+    /// triggering `get_price`'s rejection — lets a consumer inspect state
+    /// before deciding whether to call `get_price`.
+    pub fn get_price_state(env: Env, asset: Address) -> Result<PriceState, PricingAdapterError> {
+        if !env
+            .storage()
+            .persistent()
+            .has(&DataKey::AssetPrice(asset.clone()))
+        {
+            return Err(PricingAdapterError::PriceNotFound);
+        }
+        Ok(Self::price_state(&env, &asset))
+    }
+
+    /// The ledger timestamp an asset's price was last set at.
+    pub fn get_price_timestamp(env: Env, asset: Address) -> Result<u64, PricingAdapterError> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::AssetPriceTimestamp(asset))
             .ok_or(PricingAdapterError::PriceNotFound)
+    }
+
+    fn price_state(env: &Env, asset: &Address) -> PriceState {
+        let invalidated: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AssetPriceInvalidated(asset.clone()))
+            .unwrap_or(false);
+        if invalidated {
+            return PriceState::Invalidated;
+        }
+
+        let timestamp: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AssetPriceTimestamp(asset.clone()))
+            .unwrap_or(0);
+        let max_age: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::MaxPriceAge)
+            .unwrap_or(DEFAULT_MAX_PRICE_AGE);
+        let age = env.ledger().timestamp().saturating_sub(timestamp);
+
+        if age > max_age {
+            PriceState::Stale
+        } else {
+            PriceState::Fresh
+        }
     }
 
     /// Get the decimals configured for an asset (defaults to 7)

--- a/apps/onchain/contracts/pricing_adapter/src/storage.rs
+++ b/apps/onchain/contracts/pricing_adapter/src/storage.rs
@@ -7,4 +7,18 @@ pub enum DataKey {
     AssetPrice(Address),
     AssetOracle(Address),
     AssetDecimals(Address), // Stores decimals if needed for normalization
+    AssetPriceTimestamp(Address), // ledger timestamp the price was last set
+    AssetPriceInvalidated(Address), // explicit admin-set invalidation flag
+    MaxPriceAge,            // instance: u64 seconds; unset = DEFAULT_MAX_PRICE_AGE
+}
+
+/// Freshness classification for a stored price, exposed to consumers so
+/// they can inspect a price's state without triggering `get_price`'s
+/// rejection.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum PriceState {
+    Fresh,
+    Stale,
+    Invalidated,
 }

--- a/apps/onchain/contracts/pricing_adapter/src/test.rs
+++ b/apps/onchain/contracts/pricing_adapter/src/test.rs
@@ -1,5 +1,8 @@
 use super::*;
-use soroban_sdk::{testutils::Address as _, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Env,
+};
 
 #[test]
 fn test_initialization() {
@@ -102,4 +105,200 @@ fn test_normalize_amount_different_decimals() {
     // $6000 scaled by 10^7 = 60_000 * 10^7 = 60_000_000_000
     let expected: i128 = 6000 * 10_000_000;
     assert_eq!(normalized, expected);
+}
+
+// ── Staleness windows & invalidation flags ────────────────────────────────
+
+fn setup<'a>(env: &Env) -> (PricingAdapterContractClient<'a>, Address, Address) {
+    let admin = Address::generate(env);
+    let asset = Address::generate(env);
+    let contract_id = env.register(PricingAdapterContract, ());
+    let client = PricingAdapterContractClient::new(env, &contract_id);
+    client.initialize(&admin);
+    (client, admin, asset)
+}
+
+#[test]
+fn test_price_is_fresh_immediately_after_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, asset) = setup(&env);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_price(&admin, &asset, &10_000_000i128, &7u32);
+
+    assert_eq!(client.get_price_state(&asset), PriceState::Fresh);
+    assert_eq!(client.get_price(&asset), 10_000_000i128);
+    assert_eq!(client.get_price_timestamp(&asset), 1_000u64);
+}
+
+#[test]
+fn test_price_still_fresh_at_exact_staleness_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, asset) = setup(&env);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_price(&admin, &asset, &10_000_000i128, &7u32);
+
+    env.ledger().set_timestamp(1_000 + DEFAULT_MAX_PRICE_AGE);
+    assert_eq!(client.get_price_state(&asset), PriceState::Fresh);
+    assert_eq!(client.get_price(&asset), 10_000_000i128);
+}
+
+#[test]
+fn test_price_stale_one_second_past_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, asset) = setup(&env);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_price(&admin, &asset, &10_000_000i128, &7u32);
+
+    env.ledger()
+        .set_timestamp(1_000 + DEFAULT_MAX_PRICE_AGE + 1);
+    assert_eq!(client.get_price_state(&asset), PriceState::Stale);
+    assert_eq!(
+        client.try_get_price(&asset),
+        Err(Ok(PricingAdapterError::StalePrice))
+    );
+}
+
+#[test]
+fn test_normalize_amount_rejects_stale_price() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, asset) = setup(&env);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_price(&admin, &asset, &10_000_000i128, &7u32);
+
+    env.ledger()
+        .set_timestamp(1_000 + DEFAULT_MAX_PRICE_AGE + 1);
+    assert_eq!(
+        client.try_normalize_amount(&asset, &5_000_000i128),
+        Err(Ok(PricingAdapterError::StalePrice))
+    );
+}
+
+#[test]
+fn test_invalidate_price_rejects_get_price_even_when_fresh() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, asset) = setup(&env);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_price(&admin, &asset, &10_000_000i128, &7u32);
+    client.invalidate_price(&admin, &asset);
+
+    assert_eq!(client.get_price_state(&asset), PriceState::Invalidated);
+    assert_eq!(
+        client.try_get_price(&asset),
+        Err(Ok(PricingAdapterError::PriceInvalidated))
+    );
+    assert_eq!(
+        client.try_normalize_amount(&asset, &5_000_000i128),
+        Err(Ok(PricingAdapterError::PriceInvalidated))
+    );
+}
+
+#[test]
+fn test_set_price_after_invalidation_clears_flag() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, asset) = setup(&env);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_price(&admin, &asset, &10_000_000i128, &7u32);
+    client.invalidate_price(&admin, &asset);
+
+    client.set_price(&admin, &asset, &12_000_000i128, &7u32);
+
+    assert_eq!(client.get_price_state(&asset), PriceState::Fresh);
+    assert_eq!(client.get_price(&asset), 12_000_000i128);
+}
+
+#[test]
+fn test_invalidate_price_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, asset) = setup(&env);
+    let intruder = Address::generate(&env);
+
+    client.set_price(&admin, &asset, &10_000_000i128, &7u32);
+
+    assert_eq!(
+        client.try_invalidate_price(&intruder, &asset),
+        Err(Ok(PricingAdapterError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_invalidate_price_rejects_nonexistent_asset() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, asset) = setup(&env);
+
+    assert_eq!(
+        client.try_invalidate_price(&admin, &asset),
+        Err(Ok(PricingAdapterError::PriceNotFound))
+    );
+}
+
+#[test]
+fn test_get_price_state_rejects_nonexistent_asset() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, asset) = setup(&env);
+
+    assert_eq!(
+        client.try_get_price_state(&asset),
+        Err(Ok(PricingAdapterError::PriceNotFound))
+    );
+}
+
+#[test]
+fn test_staleness_window_defaults_then_reflects_configured_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _asset) = setup(&env);
+
+    assert_eq!(client.get_staleness_window(), DEFAULT_MAX_PRICE_AGE);
+
+    client.set_staleness_window(&admin, &600u64);
+    assert_eq!(client.get_staleness_window(), 600u64);
+}
+
+#[test]
+fn test_set_staleness_window_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin, _asset) = setup(&env);
+    let intruder = Address::generate(&env);
+
+    assert_eq!(
+        client.try_set_staleness_window(&intruder, &600u64),
+        Err(Ok(PricingAdapterError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_custom_staleness_window_governs_get_price() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, asset) = setup(&env);
+
+    client.set_staleness_window(&admin, &100u64);
+
+    env.ledger().set_timestamp(1_000);
+    client.set_price(&admin, &asset, &10_000_000i128, &7u32);
+
+    env.ledger().set_timestamp(1_100);
+    assert_eq!(client.get_price(&asset), 10_000_000i128);
+
+    env.ledger().set_timestamp(1_101);
+    assert_eq!(
+        client.try_get_price(&asset),
+        Err(Ok(PricingAdapterError::StalePrice))
+    );
 }


### PR DESCRIPTION
Adds explicit stale-price handling so downstream flows can reject unsafe values deterministically:

- set_price now records the ledger timestamp a price was last set and clears any prior invalidation flag.
- get_price (and normalize_amount, which calls it internally) rejects with StalePrice once a price has aged past the configured staleness window, and with PriceInvalidated once an admin has explicitly flagged it via the new invalidate_price function.
- set_staleness_window/get_staleness_window let an admin configure the global freshness window (defaults to DEFAULT_MAX_PRICE_AGE = 3600s).
- get_price_state exposes a Fresh/Stale/Invalidated classification without triggering rejection, and get_price_timestamp exposes the raw freshness metadata, satisfying "cap state is queryable" without requiring a caller to first hit an error.

Tests cover the staleness boundary (exact window vs one second past), invalidation overriding freshness, invalidation clearing on the next set_price, non-admin/nonexistent-asset rejections, and normalize_amount inheriting the same rejection behavior through its existing call into get_price.

Closes #860