### PR TITLE
fix(webapp): allow degraded rendering instead of full-page error on c…

### DIFF
--- a/apps/webapp/app/providers.tsx
+++ b/apps/webapp/app/providers.tsx
@@ -19,23 +19,31 @@ import {
 function ConfigGate({ children }: { children: ReactNode }) {
   const { config, status, error, retry } = useStellarConfig();
 
-  if (status === "error") {
-    return (
-      <ConfigErrorBanner
-        error={error}
-        onRetry={retry}
-        isRetrying={false}
-      />
-    );
-  }
-
   const isTestnet = config?.network === "testnet";
+  const isError = status === "error";
 
   // While loading we let the app render normally — individual components
   // can show their own skeletons. The config is available as soon as it resolves.
   return (
     <>
-      {isTestnet && (
+      {isError && (
+        <div
+          id="config-error-banner"
+          className="fixed top-0 left-0 right-0 z-[60] flex items-center justify-between gap-4 bg-red-500/10 border-b border-red-500/30 px-4 py-2 text-sm font-medium text-red-400 backdrop-blur-md"
+        >
+          <div className="flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-red-500 animate-pulse shrink-0" />
+            <span className="truncate">Degraded Mode: Unable to load Stellar configuration. Some features may be unavailable.</span>
+          </div>
+          <button
+            onClick={retry}
+            className="rounded bg-red-500/20 px-3 py-1 text-xs hover:bg-red-500/30 transition-colors shrink-0"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+      {isTestnet && !isError && (
         <div
           id="testnet-banner"
           className="fixed top-0 left-0 right-0 z-[60] flex items-center justify-center gap-2 bg-amber-500/10 border-b border-amber-500/30 py-1.5 text-xs font-medium text-amber-400 backdrop-blur-sm"


### PR DESCRIPTION
closes #1019

## Description
This PR improves the webapp experience when the backend configuration is degraded or fails to load. Instead of crashing the entire React tree and rendering a full-page error, the application now gracefully falls back to a degraded mode. 

**Changes made:**
- Refactored `ConfigGate` in `providers.tsx` to safely render `children` even when `status === "error"`.
- Replaced the blocking `<ConfigErrorBanner />` with an inline, sticky "Degraded Mode" banner at the top of the UI.
- The new banner maintains the existing visual language and still provides a prominent "Retry" action for the user.

**Acceptance Criteria Met:**
- [x] Critical routes show a clear degraded-mode message instead of silent failure.
- [x] Fallback surfaces preserve at least partial navigation and read-only browsing.
- [x] Configuration-loading errors do not crash the whole app tree.
- [x] Design stays aligned with existing visual language.

**Testing:**
- Locally simulated a failed response from `/api/config/stellar` and verified that the app renders the navigation routes without crashing while correctly displaying the degraded mode banner.
