### PR TITLE
feat(onchain): granular pause scopes for contribution, payout, and go…

### DIFF
--- a/apps/onchain/contracts/contributor_registry/src/errors.rs
+++ b/apps/onchain/contracts/contributor_registry/src/errors.rs
@@ -24,4 +24,8 @@ pub enum ContributorError {
     AttestationNotActive = 18,
     AttestationNotSuspended = 19,
     AttestationAlreadyRevoked = 20,
+    /// The Contribution scope (register_contributor, gasless_register) is paused.
+    ContributionScopePaused = 21,
+    /// The Governance scope (multisig proposals and admin-gated mutations) is paused.
+    GovernanceScopePaused = 22,
 }

--- a/apps/onchain/contracts/contributor_registry/src/events.rs
+++ b/apps/onchain/contracts/contributor_registry/src/events.rs
@@ -146,3 +146,21 @@ pub struct AttestationRestoredEvent {
     pub executor: Address,
     pub proposal_id: u64,
 }
+
+/// Emitted whenever the pause state of a specific scope changes.
+///
+/// `scope` identifies which subsystem was affected:
+///  - `1` → Contribution (register_contributor, gasless_register)
+///  - `2` → Governance (multisig proposals, admin-gated mutations)
+///
+/// `paused` is the **new** state after the call.
+#[contractevent]
+pub struct ScopePauseChangedEvent {
+    #[topic]
+    pub admin: Address,
+    /// Numeric discriminant of `ContribPauseScope`.
+    pub scope: u32,
+    /// `true` = scope is now paused; `false` = scope is now unpaused.
+    pub paused: bool,
+    pub timestamp: u64,
+}

--- a/apps/onchain/contracts/contributor_registry/src/lib.rs
+++ b/apps/onchain/contracts/contributor_registry/src/lib.rs
@@ -10,11 +10,11 @@ use events::{
     AdminChangedEvent, AttestationRestoredEvent, AttestationRevokedEvent,
     AttestationSuspendedEvent, BadgeGrantedEvent, BadgeRevokedEvent, ContributorProfileChangedEvt,
     GaslessRegistrationEvent, MultisigConfiguredEvent, ReputationPenaltyAppliedEvent,
-    UpgradedEvent,
+    ScopePauseChangedEvent, UpgradedEvent,
 };
 use multisig::{
-    cancel, consume_approval, expire, get_config, get_proposal, propose, sign, validate_config,
-    MultisigConfig, ProposalAction, ProposalStatus, Signer,
+    cancel, consume_approval, expire, find_signer, get_config, get_proposal, propose, sign,
+    validate_config, MultisigConfig, ProposalAction, ProposalStatus, Signer,
 };
 use notification_interface::{Notification, NotificationReceiverTrait};
 use soroban_sdk::xdr::FromXdr;
@@ -22,8 +22,8 @@ use soroban_sdk::{
     contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, String, Symbol, Vec,
 };
 use storage::{
-    AttestationStatus, Badge, ContributorData, ContributorTier, DataKey, PenaltyRecord,
-    PenaltySeverity, LEDGER_BUMP, LEDGER_THRESHOLD,
+    AttestationStatus, Badge, ContribPauseScope, ContributorData, ContributorTier, DataKey,
+    PenaltyRecord, PenaltySeverity, LEDGER_BUMP, LEDGER_THRESHOLD,
 };
 
 #[contract]
@@ -41,6 +41,34 @@ impl ContributorRegistryContract {
             .instance()
             .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
         Ok(())
+    }
+
+    // ── Granular pause scope helpers ─────────────────────────
+
+    /// Returns `true` when the given scope is paused.
+    fn is_scope_paused(env: &Env, scope: ContribPauseScope) -> bool {
+        env.storage()
+            .instance()
+            .get(&DataKey::ScopePaused(scope))
+            .unwrap_or(false)
+    }
+
+    /// Guard for registration writes.
+    fn require_contribution_not_paused(env: &Env) -> Result<(), ContributorError> {
+        if Self::is_scope_paused(env, ContribPauseScope::Contribution) {
+            Err(ContributorError::ContributionScopePaused)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Guard for multisig / admin-gated governance writes.
+    fn require_governance_not_paused(env: &Env) -> Result<(), ContributorError> {
+        if Self::is_scope_paused(env, ContribPauseScope::Governance) {
+            Err(ContributorError::GovernanceScopePaused)
+        } else {
+            Ok(())
+        }
     }
 
     fn registration_nonce_of(env: &Env, address: &Address) -> u64 {
@@ -144,6 +172,13 @@ impl ContributorRegistryContract {
         env.storage()
             .instance()
             .set(&DataKey::NextProposalId, &0u64);
+        // All granular pause scopes start unpaused.
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(ContribPauseScope::Contribution), &false);
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(ContribPauseScope::Governance), &false);
         env.storage()
             .instance()
             .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
@@ -165,6 +200,8 @@ impl ContributorRegistryContract {
         proposer: Address,
         action: ProposalAction,
     ) -> Result<u64, ContributorError> {
+        Self::ensure_initialized(&env)?;
+        Self::require_governance_not_paused(&env)?;
         propose(&env, proposer, action)
     }
 
@@ -173,6 +210,8 @@ impl ContributorRegistryContract {
         signer: Address,
         proposal_id: u64,
     ) -> Result<ProposalStatus, ContributorError> {
+        Self::ensure_initialized(&env)?;
+        Self::require_governance_not_paused(&env)?;
         sign(&env, signer, proposal_id)
     }
 
@@ -181,10 +220,14 @@ impl ContributorRegistryContract {
         signer: Address,
         proposal_id: u64,
     ) -> Result<(), ContributorError> {
+        Self::ensure_initialized(&env)?;
+        Self::require_governance_not_paused(&env)?;
         cancel(&env, signer, proposal_id)
     }
 
     pub fn expire_proposal(env: Env, proposal_id: u64) -> Result<(), ContributorError> {
+        // Expiry is a time-based cleanup; allow even under governance pause so
+        // stale proposals can always be cleared.
         expire(&env, proposal_id)
     }
 
@@ -195,6 +238,7 @@ impl ContributorRegistryContract {
         new_signers: Vec<Signer>,
         new_threshold: u32,
     ) -> Result<(), ContributorError> {
+        Self::require_governance_not_paused(&env)?;
         consume_approval(&env, &executor, proposal_id, &ProposalAction::SetAdmin)?;
 
         validate_config(&new_signers, new_threshold)?;
@@ -228,6 +272,7 @@ impl ContributorRegistryContract {
         github_handle: String,
     ) -> Result<(), ContributorError> {
         Self::ensure_initialized(&env)?;
+        Self::require_contribution_not_paused(&env)?;
         address.require_auth();
         Self::write_contributor(&env, &address, &github_handle)
     }
@@ -259,6 +304,7 @@ impl ContributorRegistryContract {
         signature: Bytes,
     ) -> Result<(), ContributorError> {
         Self::ensure_initialized(&env)?;
+        Self::require_contribution_not_paused(&env)?;
         if signature.is_empty() {
             return Err(ContributorError::InvalidSignature);
         }
@@ -497,6 +543,7 @@ impl ContributorRegistryContract {
         contributor_address: Address,
         badge: Badge,
     ) -> Result<(), ContributorError> {
+        Self::require_governance_not_paused(&env)?;
         consume_approval(&env, &executor, proposal_id, &ProposalAction::GrantBadge)?;
 
         // Ensure contributor exists
@@ -534,6 +581,7 @@ impl ContributorRegistryContract {
         contributor_address: Address,
         badge: Badge,
     ) -> Result<(), ContributorError> {
+        Self::require_governance_not_paused(&env)?;
         consume_approval(&env, &executor, proposal_id, &ProposalAction::RevokeBadge)?;
 
         // Ensure contributor exists
@@ -583,6 +631,7 @@ impl ContributorRegistryContract {
         points: u64,
         reason: String,
     ) -> Result<(), ContributorError> {
+        Self::require_governance_not_paused(&env)?;
         consume_approval(&env, &executor, proposal_id, &ProposalAction::ApplyPenalty)?;
 
         let mut contributor: ContributorData = env
@@ -645,6 +694,7 @@ impl ContributorRegistryContract {
         proposal_id: u64,
         contributor_address: Address,
     ) -> Result<(), ContributorError> {
+        Self::require_governance_not_paused(&env)?;
         consume_approval(
             &env,
             &executor,
@@ -695,6 +745,7 @@ impl ContributorRegistryContract {
         proposal_id: u64,
         contributor_address: Address,
     ) -> Result<(), ContributorError> {
+        Self::require_governance_not_paused(&env)?;
         consume_approval(
             &env,
             &executor,
@@ -744,6 +795,7 @@ impl ContributorRegistryContract {
         proposal_id: u64,
         contributor_address: Address,
     ) -> Result<(), ContributorError> {
+        Self::require_governance_not_paused(&env)?;
         consume_approval(
             &env,
             &executor,
@@ -788,6 +840,7 @@ impl ContributorRegistryContract {
         proposal_id: u64,
         new_wasm_hash: BytesN<32>,
     ) -> Result<(), ContributorError> {
+        Self::require_governance_not_paused(&env)?;
         consume_approval(&env, &executor, proposal_id, &ProposalAction::Upgrade)?;
 
         env.deployer()
@@ -808,6 +861,7 @@ impl ContributorRegistryContract {
         proposal_id: u64,
         new_admin: Address,
     ) -> Result<(), ContributorError> {
+        Self::require_governance_not_paused(&env)?;
         consume_approval(&env, &executor, proposal_id, &ProposalAction::SetAdmin)?;
 
         env.storage().instance().set(&DataKey::Admin, &new_admin);
@@ -822,6 +876,70 @@ impl ContributorRegistryContract {
         .publish(&env);
 
         Ok(())
+    }
+
+    // ── Granular pause controls ──────────────────────────────
+
+    /// Pause a specific scope.  Only a registered multisig signer may call this.
+    ///
+    /// Scopes:
+    ///  - `Contribution` — blocks `register_contributor` and
+    ///                     `register_contributor_with_sig`.
+    ///  - `Governance`   — blocks all multisig proposal creation/signing and
+    ///                     every admin-gated mutation (badge grants/revocations,
+    ///                     attestation lifecycle, reputation penalties, upgrade,
+    ///                     set_admin, set_multisig_config).
+    ///
+    /// Read-only queries are never blocked by any scope.
+    pub fn pause_scope(
+        env: Env,
+        caller: Address,
+        scope: ContribPauseScope,
+    ) -> Result<(), ContributorError> {
+        Self::ensure_initialized(&env)?;
+        caller.require_auth();
+        let config = get_config(&env)?;
+        find_signer(&config, &caller)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(scope.clone()), &true);
+        ScopePauseChangedEvent {
+            admin: caller,
+            scope: scope as u32,
+            paused: true,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Unpause a specific scope. Only a registered multisig signer may call this.
+    pub fn unpause_scope(
+        env: Env,
+        caller: Address,
+        scope: ContribPauseScope,
+    ) -> Result<(), ContributorError> {
+        Self::ensure_initialized(&env)?;
+        caller.require_auth();
+        let config = get_config(&env)?;
+        find_signer(&config, &caller)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(scope.clone()), &false);
+        ScopePauseChangedEvent {
+            admin: caller,
+            scope: scope as u32,
+            paused: false,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Read-only query: returns `true` when the given scope is currently paused.
+    /// Always callable regardless of pause state.
+    pub fn is_paused(env: Env, scope: ContribPauseScope) -> bool {
+        Self::is_scope_paused(&env, scope)
     }
 
     // ── Queries ──────────────────────────────────────────────
@@ -2140,5 +2258,264 @@ mod test {
             client.try_suspend_attestation(&s.alice, &pid, &unknown),
             Err(Ok(ContributorError::ContributorNotFound))
         );
+    }
+
+    // ── Granular pause scope tests ────────────────────────────
+
+    #[test]
+    fn test_pause_contribution_scope_blocks_register() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        // Pause contribution scope.
+        client.pause_scope(&s.alice, &ContribPauseScope::Contribution);
+        assert!(client.is_paused(&ContribPauseScope::Contribution));
+        // Governance scope is still open.
+        assert!(!client.is_paused(&ContribPauseScope::Governance));
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "blocked_dev");
+
+        assert_eq!(
+            client.try_register_contributor(&contributor, &handle),
+            Err(Ok(ContributorError::ContributionScopePaused))
+        );
+    }
+
+    #[test]
+    fn test_unpause_contribution_scope_restores_register() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        client.pause_scope(&s.alice, &ContribPauseScope::Contribution);
+        client.unpause_scope(&s.alice, &ContribPauseScope::Contribution);
+        assert!(!client.is_paused(&ContribPauseScope::Contribution));
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "restored_dev");
+        // Should succeed now.
+        client.register_contributor(&contributor, &handle);
+        let data = client.get_contributor(&contributor);
+        assert_eq!(data.github_handle, handle);
+    }
+
+    #[test]
+    fn test_pause_governance_scope_blocks_propose() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        client.pause_scope(&s.alice, &ContribPauseScope::Governance);
+        assert!(client.is_paused(&ContribPauseScope::Governance));
+
+        assert_eq!(
+            client.try_propose(&s.alice, &ProposalAction::GrantBadge),
+            Err(Ok(ContributorError::GovernanceScopePaused))
+        );
+    }
+
+    #[test]
+    fn test_pause_governance_scope_blocks_sign() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        // Create a proposal before pausing.
+        let pid = client.propose(&s.alice, &ProposalAction::GrantBadge);
+
+        client.pause_scope(&s.alice, &ContribPauseScope::Governance);
+
+        assert_eq!(
+            client.try_sign(&s.bob, &pid),
+            Err(Ok(ContributorError::GovernanceScopePaused))
+        );
+    }
+
+    #[test]
+    fn test_pause_governance_scope_blocks_cancel_proposal() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let pid = client.propose(&s.alice, &ProposalAction::GrantBadge);
+        client.pause_scope(&s.alice, &ContribPauseScope::Governance);
+
+        assert_eq!(
+            client.try_cancel_proposal(&s.alice, &pid),
+            Err(Ok(ContributorError::GovernanceScopePaused))
+        );
+    }
+
+    #[test]
+    fn test_expire_proposal_allowed_even_under_governance_pause() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let pid = client.propose(&s.alice, &ProposalAction::GrantBadge);
+
+        // Advance ledger past the TTL so the proposal expires.
+        s.env.ledger().set_timestamp(999_999_999);
+
+        client.pause_scope(&s.alice, &ContribPauseScope::Governance);
+
+        // expire_proposal is a time-based cleanup; it must work even when paused.
+        client.expire_proposal(&pid);
+    }
+
+    #[test]
+    fn test_pause_governance_scope_blocks_grant_badge() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "badgedev");
+        client.register_contributor(&contributor, &handle);
+
+        // Build a fully-approved proposal before pausing.
+        let pid = client.propose(&s.alice, &ProposalAction::GrantBadge);
+        client.sign(&s.bob, &pid);
+
+        // Now pause governance.
+        client.pause_scope(&s.alice, &ContribPauseScope::Governance);
+
+        assert_eq!(
+            client.try_grant_badge(&s.alice, &pid, &contributor, &Badge::EarlyAdopter),
+            Err(Ok(ContributorError::GovernanceScopePaused))
+        );
+    }
+
+    #[test]
+    fn test_pause_governance_scope_blocks_suspend_attestation() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "suspdev");
+        client.register_contributor(&contributor, &handle);
+
+        let pid = client.propose(&s.alice, &ProposalAction::SuspendAttestation);
+        client.sign(&s.bob, &pid);
+
+        client.pause_scope(&s.alice, &ContribPauseScope::Governance);
+
+        assert_eq!(
+            client.try_suspend_attestation(&s.alice, &pid, &contributor),
+            Err(Ok(ContributorError::GovernanceScopePaused))
+        );
+        // Status unchanged.
+        assert_eq!(
+            client.get_attestation_status(&contributor),
+            AttestationStatus::Active
+        );
+    }
+
+    #[test]
+    fn test_read_queries_always_available_under_all_scopes_paused() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "readdev");
+        client.register_contributor(&contributor, &handle);
+
+        // Pause all scopes.
+        client.pause_scope(&s.alice, &ContribPauseScope::Contribution);
+        client.pause_scope(&s.alice, &ContribPauseScope::Governance);
+
+        // All reads must succeed.
+        let _ = client.get_contributor(&contributor);
+        let _ = client.get_contributor_by_github(&handle);
+        let _ = client.get_attestation_status(&contributor);
+        let _ = client.get_reputation(&contributor);
+        let _ = client.get_multisig_config();
+        assert!(client.is_paused(&ContribPauseScope::Contribution));
+        assert!(client.is_paused(&ContribPauseScope::Governance));
+    }
+
+    #[test]
+    fn test_mixed_contribution_paused_governance_open() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "mixeddev");
+
+        // Register before pausing contribution.
+        client.register_contributor(&contributor, &handle);
+
+        // Pause only contribution.
+        client.pause_scope(&s.alice, &ContribPauseScope::Contribution);
+
+        // Governance still works: propose + sign + grant_badge.
+        let pid = client.propose(&s.alice, &ProposalAction::GrantBadge);
+        client.sign(&s.bob, &pid);
+        client.grant_badge(&s.alice, &pid, &contributor, &Badge::TopContributor);
+        let badges = client.get_badges(&contributor);
+        assert_eq!(badges.len(), 1);
+
+        // New registration is blocked.
+        let newcomer = Address::generate(&s.env);
+        let new_handle = soroban_sdk::String::from_str(&s.env, "newcomer");
+        assert_eq!(
+            client.try_register_contributor(&newcomer, &new_handle),
+            Err(Ok(ContributorError::ContributionScopePaused))
+        );
+    }
+
+    #[test]
+    fn test_mixed_governance_paused_contribution_open() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        // Pause only governance.
+        client.pause_scope(&s.alice, &ContribPauseScope::Governance);
+
+        // Registration (contribution scope) still works.
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "govpauseddev");
+        client.register_contributor(&contributor, &handle);
+        let data = client.get_contributor(&contributor);
+        assert_eq!(data.github_handle, handle);
+
+        // Governance op blocked.
+        assert_eq!(
+            client.try_propose(&s.alice, &ProposalAction::GrantBadge),
+            Err(Ok(ContributorError::GovernanceScopePaused))
+        );
+    }
+
+    #[test]
+    fn test_only_admin_can_pause_scope() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        let non_admin = Address::generate(&s.env);
+        assert_eq!(
+            client.try_pause_scope(&non_admin, &ContribPauseScope::Contribution),
+            Err(Ok(ContributorError::Unauthorized))
+        );
+        assert_eq!(
+            client.try_unpause_scope(&non_admin, &ContribPauseScope::Governance),
+            Err(Ok(ContributorError::Unauthorized))
+        );
+    }
+
+    #[test]
+    fn test_unpause_governance_restores_multisig_operations() {
+        let s = setup();
+        let client = ContributorRegistryContractClient::new(&s.env, &s.contract);
+
+        client.pause_scope(&s.alice, &ContribPauseScope::Governance);
+
+        // Unblock.
+        client.unpause_scope(&s.alice, &ContribPauseScope::Governance);
+        assert!(!client.is_paused(&ContribPauseScope::Governance));
+
+        // Proposal lifecycle works again.
+        let pid = client.propose(&s.alice, &ProposalAction::GrantBadge);
+        client.sign(&s.bob, &pid);
+
+        let contributor = Address::generate(&s.env);
+        let handle = soroban_sdk::String::from_str(&s.env, "govrestored");
+        client.register_contributor(&contributor, &handle);
+        client.grant_badge(&s.alice, &pid, &contributor, &Badge::BugHunter);
+        assert_eq!(client.get_badges(&contributor).len(), 1);
     }
 }

--- a/apps/onchain/contracts/contributor_registry/src/lib.rs
+++ b/apps/onchain/contracts/contributor_registry/src/lib.rs
@@ -903,7 +903,7 @@ impl ContributorRegistryContract {
         find_signer(&config, &caller)?;
         env.storage()
             .instance()
-            .set(&DataKey::ScopePaused(scope.clone()), &true);
+            .set(&DataKey::ScopePaused(scope), &true);
         ScopePauseChangedEvent {
             admin: caller,
             scope: scope as u32,
@@ -926,7 +926,7 @@ impl ContributorRegistryContract {
         find_signer(&config, &caller)?;
         env.storage()
             .instance()
-            .set(&DataKey::ScopePaused(scope.clone()), &false);
+            .set(&DataKey::ScopePaused(scope), &false);
         ScopePauseChangedEvent {
             admin: caller,
             scope: scope as u32,

--- a/apps/onchain/contracts/contributor_registry/src/lib.rs
+++ b/apps/onchain/contracts/contributor_registry/src/lib.rs
@@ -173,9 +173,10 @@ impl ContributorRegistryContract {
             .instance()
             .set(&DataKey::NextProposalId, &0u64);
         // All granular pause scopes start unpaused.
-        env.storage()
-            .instance()
-            .set(&DataKey::ScopePaused(ContribPauseScope::Contribution), &false);
+        env.storage().instance().set(
+            &DataKey::ScopePaused(ContribPauseScope::Contribution),
+            &false,
+        );
         env.storage()
             .instance()
             .set(&DataKey::ScopePaused(ContribPauseScope::Governance), &false);

--- a/apps/onchain/contracts/contributor_registry/src/storage.rs
+++ b/apps/onchain/contracts/contributor_registry/src/storage.rs
@@ -6,6 +6,26 @@ use soroban_sdk::{contracttype, Address, String};
 pub const LEDGER_THRESHOLD: u32 = 100_000;
 pub const LEDGER_BUMP: u32 = 518_400;
 
+/// Named pause scopes for the contributor registry.
+///
+/// - `Contribution` — blocks `register_contributor` and `gasless_register`.
+/// - `Governance`   — blocks all multisig operations: `propose`, `sign`,
+///                    `cancel_proposal`, `expire_proposal`,
+///                    `set_multisig_config`, and any multisig-gated admin
+///                    actions (`suspend_attestation`, `revoke_attestation`,
+///                    `restore_attestation`, `grant_badge`, `revoke_badge`,
+///                    `apply_reputation_penalty`, `update_contributor` via
+///                    admin path).
+///
+/// Read-only queries (`get_contributor`, `get_admin`, etc.) are never blocked.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ContribPauseScope {
+    Contribution = 1,
+    Governance = 2,
+}
+
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
@@ -26,6 +46,10 @@ pub enum DataKey {
     // ── Penalty keys ──────────────────────────────────────────
     /// Latest penalty record for a contributor (keyed by contributor address).
     ReputationPenalty(Address),
+
+    // ── Granular pause scope flags ────────────────────────────
+    /// Per-scope pause flag.  Key: `ScopePaused(ContribPauseScope)`.
+    ScopePaused(ContribPauseScope),
 }
 
 #[contracttype]

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_bob_carol_together_cannot_reach_threshold.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_bob_carol_together_cannot_reach_threshold.1.json
@@ -364,6 +364,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_cancel_blocks_execution.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_cancel_blocks_execution.1.json
@@ -386,6 +386,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_consume_approval_executes_after_threshold.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_consume_approval_executes_after_threshold.1.json
@@ -401,6 +401,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_contributor_entry_accessible_after_ledger_advance.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_contributor_entry_accessible_after_ledger_advance.1.json
@@ -191,6 +191,14 @@
                       "val": {
                         "u64": "0"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -369,6 +377,36 @@
                         },
                         "val": {
                           "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
                         }
                       }
                     ]

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_deregister_removes_all_keys.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_deregister_removes_all_keys.1.json
@@ -246,6 +246,14 @@
                       "val": {
                         "u64": "0"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -469,6 +477,36 @@
                         },
                         "val": {
                           "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
                         }
                       }
                     ]

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_double_initialize_fails.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_double_initialize_fails.1.json
@@ -225,6 +225,36 @@
                         "val": {
                           "u64": "0"
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_double_sign_rejected.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_double_sign_rejected.1.json
@@ -339,6 +339,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_execute_below_threshold_fails.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_execute_below_threshold_fails.1.json
@@ -339,6 +339,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_expire_after_ttl.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_expire_after_ttl.1.json
@@ -340,6 +340,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_expire_before_ttl_fails.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_expire_before_ttl_fails.1.json
@@ -339,6 +339,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_full_proposal_flow.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_full_proposal_flow.1.json
@@ -428,6 +428,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_gasless_registration_replay_is_rejected.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_gasless_registration_replay_is_rejected.1.json
@@ -199,6 +199,14 @@
                       "val": {
                         "u64": "0"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -422,6 +430,36 @@
                         },
                         "val": {
                           "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
                         }
                       }
                     ]

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_get_registration_nonce_query.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_get_registration_nonce_query.1.json
@@ -198,6 +198,14 @@
                       "val": {
                         "u64": "0"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -421,6 +429,36 @@
                         },
                         "val": {
                           "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
                         }
                       }
                     ]

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_initialize_stores_config.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_initialize_stores_config.1.json
@@ -225,6 +225,36 @@
                         "val": {
                           "u64": "0"
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_non_signer_cannot_sign.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_non_signer_cannot_sign.1.json
@@ -339,6 +339,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_propose_by_non_signer_fails.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_propose_by_non_signer_fails.1.json
@@ -225,6 +225,36 @@
                         "val": {
                           "u64": "0"
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_propose_counts_proposer_weight.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_propose_counts_proposer_weight.1.json
@@ -339,6 +339,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_register_contributor_with_sig_increments_nonce.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_register_contributor_with_sig_increments_nonce.1.json
@@ -199,6 +199,14 @@
                       "val": {
                         "u64": "0"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -422,6 +430,36 @@
                         },
                         "val": {
                           "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
                         }
                       }
                     ]

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_register_contributor_with_sig_rejects_empty_signature.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_register_contributor_with_sig_rejects_empty_signature.1.json
@@ -226,6 +226,36 @@
                         "val": {
                           "u64": "0"
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_replay_blocked_after_execution.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_replay_blocked_after_execution.1.json
@@ -365,6 +365,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_sign_reaches_threshold.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_sign_reaches_threshold.1.json
@@ -363,6 +363,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_single_signer_above_threshold_auto_approves.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_single_signer_above_threshold_auto_approves.1.json
@@ -299,6 +299,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_ttl_extended_after_read_write.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_ttl_extended_after_read_write.1.json
@@ -192,6 +192,14 @@
                       "val": {
                         "u64": "0"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -370,6 +378,36 @@
                         },
                         "val": {
                           "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
                         }
                       }
                     ]

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_update_reputation_requires_multisig.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_update_reputation_requires_multisig.1.json
@@ -191,6 +191,14 @@
                       "val": {
                         "u64": "0"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -369,6 +377,36 @@
                         },
                         "val": {
                           "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
                         }
                       }
                     ]

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_update_reputation_succeeds_with_approval.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_update_reputation_succeeds_with_approval.1.json
@@ -267,6 +267,14 @@
                       "val": {
                         "u64": "50"
                       }
+                    },
+                    {
+                      "key": {
+                        "symbol": "status"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
                     }
                   ]
                 }
@@ -536,6 +544,36 @@
                               }
                             }
                           ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
                         }
                       }
                     ]

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_upgrade_approved_before_execution.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_upgrade_approved_before_execution.1.json
@@ -365,6 +365,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_wrong_action_type_rejected.1.json
+++ b/apps/onchain/contracts/contributor_registry/test_snapshots/test/test_wrong_action_type_rejected.1.json
@@ -364,6 +364,36 @@
                             }
                           ]
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/matching_pool/proptest-regressions/tests/invariants.txt
+++ b/apps/onchain/contracts/matching_pool/proptest-regressions/tests/invariants.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 8b4b8f9455f37419a23d080dee1a0b950994afa39d502189d34d357a5c987951 # shrinks to amount = 1

--- a/apps/onchain/contracts/matching_pool/src/errors.rs
+++ b/apps/onchain/contracts/matching_pool/src/errors.rs
@@ -19,7 +19,14 @@ pub enum MatchingPoolError {
     RoundStillOpen = 13,
     MatchAlreadyDistributed = 14,
     InvalidRoundDates = 15,
+    /// Legacy: kept for backwards compatibility; granular codes preferred.
     ContractPaused = 16,
     Reentrancy = 17,
     ContributionCapExceeded = 18,
+    /// The Contribution scope (fund_pool / record_contribution) is paused.
+    ContributionScopePaused = 19,
+    /// The Payout scope (distribute_matching_funds) is paused.
+    PayoutScopePaused = 20,
+    /// The Governance scope (create_round, finalize_round, admin ops) is paused.
+    GovernanceScopePaused = 21,
 }

--- a/apps/onchain/contracts/matching_pool/src/events.rs
+++ b/apps/onchain/contracts/matching_pool/src/events.rs
@@ -79,3 +79,22 @@ pub struct RoundCapUpdatedEvent {
     pub round_id: u64,
     pub cap: i128,
 }
+
+/// Emitted whenever the pause state of a specific scope changes.
+///
+/// `scope` identifies which subsystem was affected:
+///  - `1` → Contribution (fund_pool, record_contribution)
+///  - `2` → Payout (distribute_matching_funds)
+///  - `3` → Governance (create_round, finalize_round, approve/remove project, …)
+///
+/// `paused` is the **new** state after the call.
+#[contractevent]
+pub struct ScopePauseChangedEvent {
+    #[topic]
+    pub admin: Address,
+    /// Numeric discriminant of `PauseScope`.
+    pub scope: u32,
+    /// `true` = scope is now paused; `false` = scope is now unpaused.
+    pub paused: bool,
+    pub timestamp: u64,
+}

--- a/apps/onchain/contracts/matching_pool/src/lib.rs
+++ b/apps/onchain/contracts/matching_pool/src/lib.rs
@@ -10,7 +10,7 @@ use math::{sqrt_scaled, unscale};
 use reentrancy_guard::{acquire as acquire_reentrancy, release as release_reentrancy};
 use soroban_sdk::token::TokenClient;
 use soroban_sdk::{contract, contractimpl, vec, Address, BytesN, Env, Symbol, Vec};
-use storage::{DataKey, RoundData};
+use storage::{DataKey, PauseScope, RoundData};
 
 #[contract]
 pub struct MatchingPoolContract;
@@ -30,6 +30,58 @@ impl MatchingPoolContract {
         Ok(())
     }
 
+    // ── Granular pause scope guards ──────────────────────────────────────────
+
+    /// Returns `true` when the given scope is paused, `false` otherwise.
+    ///
+    /// A scope is paused when either:
+    ///  1. Its own `ScopePaused(scope)` key is `true`, **or**
+    ///  2. The legacy global `Paused` key is `true` (backward-compat).
+    fn is_scope_paused(env: &Env, scope: PauseScope) -> bool {
+        let global: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        if global {
+            return true;
+        }
+        env.storage()
+            .instance()
+            .get(&DataKey::ScopePaused(scope))
+            .unwrap_or(false)
+    }
+
+    /// Guard for operations that write contributions or fund the pool.
+    fn require_contribution_not_paused(env: &Env) -> Result<(), MatchingPoolError> {
+        if Self::is_scope_paused(env, PauseScope::Contribution) {
+            Err(MatchingPoolError::ContributionScopePaused)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Guard for distribute_matching_funds.
+    fn require_payout_not_paused(env: &Env) -> Result<(), MatchingPoolError> {
+        if Self::is_scope_paused(env, PauseScope::Payout) {
+            Err(MatchingPoolError::PayoutScopePaused)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Guard for admin governance operations (round creation, finalization, …).
+    fn require_governance_not_paused(env: &Env) -> Result<(), MatchingPoolError> {
+        if Self::is_scope_paused(env, PauseScope::Governance) {
+            Err(MatchingPoolError::GovernanceScopePaused)
+        } else {
+            Ok(())
+        }
+    }
+
+    // Legacy helper kept so old callers still compile; internally it is
+    // replaced by the scoped helpers above.
+    #[allow(dead_code)]
     fn require_not_paused(env: &Env) -> Result<(), MatchingPoolError> {
         let paused: bool = env
             .storage()
@@ -59,7 +111,18 @@ impl MatchingPoolContract {
         }
         admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
+        // Legacy global-pause starts false.
         env.storage().instance().set(&DataKey::Paused, &false);
+        // All granular scopes start unpaused.
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(PauseScope::Contribution), &false);
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(PauseScope::Payout), &false);
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(PauseScope::Governance), &false);
         env.storage().instance().set(&DataKey::NextRoundId, &0u64);
         events::InitializedEvent { admin }.publish(&env);
         Ok(())
@@ -74,7 +137,7 @@ impl MatchingPoolContract {
         end_time: u64,
     ) -> Result<u64, MatchingPoolError> {
         Self::require_admin(&env, &admin)?;
-        Self::require_not_paused(&env)?;
+        Self::require_governance_not_paused(&env)?;
         if end_time <= start_time {
             return Err(MatchingPoolError::InvalidRoundDates);
         }
@@ -130,7 +193,7 @@ impl MatchingPoolContract {
         amount: i128,
     ) -> Result<(), MatchingPoolError> {
         Self::with_reentrancy_guard(&env, || {
-            Self::require_not_paused(&env)?;
+            Self::require_contribution_not_paused(&env)?;
             funder.require_auth();
             if amount <= 0 {
                 return Err(MatchingPoolError::InvalidAmount);
@@ -173,6 +236,7 @@ impl MatchingPoolContract {
         project_id: u64,
     ) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &admin)?;
+        Self::require_governance_not_paused(&env)?;
         let round: RoundData = env
             .storage()
             .persistent()
@@ -219,6 +283,7 @@ impl MatchingPoolContract {
         project_id: u64,
     ) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &admin)?;
+        Self::require_governance_not_paused(&env)?;
         let round: RoundData = env
             .storage()
             .persistent()
@@ -257,6 +322,7 @@ impl MatchingPoolContract {
         cap: i128,
     ) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &admin)?;
+        Self::require_governance_not_paused(&env)?;
         if cap < 0 {
             return Err(MatchingPoolError::InvalidAmount);
         }
@@ -287,7 +353,7 @@ impl MatchingPoolContract {
         contributor: Address,
         amount: i128,
     ) -> Result<(), MatchingPoolError> {
-        Self::require_not_paused(&env)?;
+        Self::require_contribution_not_paused(&env)?;
         if amount <= 0 {
             return Err(MatchingPoolError::InvalidAmount);
         }
@@ -367,7 +433,7 @@ impl MatchingPoolContract {
     ) -> Result<(), MatchingPoolError> {
         Self::with_reentrancy_guard(&env, || {
             Self::require_admin(&env, &admin)?;
-            Self::require_not_paused(&env)?;
+            Self::require_governance_not_paused(&env)?;
 
             let mut round: RoundData = env
                 .storage()
@@ -414,7 +480,7 @@ impl MatchingPoolContract {
     ) -> Result<i128, MatchingPoolError> {
         Self::with_reentrancy_guard(&env, || {
             Self::require_admin(&env, &admin)?;
-            Self::require_not_paused(&env)?;
+            Self::require_payout_not_paused(&env)?;
             let mut round: RoundData = env
                 .storage()
                 .persistent()
@@ -766,16 +832,70 @@ impl MatchingPoolContract {
             .ok_or(MatchingPoolError::NotInitialized)
     }
 
+    // ── Granular pause / unpause ─────────────────────────────────────────────
+
+    /// Pause a specific subsystem scope. Admin-only.
+    ///
+    /// Read-only queries are never affected by any scope.
+    pub fn pause_scope(
+        env: Env,
+        admin: Address,
+        scope: PauseScope,
+    ) -> Result<(), MatchingPoolError> {
+        Self::require_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(scope.clone()), &true);
+        events::ScopePauseChangedEvent {
+            admin,
+            scope: scope as u32,
+            paused: true,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Unpause a specific subsystem scope. Admin-only.
+    pub fn unpause_scope(
+        env: Env,
+        admin: Address,
+        scope: PauseScope,
+    ) -> Result<(), MatchingPoolError> {
+        Self::require_admin(&env, &admin)?;
+        env.storage()
+            .instance()
+            .set(&DataKey::ScopePaused(scope.clone()), &false);
+        events::ScopePauseChangedEvent {
+            admin,
+            scope: scope as u32,
+            paused: false,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
+        Ok(())
+    }
+
+    /// Legacy whole-contract pause (kept for backward-compatibility).
+    /// Prefer `pause_scope` for new integrations.
     pub fn pause(env: Env, admin: Address) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &admin)?;
         env.storage().instance().set(&DataKey::Paused, &true);
         Ok(())
     }
 
+    /// Legacy whole-contract unpause (kept for backward-compatibility).
+    /// Prefer `unpause_scope` for new integrations.
     pub fn unpause(env: Env, admin: Address) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &admin)?;
         env.storage().instance().set(&DataKey::Paused, &false);
         Ok(())
+    }
+
+    /// Read-only: returns `true` when a given scope is currently paused.
+    /// Never modifies state and is always callable regardless of pause status.
+    pub fn is_paused(env: Env, scope: PauseScope) -> bool {
+        Self::is_scope_paused(&env, scope)
     }
 
     pub fn set_admin(
@@ -784,6 +904,7 @@ impl MatchingPoolContract {
         new_admin: Address,
     ) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &current_admin)?;
+        Self::require_governance_not_paused(&env)?;
         env.storage().instance().set(&DataKey::Admin, &new_admin);
         Ok(())
     }
@@ -794,6 +915,7 @@ impl MatchingPoolContract {
         new_wasm_hash: BytesN<32>,
     ) -> Result<(), MatchingPoolError> {
         Self::require_admin(&env, &caller)?;
+        Self::require_governance_not_paused(&env)?;
         env.deployer().update_current_contract_wasm(new_wasm_hash);
         Ok(())
     }

--- a/apps/onchain/contracts/matching_pool/src/lib.rs
+++ b/apps/onchain/contracts/matching_pool/src/lib.rs
@@ -845,7 +845,7 @@ impl MatchingPoolContract {
         Self::require_admin(&env, &admin)?;
         env.storage()
             .instance()
-            .set(&DataKey::ScopePaused(scope.clone()), &true);
+            .set(&DataKey::ScopePaused(scope), &true);
         events::ScopePauseChangedEvent {
             admin,
             scope: scope as u32,
@@ -865,7 +865,7 @@ impl MatchingPoolContract {
         Self::require_admin(&env, &admin)?;
         env.storage()
             .instance()
-            .set(&DataKey::ScopePaused(scope.clone()), &false);
+            .set(&DataKey::ScopePaused(scope), &false);
         events::ScopePauseChangedEvent {
             admin,
             scope: scope as u32,

--- a/apps/onchain/contracts/matching_pool/src/storage.rs
+++ b/apps/onchain/contracts/matching_pool/src/storage.rs
@@ -1,11 +1,38 @@
 use soroban_sdk::{contracttype, Address, Symbol};
 
+/// Named pause scopes.
+///
+/// Each scope independently controls a category of state-changing operations:
+///
+/// - `Contribution` — blocks `record_contribution` and `fund_pool`.
+/// - `Payout`       — blocks `distribute_matching_funds`.
+/// - `Governance`   — blocks `create_round`, `finalize_round`, `approve_project`,
+///                    `remove_project`, `set_round_cap`, `set_admin`, and `upgrade`.
+///
+/// Read-only queries (`get_round`, `get_pool_balance`, `get_round_status`, …)
+/// are never blocked by any scope.
+///
+/// The legacy `Paused` key is kept for backward-compatibility; it is treated as
+/// "all scopes paused" by the old `require_not_paused` helper which is no longer
+/// called directly — callers use the scoped helpers instead.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum PauseScope {
+    Contribution = 1,
+    Payout = 2,
+    Governance = 3,
+}
+
 /// Storage keys for the matching pool contract
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
     Admin,
+    /// Legacy global-pause flag (kept for storage-layout compatibility).
     Paused,
+    /// Granular pause scope flags — one per `PauseScope` variant.
+    ScopePaused(PauseScope),
     NextRoundId,
     Round(u64),                           // round_id -> RoundData
     RoundPool(u64),                       // round_id -> i128 (pool balance)

--- a/apps/onchain/contracts/matching_pool/src/test.rs
+++ b/apps/onchain/contracts/matching_pool/src/test.rs
@@ -575,7 +575,7 @@ fn test_finalize_while_paused_fails() {
     env.ledger().set_timestamp(4000);
     assert_eq!(
         client.try_finalize_round(&admin, &round_id),
-        Err(Ok(MatchingPoolError::ContractPaused))
+        Err(Ok(MatchingPoolError::GovernanceScopePaused))
     );
 
     let round = client.get_round(&round_id);
@@ -675,7 +675,7 @@ fn test_distribute_while_paused_fails() {
     let owners = vec![&env, owner1.clone()];
     assert_eq!(
         client.try_distribute_matching_funds(&admin, &round_id, &owners),
-        Err(Ok(MatchingPoolError::ContractPaused))
+        Err(Ok(MatchingPoolError::PayoutScopePaused))
     );
 
     let round = client.get_round(&round_id);
@@ -1029,3 +1029,306 @@ fn test_qf_score_unaffected_by_cap_bookkeeping() {
     let score = client.get_project_qf_score(&round_id, &1u64);
     assert!(score > 0);
 }
+
+// ── Granular pause scopes ────────────────────────────────────────────────────
+
+#[test]
+fn test_pause_contribution_scope_blocks_fund_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(1000);
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R"),
+        &token.address,
+        &1000u64,
+        &2000u64,
+    );
+
+    let funder = Address::generate(&env);
+    token_admin.mint(&funder, &1000i128);
+
+    // Pause contribution scope only.
+    client.pause_scope(&admin, &crate::storage::PauseScope::Contribution);
+    assert!(client.is_paused(&crate::storage::PauseScope::Contribution));
+    assert!(!client.is_paused(&crate::storage::PauseScope::Payout));
+    assert!(!client.is_paused(&crate::storage::PauseScope::Governance));
+
+    assert_eq!(
+        client.try_fund_pool(&funder, &round_id, &100i128),
+        Err(Ok(MatchingPoolError::ContributionScopePaused))
+    );
+
+    // Governance ops still work while contribution is paused.
+    client.approve_project(&admin, &round_id, &42u64);
+
+    // Unpause restores fund_pool.
+    client.unpause_scope(&admin, &crate::storage::PauseScope::Contribution);
+    assert!(!client.is_paused(&crate::storage::PauseScope::Contribution));
+    client.fund_pool(&funder, &round_id, &100i128);
+    assert_eq!(client.get_pool_balance(&round_id), 100i128);
+}
+
+#[test]
+fn test_pause_contribution_scope_blocks_record_contribution() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+    client.approve_project(&admin, &round_id, &1u64);
+
+    client.pause_scope(&admin, &crate::storage::PauseScope::Contribution);
+    env.ledger().set_timestamp(1500);
+
+    let contributor = Address::generate(&env);
+    assert_eq!(
+        client.try_record_contribution(&round_id, &1u64, &contributor, &100i128),
+        Err(Ok(MatchingPoolError::ContributionScopePaused))
+    );
+
+    // After unpause the contribution goes through.
+    client.unpause_scope(&admin, &crate::storage::PauseScope::Contribution);
+    client.record_contribution(&round_id, &1u64, &contributor, &100i128);
+    assert_eq!(client.get_project_contributions(&round_id, &1u64), 100i128);
+}
+
+#[test]
+fn test_pause_payout_scope_blocks_distribute() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+    client.approve_project(&admin, &round_id, &1u64);
+
+    let funder = Address::generate(&env);
+    token_admin.mint(&funder, &10_000i128);
+    client.fund_pool(&funder, &round_id, &1_000i128);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &100i128);
+
+    // Round ends at 3000; finalize requires now > end_time.
+    env.ledger().set_timestamp(3001);
+    client.finalize_round(&admin, &round_id);
+
+    // Pause payout scope only.
+    client.pause_scope(&admin, &crate::storage::PauseScope::Payout);
+    assert!(client.is_paused(&crate::storage::PauseScope::Payout));
+    assert!(!client.is_paused(&crate::storage::PauseScope::Contribution));
+    assert!(!client.is_paused(&crate::storage::PauseScope::Governance));
+
+    let owner = Address::generate(&env);
+    assert_eq!(
+        client.try_distribute_matching_funds(&admin, &round_id, &vec![&env, owner.clone()]),
+        Err(Ok(MatchingPoolError::PayoutScopePaused))
+    );
+
+    // Unpause and distribution succeeds.
+    client.unpause_scope(&admin, &crate::storage::PauseScope::Payout);
+    let distributed = client.distribute_matching_funds(&admin, &round_id, &vec![&env, owner]);
+    assert!(distributed > 0);
+}
+
+#[test]
+fn test_pause_governance_scope_blocks_create_round() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    client.initialize(&admin);
+
+    client.pause_scope(&admin, &crate::storage::PauseScope::Governance);
+    assert!(client.is_paused(&crate::storage::PauseScope::Governance));
+
+    assert_eq!(
+        client.try_create_round(
+            &admin,
+            &symbol_short!("R"),
+            &token.address,
+            &1000u64,
+            &2000u64,
+        ),
+        Err(Ok(MatchingPoolError::GovernanceScopePaused))
+    );
+
+    // Contribution scope still open while governance is paused.
+    assert!(!client.is_paused(&crate::storage::PauseScope::Contribution));
+}
+
+#[test]
+fn test_pause_governance_scope_blocks_finalize_round() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+
+    // Round ends at 3000; advance past it.
+    env.ledger().set_timestamp(3001);
+    client.pause_scope(&admin, &crate::storage::PauseScope::Governance);
+
+    assert_eq!(
+        client.try_finalize_round(&admin, &round_id),
+        Err(Ok(MatchingPoolError::GovernanceScopePaused))
+    );
+
+    // After unpause finalize succeeds.
+    client.unpause_scope(&admin, &crate::storage::PauseScope::Governance);
+    client.finalize_round(&admin, &round_id);
+    assert!(client.get_round(&round_id).is_finalized);
+}
+
+#[test]
+fn test_pause_governance_scope_blocks_approve_and_remove_project() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+
+    client.pause_scope(&admin, &crate::storage::PauseScope::Governance);
+
+    assert_eq!(
+        client.try_approve_project(&admin, &round_id, &99u64),
+        Err(Ok(MatchingPoolError::GovernanceScopePaused))
+    );
+    assert_eq!(
+        client.try_remove_project(&admin, &round_id, &99u64),
+        Err(Ok(MatchingPoolError::GovernanceScopePaused))
+    );
+}
+
+#[test]
+fn test_pause_governance_scope_blocks_set_round_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+
+    client.pause_scope(&admin, &crate::storage::PauseScope::Governance);
+
+    assert_eq!(
+        client.try_set_round_cap(&admin, &round_id, &500i128),
+        Err(Ok(MatchingPoolError::GovernanceScopePaused))
+    );
+}
+
+#[test]
+fn test_read_queries_always_available_under_all_scopes_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, _) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+
+    // Pause all three scopes.
+    client.pause_scope(&admin, &crate::storage::PauseScope::Contribution);
+    client.pause_scope(&admin, &crate::storage::PauseScope::Payout);
+    client.pause_scope(&admin, &crate::storage::PauseScope::Governance);
+
+    // All read queries must succeed regardless.
+    let _round = client.get_round(&round_id);
+    let _bal = client.get_pool_balance(&round_id);
+    let _status = client.get_round_status(&round_id);
+    let _admin_addr = client.get_admin();
+    assert!(client.is_paused(&crate::storage::PauseScope::Contribution));
+    assert!(client.is_paused(&crate::storage::PauseScope::Payout));
+    assert!(client.is_paused(&crate::storage::PauseScope::Governance));
+}
+
+#[test]
+fn test_mixed_scopes_contribution_paused_payout_open() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    let round_id = setup_round(&env, &client, &admin, &token);
+    client.approve_project(&admin, &round_id, &1u64);
+
+    // Pre-fund before pausing contribution.
+    let funder = Address::generate(&env);
+    token_admin.mint(&funder, &10_000i128);
+    client.fund_pool(&funder, &round_id, &2_000i128);
+
+    let contributor = Address::generate(&env);
+    env.ledger().set_timestamp(1500);
+    client.record_contribution(&round_id, &1u64, &contributor, &200i128);
+
+    // Now pause contribution — payout and governance remain open.
+    client.pause_scope(&admin, &crate::storage::PauseScope::Contribution);
+
+    // Governance: finalize still works (round ends at 3000).
+    env.ledger().set_timestamp(3001);
+    client.finalize_round(&admin, &round_id);
+
+    // Payout: distribute still works.
+    let owner = Address::generate(&env);
+    let distributed =
+        client.distribute_matching_funds(&admin, &round_id, &vec![&env, owner]);
+    assert!(distributed > 0);
+
+    // Contribution: record is blocked.
+    let latecontributor = Address::generate(&env);
+    assert_eq!(
+        client.try_record_contribution(&round_id, &1u64, &latecontributor, &10i128),
+        Err(Ok(MatchingPoolError::ContributionScopePaused))
+    );
+}
+
+#[test]
+fn test_legacy_pause_still_blocks_all_write_operations() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, token, token_admin) = setup(&env);
+    client.initialize(&admin);
+
+    env.ledger().set_timestamp(1000);
+
+    // Use legacy global pause.
+    client.pause(&admin);
+
+    let funder = Address::generate(&env);
+    token_admin.mint(&funder, &1000i128);
+
+    // All three scope guards treat global pause as paused.
+    assert_eq!(
+        client.try_create_round(
+            &admin,
+            &symbol_short!("R"),
+            &token.address,
+            &1000u64,
+            &2000u64,
+        ),
+        Err(Ok(MatchingPoolError::GovernanceScopePaused))
+    );
+
+    client.unpause(&admin);
+
+    // After unpause create_round succeeds.
+    let round_id = client.create_round(
+        &admin,
+        &symbol_short!("R"),
+        &token.address,
+        &1000u64,
+        &2000u64,
+    );
+    assert_eq!(round_id, 0);
+}
+
+#[test]
+fn test_only_admin_can_pause_scope() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin, _, _) = setup(&env);
+    client.initialize(&admin);
+
+    let non_admin = Address::generate(&env);
+    assert_eq!(
+        client.try_pause_scope(&non_admin, &crate::storage::PauseScope::Contribution),
+        Err(Ok(MatchingPoolError::Unauthorized))
+    );
+    assert_eq!(
+        client.try_unpause_scope(&non_admin, &crate::storage::PauseScope::Contribution),
+        Err(Ok(MatchingPoolError::Unauthorized))
+    );
+}
+

--- a/apps/onchain/contracts/matching_pool/src/test.rs
+++ b/apps/onchain/contracts/matching_pool/src/test.rs
@@ -1262,8 +1262,7 @@ fn test_mixed_scopes_contribution_paused_payout_open() {
 
     // Payout: distribute still works.
     let owner = Address::generate(&env);
-    let distributed =
-        client.distribute_matching_funds(&admin, &round_id, &vec![&env, owner]);
+    let distributed = client.distribute_matching_funds(&admin, &round_id, &vec![&env, owner]);
     assert!(distributed > 0);
 
     // Contribution: record is blocked.
@@ -1331,4 +1330,3 @@ fn test_only_admin_can_pause_scope() {
         Err(Ok(MatchingPoolError::Unauthorized))
     );
 }
-

--- a/apps/onchain/contracts/matching_pool/src/tests/invariants.rs
+++ b/apps/onchain/contracts/matching_pool/src/tests/invariants.rs
@@ -158,7 +158,7 @@ mod open_phase {
             );
             prop_assert_eq!(
                 result,
-                Err(Ok(MatchingPoolError::ContractPaused)),
+                Err(Ok(MatchingPoolError::GovernanceScopePaused)),
                 "INV-6: paused contract must reject create_round"
             );
         }
@@ -297,7 +297,7 @@ mod contribute_phase {
             let result = client.try_fund_pool(&admin, &round_id, &amount);
             prop_assert_eq!(
                 result,
-                Err(Ok(MatchingPoolError::ContractPaused)),
+                Err(Ok(MatchingPoolError::ContributionScopePaused)),
                 "INV-6: paused contract must reject fund_pool"
             );
         }

--- a/apps/onchain/contracts/matching_pool/test_snapshots/test/test_approve_and_remove_project.1.json
+++ b/apps/onchain/contracts/matching_pool/test_snapshots/test/test_approve_and_remove_project.1.json
@@ -883,6 +883,51 @@
                         "val": {
                           "bool": false
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 3
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/matching_pool/test_snapshots/test/test_contribution_outside_window_fails.1.json
+++ b/apps/onchain/contracts/matching_pool/test_snapshots/test/test_contribution_outside_window_fails.1.json
@@ -824,6 +824,51 @@
                         "val": {
                           "bool": false
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 3
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/matching_pool/test_snapshots/test/test_create_round.1.json
+++ b/apps/onchain/contracts/matching_pool/test_snapshots/test/test_create_round.1.json
@@ -562,6 +562,51 @@
                         "val": {
                           "bool": false
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 3
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/matching_pool/test_snapshots/test/test_finalize_before_end_fails.1.json
+++ b/apps/onchain/contracts/matching_pool/test_snapshots/test/test_finalize_before_end_fails.1.json
@@ -562,6 +562,51 @@
                         "val": {
                           "bool": false
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 3
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/matching_pool/test_snapshots/test/test_full_distribution_flow.1.json
+++ b/apps/onchain/contracts/matching_pool/test_snapshots/test/test_full_distribution_flow.1.json
@@ -850,6 +850,261 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "ContributorRoundTotal"
+                },
+                {
+                  "u64": "0"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ContributorRoundTotal"
+                    },
+                    {
+                      "u64": "0"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOLZM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "25"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ContributorRoundTotal"
+                },
+                {
+                  "u64": "0"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ContributorRoundTotal"
+                    },
+                    {
+                      "u64": "0"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARQG5"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "25"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ContributorRoundTotal"
+                },
+                {
+                  "u64": "0"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ContributorRoundTotal"
+                    },
+                    {
+                      "u64": "0"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAATYON"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "25"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ContributorRoundTotal"
+                },
+                {
+                  "u64": "0"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAX5"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ContributorRoundTotal"
+                    },
+                    {
+                      "u64": "0"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVAX5"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "25"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "ContributorRoundTotal"
+                },
+                {
+                  "u64": "0"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ContributorRoundTotal"
+                    },
+                    {
+                      "u64": "0"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAXI7N"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "100"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
                   "symbol": "EligibleProject"
                 },
                 {
@@ -1931,6 +2186,51 @@
                           "vec": [
                             {
                               "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 3
                             }
                           ]
                         },

--- a/apps/onchain/contracts/matching_pool/test_snapshots/test/test_fund_pool.1.json
+++ b/apps/onchain/contracts/matching_pool/test_snapshots/test/test_fund_pool.1.json
@@ -672,6 +672,51 @@
                         "val": {
                           "bool": false
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 3
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/matching_pool/test_snapshots/test/test_invalid_round_dates.1.json
+++ b/apps/onchain/contracts/matching_pool/test_snapshots/test/test_invalid_round_dates.1.json
@@ -208,6 +208,51 @@
                         "val": {
                           "bool": false
                         }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 3
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
                       }
                     ]
                   }

--- a/apps/onchain/contracts/matching_pool/test_snapshots/test/test_qf_score_single_contributor.1.json
+++ b/apps/onchain/contracts/matching_pool/test_snapshots/test/test_qf_score_single_contributor.1.json
@@ -337,6 +337,57 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "ContributorRoundTotal"
+                },
+                {
+                  "u64": "0"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ContributorRoundTotal"
+                    },
+                    {
+                      "u64": "0"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "100"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
                   "symbol": "EligibleProject"
                 },
                 {
@@ -933,6 +984,51 @@
                           "vec": [
                             {
                               "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 3
                             }
                           ]
                         },

--- a/apps/onchain/contracts/matching_pool/test_snapshots/test/test_record_contribution.1.json
+++ b/apps/onchain/contracts/matching_pool/test_snapshots/test/test_record_contribution.1.json
@@ -338,6 +338,57 @@
             "key": {
               "vec": [
                 {
+                  "symbol": "ContributorRoundTotal"
+                },
+                {
+                  "u64": "0"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "ContributorRoundTotal"
+                    },
+                    {
+                      "u64": "0"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": "100000"
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "vec": [
+                {
                   "symbol": "EligibleProject"
                 },
                 {
@@ -934,6 +985,51 @@
                           "vec": [
                             {
                               "symbol": "Paused"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 1
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 2
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": false
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "ScopePaused"
+                            },
+                            {
+                              "u32": 3
                             }
                           ]
                         },


### PR DESCRIPTION
Closes #910

## Summary
Extends pause controls on both `matching_pool` and `contributor_registry` so
maintainers can halt only the affected subsystem rather than the entire protocol.

## Changes

### matching_pool
- PauseScope enum: Contribution | Payout | Governance
- DataKey::ScopePaused(PauseScope) stored per scope; all start false in initialize
- is_scope_paused() checks scope key OR legacy global Paused key (backward-compat)
- Scoped guards replace require_not_paused():
  - require_contribution_not_paused → fund_pool, record_contribution
  - require_payout_not_paused       → distribute_matching_funds
  - require_governance_not_paused   → create_round, finalize_round,
                                      approve/remove_project, set_cap
- pause_scope / unpause_scope public entry-points (admin-only)
- is_paused() read-only query, always callable
- ScopePauseChangedEvent emitted with scope discriminant and ledger timestamp
- New errors: ContributionScopePaused, PayoutScopePaused, GovernanceScopePaused

### contributor_registry
- ContribPauseScope enum: Contribution | Governance
- Same DataKey::ScopePaused pattern; scopes initialised in initialize
- require_contribution_not_paused → register_contributor, register_contributor_with_sig
- require_governance_not_paused   → propose, sign, cancel_proposal,
                                    set_multisig_config, grant_badge, revoke_badge,
                                    apply_reputation_penalty, suspend/revoke/restore_attestation,
                                    upgrade, set_admin
- expire_proposal exempt — time-based cleanup must always succeed
- pause_scope / unpause_scope authorised via find_signer() (any multisig signer)
- is_paused() read-only query always available
- ScopePauseChangedEvent emitted on every scope transition
- New errors: ContributionScopePaused, GovernanceScopePaused

## Acceptance criteria
- [x] Pause scopes separated by action domain
- [x] Read-only access available under all pause states
- [x] Events identify scope changes clearly
- [x] Tests cover mixed paused and unpaused flows

## Test results
contributor_registry: 68 tests (13 new) — all pass
matching_pool:        73 tests         — all pass
