### PR TITLE
feat: trusted caller verification for contract admin endpoints (#1080)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -118,6 +118,10 @@ SOROBAN_TIMESTAMP_TOLERANCE_MS=300000
 # Ledger sequence to start indexing from on first boot (0 = latest)
 SOROBAN_INDEXER_START_LEDGER=0
 
+# Contract admin trusted caller verification
+CONTRACT_ADMIN_API_KEY=contract-admin-api-key-here
+CONTRACT_ADMIN_TRUSTED_CALLER_ENABLED=false
+
 # Webhooks and bot
 WEBHOOK_SECRET=webhook-secret-here
 WEBHOOK_PROVIDERS='[{"name":"data-processing","algorithm":"hmac-sha256","secret":"webhook-secret-here","enabled":true}]'

--- a/apps/backend/src/common/decorators/access-control.decorators.ts
+++ b/apps/backend/src/common/decorators/access-control.decorators.ts
@@ -182,3 +182,18 @@ export const RequireIpAllowlist = (required = true) =>
     verificationType: 'ip_allowlist',
     required,
   });
+
+/**
+ * Require API key verification for trusted caller access.
+ * Checks the x-api-key header or Bearer token against configured keys.
+ *
+ * @example
+ * @RequireApiKey()
+ * @Post('admin/operation')
+ * performAdminOperation() { ... }
+ */
+export const RequireApiKey = (required = true) =>
+  RequireTrustedCaller({
+    verificationType: 'api_key',
+    required,
+  });

--- a/apps/backend/src/common/guards/contract-admin-trusted-caller.guard.ts
+++ b/apps/backend/src/common/guards/contract-admin-trusted-caller.guard.ts
@@ -1,0 +1,82 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  UnauthorizedException,
+  Logger,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { AccessControlService } from '../services/access-control.service';
+import { config } from '../../lib/config';
+
+/**
+ * Optional trusted-caller verification for contract admin routes.
+ *
+ * When CONTRACT_ADMIN_TRUSTED_CALLER_ENABLED is true, this guard requires
+ * a valid API key (via the x-api-key header) verified against the
+ * CONTRACT_ADMIN_API_KEY env var.  When disabled (default for dev/test),
+ * the guard is a no-op so the regular JWT + RBAC guards still apply.
+ *
+ * Intended to be stacked after JwtAuthGuard and ContractAdminGuard so that
+ * an attacker must bypass three layers:
+ *   1. Valid JWT session
+ *   2. ADMIN role
+ *   3. Trusted-caller API key (when enabled)
+ */
+@Injectable()
+export class ContractAdminTrustedCallerGuard implements CanActivate {
+  private readonly logger = new Logger(ContractAdminTrustedCallerGuard.name);
+
+  constructor(
+    private readonly accessControlService: AccessControlService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const enabled = config.contractAdmin.trustedCallerEnabled;
+
+    if (!enabled) {
+      this.logger.debug(
+        'Contract admin trusted caller verification is DISABLED ' +
+          '(set CONTRACT_ADMIN_TRUSTED_CALLER_ENABLED=true to enable).',
+      );
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest<Request>();
+    const headers = request.headers;
+
+    const apiKey =
+      (headers['x-api-key'] as string) ||
+      (headers['authorization'] as string)?.replace('Bearer ', '');
+
+    if (!apiKey) {
+      this.logger.warn(
+        'Trusted caller verification failed: no API key provided ' +
+          `for ${request.method} ${request.path}`,
+      );
+      throw new UnauthorizedException(
+        'API key required for contract admin operations',
+      );
+    }
+
+    const result = await this.accessControlService.verifyTrustedCaller({
+      verificationType: 'api_key',
+      verificationData: { apiKey },
+    });
+
+    if (!result.trusted) {
+      this.logger.warn(
+        `Trusted caller verification DENIED for ${request.method} ${request.path}: ${result.error}`,
+      );
+      throw new UnauthorizedException(
+        result.error || 'Invalid API key for contract admin operation',
+      );
+    }
+
+    this.logger.log(
+      `Trusted caller verification GRANTED for ${request.method} ${request.path}`,
+    );
+
+    return true;
+  }
+}

--- a/apps/backend/src/common/index.ts
+++ b/apps/backend/src/common/index.ts
@@ -40,6 +40,7 @@ export {
   RequirePortfolioWrite,
   RequireWebhookVerification,
   RequireIpAllowlist,
+  RequireApiKey,
   GetAccessContext,
   GetResource,
   GetPermissionResult,
@@ -52,5 +53,6 @@ export {
   type TrustedCallerMetadata,
 } from './decorators/access-control.decorators';
 export * from './guards/access-control.guard';
+export * from './guards/contract-admin-trusted-caller.guard';
 export * from './utils/access-control.utils';
 export * from './access-control.module';

--- a/apps/backend/src/common/services/access-control.service.spec.ts
+++ b/apps/backend/src/common/services/access-control.service.spec.ts
@@ -148,6 +148,69 @@ describe('AccessControlService', () => {
     });
   });
 
+  describe('verifyApiKey', () => {
+    it('should verify a valid API key', async () => {
+      configService.get.mockReturnValue('valid-admin-key');
+
+      const request = {
+        verificationType: VerificationType.API_KEY,
+        verificationData: {
+          apiKey: 'valid-admin-key',
+        },
+      };
+
+      const result = await service.verifyTrustedCaller(request);
+
+      expect(result.trusted).toBe(true);
+      expect(result.callerId).toBe('api-key:contract-admin');
+      expect(configService.get).toHaveBeenCalledWith('CONTRACT_ADMIN_API_KEY');
+    });
+
+    it('should reject an invalid API key', async () => {
+      configService.get.mockReturnValue('valid-admin-key');
+
+      const request = {
+        verificationType: VerificationType.API_KEY,
+        verificationData: {
+          apiKey: 'wrong-key',
+        },
+      };
+
+      const result = await service.verifyTrustedCaller(request);
+
+      expect(result.trusted).toBe(false);
+      expect(result.error).toBe('Invalid API key');
+    });
+
+    it('should reject when no API key is provided', async () => {
+      const request = {
+        verificationType: VerificationType.API_KEY,
+        verificationData: {},
+      };
+
+      const result = await service.verifyTrustedCaller(request);
+
+      expect(result.trusted).toBe(false);
+      expect(result.error).toBe('API key is required');
+    });
+
+    it('should reject when CONTRACT_ADMIN_API_KEY is not configured', async () => {
+      configService.get.mockReturnValue(undefined);
+
+      const request = {
+        verificationType: VerificationType.API_KEY,
+        verificationData: {
+          apiKey: 'any-key',
+        },
+      };
+
+      const result = await service.verifyTrustedCaller(request);
+
+      expect(result.trusted).toBe(false);
+      expect(result.error).toBe('API key verification not configured');
+    });
+  });
+
   describe('verifyTrustedCaller', () => {
     it('should verify webhook signatures', async () => {
       const mockVerificationResult = {

--- a/apps/backend/src/common/services/access-control.service.ts
+++ b/apps/backend/src/common/services/access-control.service.ts
@@ -439,16 +439,60 @@ export class AccessControlService implements IAccessControlService {
   }
 
   /**
-   * Verify API key (placeholder for future implementation)
+   * Verify API key against configured admin API keys.
+   * Checks the provided key against CONTRACT_ADMIN_API_KEY env var.
    */
   private verifyApiKey(
-    _verificationData: Record<string, any>,
+    verificationData: Record<string, any>,
   ): Promise<TrustedCallerResult> {
-    // Placeholder - implement based on your API key strategy
+    const providedKey = verificationData.apiKey as string | undefined;
+
+    if (!providedKey) {
+      return Promise.resolve({
+        trusted: false,
+        error: 'API key is required',
+      });
+    }
+
+    const configuredKey =
+      this.configService.get<string>('CONTRACT_ADMIN_API_KEY');
+
+    if (!configuredKey) {
+      this.logger.warn(
+        'CONTRACT_ADMIN_API_KEY not configured. API key verification cannot proceed.',
+      );
+      return Promise.resolve({
+        trusted: false,
+        error: 'API key verification not configured',
+      });
+    }
+
+    // Constant-time comparison to prevent timing attacks
+    const trusted = this.constantTimeCompare(providedKey, configuredKey);
+
     return Promise.resolve({
-      trusted: false,
-      error: 'API key verification not implemented',
+      trusted,
+      callerId: trusted ? 'api-key:contract-admin' : undefined,
+      error: trusted ? undefined : 'Invalid API key',
+      metadata: {
+        verificationMethod: 'api_key',
+      },
     });
+  }
+
+  /**
+   * Constant-time string comparison to prevent timing attacks
+   */
+  private constantTimeCompare(a: string, b: string): boolean {
+    if (a.length !== b.length) {
+      return false;
+    }
+
+    let result = 0;
+    for (let i = 0; i < a.length; i++) {
+      result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    }
+    return result === 0;
   }
 
   /**

--- a/apps/backend/src/contract-admin/contract-admin.module.ts
+++ b/apps/backend/src/contract-admin/contract-admin.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ContractAdminGuard } from '../common/guards/contract-admin.guard';
+import { ContractAdminTrustedCallerGuard } from '../common/guards/contract-admin-trusted-caller.guard';
 import { ContractAdminAuditService } from './contract-admin-audit.service';
 import { AdminBlockchainAuditLog } from '../admin-audit/entities/admin-blockchain-audit-log.entity';
 import { AccessControlModule } from '../common/access-control.module';
@@ -10,7 +11,15 @@ import { AccessControlModule } from '../common/access-control.module';
     TypeOrmModule.forFeature([AdminBlockchainAuditLog]),
     AccessControlModule,
   ],
-  providers: [ContractAdminGuard, ContractAdminAuditService],
-  exports: [ContractAdminGuard, ContractAdminAuditService],
+  providers: [
+    ContractAdminGuard,
+    ContractAdminTrustedCallerGuard,
+    ContractAdminAuditService,
+  ],
+  exports: [
+    ContractAdminGuard,
+    ContractAdminTrustedCallerGuard,
+    ContractAdminAuditService,
+  ],
 })
 export class ContractAdminModule {}

--- a/apps/backend/src/contracts/deployment-manifest.controller.ts
+++ b/apps/backend/src/contracts/deployment-manifest.controller.ts
@@ -23,6 +23,7 @@ import {
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { ContractAdminGuard } from '../common/guards/contract-admin.guard';
+import { ContractAdminTrustedCallerGuard } from '../common/guards/contract-admin-trusted-caller.guard';
 import { Roles } from '../auth/decorators/auth.decorators';
 import { UserRole } from '../users/entities/user.entity';
 import { DeploymentManifestService } from './deployment-manifest.service';
@@ -128,7 +129,7 @@ export class DeploymentManifestController {
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  @UseGuards(JwtAuthGuard, ContractAdminGuard)
+  @UseGuards(JwtAuthGuard, ContractAdminGuard, ContractAdminTrustedCallerGuard)
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({
@@ -154,7 +155,7 @@ export class DeploymentManifestController {
 
   @Put(':id')
   @HttpCode(HttpStatus.OK)
-  @UseGuards(JwtAuthGuard, ContractAdminGuard)
+  @UseGuards(JwtAuthGuard, ContractAdminGuard, ContractAdminTrustedCallerGuard)
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({
@@ -185,7 +186,7 @@ export class DeploymentManifestController {
 
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  @UseGuards(JwtAuthGuard, ContractAdminGuard)
+  @UseGuards(JwtAuthGuard, ContractAdminGuard, ContractAdminTrustedCallerGuard)
   @Roles(UserRole.ADMIN)
   @ApiBearerAuth('JWT-auth')
   @ApiOperation({

--- a/apps/backend/src/lib/config.ts
+++ b/apps/backend/src/lib/config.ts
@@ -448,6 +448,12 @@ const envSchema = z
     WEBHOOK_SECRET: z.string().trim().optional(),
     WEBHOOK_PROVIDERS: z.string().trim().optional(),
 
+    CONTRACT_ADMIN_API_KEY: z.string().trim().optional(),
+    CONTRACT_ADMIN_TRUSTED_CALLER_ENABLED: z.preprocess(
+      parseBoolean,
+      z.boolean().default(false),
+    ),
+
     SOROBAN_INGEST_SECRET: z.string().trim().optional(),
     SOROBAN_TIMESTAMP_TOLERANCE_MS: z.coerce
       .number()
@@ -860,6 +866,14 @@ const optionalSummary = [
     parsedEnv.WEBHOOK_PROVIDERS ? '[REDACTED]' : '(not set)',
   ],
   [
+    'CONTRACT_ADMIN_API_KEY',
+    parsedEnv.CONTRACT_ADMIN_API_KEY ? '[REDACTED]' : '(not set)',
+  ],
+  [
+    'CONTRACT_ADMIN_TRUSTED_CALLER_ENABLED',
+    String(parsedEnv.CONTRACT_ADMIN_TRUSTED_CALLER_ENABLED),
+  ],
+  [
     'SOROBAN_INGEST_SECRET',
     parsedEnv.SOROBAN_INGEST_SECRET ? '[REDACTED]' : '(not set)',
   ],
@@ -1037,6 +1051,10 @@ export const config = Object.freeze({
     webhookSecret: parsedEnv.WEBHOOK_SECRET,
     webhookProviders: parsedEnv.WEBHOOK_PROVIDERS,
     telegramBotToken: parsedEnv.TELEGRAM_BOT_TOKEN,
+    contractAdmin: parsedEnv.CONTRACT_ADMIN_API_KEY,
+  }),
+  contractAdmin: Object.freeze({
+    trustedCallerEnabled: parsedEnv.CONTRACT_ADMIN_TRUSTED_CALLER_ENABLED,
   }),
   soroban: Object.freeze({
     ingestSecret: parsedEnv.SOROBAN_INGEST_SECRET,


### PR DESCRIPTION
## Overview

This PR replaces placeholder trusted-caller checks with a real verification path for backend routes that proxy privileged contract operations. It implements API key validation, a dedicated guard with environment-based configurability, and applies it to the contract deployment manifest admin route group.

## Related Issue

Closes #1080

## Changes

### API Key Verification Engine

* **[FIX]** src/common/services/access-control.service.ts
  * Replaced the verifyApiKey() placeholder with a real implementation that validates against the CONTRACT_ADMIN_API_KEY environment variable
  * Uses constant-time comparison to prevent timing attacks
  * Provides clear error messages for missing key, invalid key, and unconfigured key

### Shared Guard Logic

* **[ADD]** src/common/guards/contract-admin-trusted-caller.guard.ts
  * New guard that enforces trusted caller verification via API key for contract admin routes
  * Configurable by environment - when CONTRACT_ADMIN_TRUSTED_CALLER_ENABLED=false (dev/test default), the guard is a no-op
  * When enabled in production, requires valid API key via x-api-key header
  * Uses the shared AccessControlService.verifyTrustedCaller() method

### Convenience Decorator

* **[ADD]** src/common/decorators/access-control.decorators.ts - Added RequireApiKey() decorator

### Applied to Contract Admin Routes

* **[MODIFY]** src/contracts/deployment-manifest.controller.ts - All admin endpoints now enforce trusted caller verification

### Environment Configuration

* **[ADD]** CONTRACT_ADMIN_API_KEY and CONTRACT_ADMIN_TRUSTED_CALLER_ENABLED env vars

### Tests

* **[ADD]** Tests for valid key, invalid key, missing key, and unconfigured key scenarios

## Acceptance Criteria

| Criteria | Status |
|----------|--------|
| Trusted caller verification enforced by shared guard/service logic | Uses AccessControlService.verifyTrustedCaller() via ContractAdminTrustedCallerGuard |
| Unauthorized callers fail consistently and safely | Throws UnauthorizedException; constant-time comparison prevents timing leaks |
| Verification behavior configurable by environment | CONTRACT_ADMIN_TRUSTED_CALLER_ENABLED env var with false default for dev/test |
| Covers at least one sensitive contract admin route group | Deployment manifest admin endpoints (POST/PUT/DELETE /v1/contracts/manifests) |
