### PR TITLE
Feat/production mobile wallet adapter

### DIFF
--- a/apps/mobile/app/(tabs)/projects/[id].tsx
+++ b/apps/mobile/app/(tabs)/projects/[id].tsx
@@ -285,7 +285,8 @@ export default function ProjectDetailScreen() {
           if (signResult.status === 'failed' || !signResult.txHash) {
             return {
               errorMessage:
-                signResult.error?.message ?? 'Wallet signing failed. Please check your wallet app and try again.',
+                signResult.error?.message ??
+                'Wallet signing failed. Please check your wallet app and try again.',
             };
           }
           finalTxHash = signResult.txHash;

--- a/apps/mobile/app/(tabs)/projects/[id].tsx
+++ b/apps/mobile/app/(tabs)/projects/[id].tsx
@@ -274,16 +274,19 @@ export default function ProjectDetailScreen() {
       if (response.success && response.data) {
         let finalTxHash = response.data.transactionHash;
 
-        // Use wallet signing if backend requests client signature (or mock for Testnet app flow)
-        if (response.data.unsignedXdr || !finalTxHash) {
-          const xdrToSign = response.data.unsignedXdr || 'AAAA_MOCK_XDR_FOR_TESTNET_DEMO';
-          const signResult = await signAndSubmitXdr(xdrToSign);
+        // Use wallet signing when the backend requests a client-side signature.
+        // The backend must provide a real unsigned XDR; there is no mock fallback.
+        if (response.data.unsignedXdr) {
+          const signResult = await signAndSubmitXdr(response.data.unsignedXdr);
 
           if (signResult.status === 'rejected') {
             return { errorMessage: 'Transaction signature rejected by the wallet.' };
           }
           if (signResult.status === 'failed' || !signResult.txHash) {
-            return { errorMessage: 'Wallet signing failed.' };
+            return {
+              errorMessage:
+                signResult.error?.message ?? 'Wallet signing failed. Please check your wallet app and try again.',
+            };
           }
           finalTxHash = signResult.txHash;
         }

--- a/apps/mobile/contexts/WalletContext.tsx
+++ b/apps/mobile/contexts/WalletContext.tsx
@@ -4,13 +4,19 @@ import { Alert } from 'react-native';
 import { useLocalization } from '../src/context';
 import { useEnvironment } from './EnvironmentContext';
 import { storage, WalletNetworkTag, sanitizePublicKey } from '../lib/storage';
+import { WalletError } from '../lib/wallet/errors';
+import { getDefaultWalletAdapter } from '../lib/wallet/registry';
+import {
+  WalletAdapter,
+  WalletSigningResult,
+  WalletSigningState,
+} from '../lib/wallet/types';
 
 export type WalletStatus =
   | 'disconnected'
   | 'connecting'
   | 'connected'
   | 'rejected'
-  | 'signing'
   | 'reconnecting'
   | 'network_mismatch'
   | 'restore_failed';
@@ -36,6 +42,10 @@ interface WalletContextType {
   isRestoring: boolean;
   /** Outcome of the most recent restore attempt, if any. */
   lastRestoreOutcome: WalletRestoreOutcome | null;
+  /** Independent signing lifecycle state. */
+  signingState: WalletSigningState;
+  /** Error from the most recent signing attempt, if any. */
+  lastSigningError: WalletError | null;
   /** Connect a wallet for the first time on the active network. */
   connect: () => Promise<void>;
   /**
@@ -55,12 +65,27 @@ interface WalletContextType {
   adoptLinkedAccount: (publicKey: string, network?: WalletNetworkTag) => Promise<void>;
   /** Disconnect the active wallet and clear the stored session pointer. */
   disconnect: () => void;
-  signAndSubmitXdr: (
-    xdr: string,
-  ) => Promise<{ status: 'success' | 'rejected' | 'failed'; txHash?: string }>;
+  /** Sign a base64 Stellar transaction envelope using the active wallet adapter. */
+  signAndSubmitXdr: (xdr: string) => Promise<WalletSigningResult>;
 }
 
 const WalletContext = createContext<WalletContextType | null>(null);
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void;
+  let reject: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve: resolve!, reject: reject! };
+}
 
 export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [publicKey, setPublicKey] = useState<string | null>(null);
@@ -70,12 +95,16 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const [isRestoring, setIsRestoring] = useState(true);
   const [lastRestoreOutcome, setLastRestoreOutcome] =
     useState<WalletRestoreOutcome | null>(null);
+  const [signingState, setSigningState] = useState<WalletSigningState>('idle');
+  const [lastSigningError, setLastSigningError] = useState<WalletError | null>(null);
   const { t } = useLocalization();
   const { environment, isInitialized: isEnvironmentReady } = useEnvironment();
   // Tracks whether a restore attempt has completed at least once so we
   // don't re-clear a freshly connected session when the environment
   // re-resolves during normal app use.
   const hasRestoredRef = useRef(false);
+  const activeAdapterRef = useRef<WalletAdapter | null>(null);
+  const pendingSignRef = useRef<Deferred<WalletSigningResult> | null>(null);
 
   // ------- Restore on launch ---------------------------------------------
   useEffect(() => {
@@ -179,10 +208,35 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       try {
         const parsedUrl = Linking.parse(url);
 
-        // Handle Albedo/Lobstr callbacks
         if (parsedUrl.path === 'wallet-callback') {
           const { status: cbStatus, tx_hash: txHash, pubkey } = parsedUrl.queryParams || {};
 
+          // If a signing flow is pending, the callback belongs to it.
+          if (pendingSignRef.current) {
+            const deferred = pendingSignRef.current;
+            pendingSignRef.current = null;
+
+            if (cbStatus === 'success' && typeof txHash === 'string' && txHash.length > 0) {
+              setSigningState('success');
+              deferred.resolve({ status: 'success', txHash });
+            } else if (cbStatus === 'rejected') {
+              setSigningState('rejected');
+              deferred.resolve({ status: 'rejected' });
+            } else {
+              const err = new WalletError(
+                'unknown',
+                cbStatus === 'failed'
+                  ? t('wallet.sign.error_failed')
+                  : t('wallet.sign.error_unknown'),
+              );
+              setSigningState('failed');
+              setLastSigningError(err);
+              deferred.resolve({ status: 'failed', error: err });
+            }
+            return;
+          }
+
+          // Otherwise this is a connection callback.
           if (status === 'connecting' || status === 'reconnecting') {
             if (pubkey) {
               const cleanKey = sanitizePublicKey(pubkey);
@@ -192,11 +246,9 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
               if (cleanKey) {
                 void storage.setActiveWalletPublicKey(cleanKey, environment);
               }
+            } else if (cbStatus === 'rejected') {
+              setStatus('rejected');
             }
-          } else if (cbStatus === 'success') {
-            setStatus('connected');
-          } else if (cbStatus === 'rejected') {
-            setStatus(publicKey ? 'connected' : 'rejected');
           }
         }
       } catch (e) {
@@ -230,115 +282,86 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     [environment],
   );
 
-  const showConnectionDialog = useCallback(
-    (intent: 'connect' | 'reconnect') => {
-      // SEP-0007 web+stellar:auth or pay
-      // Since proper SEP-0007 auth requires a backend challenge, we'll simulate a wallet connection via a generic deep link or fallback to a Mock Wallet for testnet.
+  const ensureAdapter = useCallback(async () => {
+    if (!activeAdapterRef.current) {
+      activeAdapterRef.current = await getDefaultWalletAdapter();
+    }
+    return activeAdapterRef.current;
+  }, []);
+
+  const promptAdapterAction = useCallback(
+    (
+      intent: 'connect' | 'reconnect',
+      action: () => Promise<void>,
+    ): Promise<void> => {
       const title = intent === 'reconnect' ? t('wallet.reconnect.title') : t('wallet.connect.title');
       const message =
         intent === 'reconnect'
           ? t('wallet.reconnect.message', { network: environment })
           : t('wallet.connect.message', { network: environment });
 
-      return new Promise<{ status: 'connected' | 'rejected' | 'failed'; pubkey: string | null }>(
-        (resolve) => {
-          Alert.alert(title, message, [
-            {
-              text: t('common.cancel'),
-              style: 'cancel',
-              onPress: () => {
-                // Only escalate to 'network_mismatch' if there actually was a
-                // stale session pointing at the wrong network. Otherwise the
-                // user just canceled from a generic "no session" state and
-                // should return to a neutral disconnected state.
-                setStatus((prev) =>
-                  intent === 'reconnect' && prev === 'network_mismatch'
-                    ? 'network_mismatch'
-                    : intent === 'reconnect'
-                      ? 'disconnected'
-                      : 'rejected',
-                );
-                resolve({ status: 'rejected', pubkey: null });
-              },
+      return new Promise<void>((resolve) => {
+        Alert.alert(title, message, [
+          {
+            text: t('common.cancel'),
+            style: 'cancel',
+            onPress: () => {
+              setStatus((prev) =>
+                intent === 'reconnect' && prev === 'network_mismatch'
+                  ? 'network_mismatch'
+                  : 'disconnected',
+              );
+              resolve();
             },
-            {
-              text: t('wallet.connect.mock_button'),
-              onPress: () => {
-                // Generate a mock testnet public key for testing
-                const mockKey =
-                  'G' +
-                  Array.from(
-                    { length: 55 },
-                    () => 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'[Math.floor(Math.random() * 32)],
-                  ).join('');
-                resolve({ status: 'connected', pubkey: mockKey });
-              },
-            },
-            {
-              text: t('wallet.connect.deep_link_button'),
-              onPress: async () => {
-                // Attempt to open a real wallet
-                const callbackUrl = encodeURIComponent(Linking.createURL('wallet-callback'));
-                const url = `web+stellar:pay?destination=GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF&amount=0&callback=${callbackUrl}`;
-                const canOpen = await Linking.canOpenURL(url);
-                if (canOpen) {
-                  await Linking.openURL(url);
-                  // Deep link flow resolves async via the callback listener.
-                  resolve({ status: 'connected', pubkey: null });
-                } else {
-                  Alert.alert(
-                    t('wallet.connect.no_wallet_title'),
-                    t('wallet.connect.no_wallet_message'),
-                  );
-                  setStatus('disconnected');
-                  resolve({ status: 'failed', pubkey: null });
+          },
+          {
+            text: t('wallet.connect.continue_button'),
+            onPress: () => {
+              void (async () => {
+                try {
+                  await action();
+                } catch (error) {
+                  console.error(`${intent} action failed:`, error);
+                  setStatus('rejected');
+                } finally {
+                  resolve();
                 }
-              },
+              })();
             },
-          ]);
-        },
-      );
+          },
+        ]);
+      });
     },
     [environment, t],
   );
 
+  const performConnect = useCallback(
+    async (intent: 'connect' | 'reconnect') => {
+      const adapter = await ensureAdapter();
+      const result = await adapter.connect();
+
+      if (result.status === 'connected' && result.pubkey) {
+        await finalizeConnection(result.pubkey);
+      } else if (result.status === 'connected') {
+        // Deep-link flow: the wallet app will call back with the public key.
+      } else {
+        const err = result.error ?? new WalletError('unknown', t('wallet.connect.error_message'));
+        setStatus('rejected');
+        Alert.alert(t('wallet.connect.error_title'), t(`wallet.error.${err.code}`));
+      }
+    },
+    [ensureAdapter, finalizeConnection, t],
+  );
+
   const connect = useCallback(async () => {
     setStatus('connecting');
-    try {
-      const result = await showConnectionDialog('connect');
-      if (result.status === 'connected' && result.pubkey) {
-        await finalizeConnection(result.pubkey);
-      } else if (result.status === 'connected') {
-        // Deep link path: status will flip to 'connected' when callback fires.
-        setStatus('connecting');
-      }
-    } catch (error) {
-      console.error('connect failed:', error);
-      setStatus('rejected');
-    }
-  }, [finalizeConnection, showConnectionDialog]);
+    await promptAdapterAction('connect', () => performConnect('connect'));
+  }, [performConnect, promptAdapterAction]);
 
   const reconnect = useCallback(async () => {
-    const priorMismatch = status === 'network_mismatch';
     setStatus('reconnecting');
-    try {
-      const result = await showConnectionDialog('reconnect');
-      if (result.status === 'connected' && result.pubkey) {
-        await finalizeConnection(result.pubkey);
-      } else if (result.status === 'connected') {
-        setStatus('reconnecting');
-      } else if (priorMismatch) {
-        // Only keep the mismatch state if the user got there via a real
-        // mismatch. Otherwise restore a neutral disconnected state.
-        setStatus('network_mismatch');
-      } else {
-        setStatus('disconnected');
-      }
-    } catch (error) {
-      console.error('reconnect failed:', error);
-      setStatus(priorMismatch ? 'network_mismatch' : 'disconnected');
-    }
-  }, [finalizeConnection, showConnectionDialog, status]);
+    await promptAdapterAction('reconnect', () => performConnect('reconnect'));
+  }, [performConnect, promptAdapterAction]);
 
   const adoptLinkedAccount = useCallback(
     async (publicKey: string, network: WalletNetworkTag | null = null): Promise<void> => {
@@ -366,6 +389,8 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     setLastConnectedNetwork(null);
     setStatus('disconnected');
     setLastRestoreOutcome('no_session');
+    setSigningState('idle');
+    setLastSigningError(null);
     try {
       await storage.clearActiveWalletSession();
     } catch (error) {
@@ -374,57 +399,66 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }, []);
 
   const signAndSubmitXdr = useCallback(
-    async (
-      xdr: string,
-    ): Promise<{ status: 'success' | 'rejected' | 'failed'; txHash?: string }> => {
-      setStatus('signing');
+    async (xdr: string): Promise<WalletSigningResult> => {
+      if (signingState === 'signing' || signingState === 'pending') {
+        return {
+          status: 'failed',
+          error: new WalletError(
+            'not_available',
+            t('wallet.sign.error_concurrent'),
+          ),
+        };
+      }
 
-      return new Promise((resolve) => {
-        Alert.alert(t('wallet.sign.title'), t('wallet.sign.message'), [
-          {
-            text: t('wallet.sign.reject'),
-            style: 'cancel',
-            onPress: () => {
-              setStatus('connected');
-              resolve({ status: 'rejected' });
-            },
-          },
-          {
-            text: t('wallet.sign.sign_mock'),
-            onPress: () => {
-              // Simulate network delay
-              setTimeout(() => {
-                setStatus('connected');
-                // Generate a fake transaction hash
-                const mockHash = Array.from(
-                  { length: 64 },
-                  () => '0123456789abcdef'[Math.floor(Math.random() * 16)],
-                ).join('');
-                resolve({ status: 'success', txHash: mockHash });
-              }, 1500);
-            },
-          },
-          {
-            text: t('wallet.sign.open_app'),
-            onPress: async () => {
-              const callbackUrl = encodeURIComponent(Linking.createURL('wallet-callback'));
-              const url = `web+stellar:tx?xdr=${encodeURIComponent(xdr)}&callback=${callbackUrl}`;
-              const canOpen = await Linking.canOpenURL(url);
-              if (canOpen) {
-                await Linking.openURL(url);
-                setStatus('connected');
-                resolve({ status: 'success', txHash: 'pending_via_deeplink' });
-              } else {
-                Alert.alert(t('wallet.sign.error_title'), t('wallet.sign.error_no_wallet'));
-                setStatus('connected');
-                resolve({ status: 'failed' });
-              }
-            },
-          },
-        ]);
-      });
+      const adapter = await ensureAdapter();
+
+      setSigningState('signing');
+      setLastSigningError(null);
+
+      try {
+        const result = await adapter.signXdr(xdr);
+
+        if (result.status === 'pending') {
+          setSigningState('pending');
+          const deferred = createDeferred<WalletSigningResult>();
+          pendingSignRef.current = deferred;
+
+          // Defensive timeout: if the wallet app never calls back, fail open
+          // after five minutes so the UI is not stuck forever.
+          const timeoutId = setTimeout(() => {
+            if (pendingSignRef.current === deferred) {
+              pendingSignRef.current = null;
+              const err = new WalletError(
+                'unknown',
+                t('wallet.sign.error_timeout'),
+              );
+              setSigningState('failed');
+              setLastSigningError(err);
+              deferred.resolve({ status: 'failed', error: err });
+            }
+          }, 5 * 60 * 1000);
+
+          const finalResult = await deferred.promise;
+          clearTimeout(timeoutId);
+          return finalResult;
+        }
+
+        setSigningState(result.status === 'success' ? 'success' : result.status);
+        if (result.error) {
+          setLastSigningError(result.error);
+        }
+        return result;
+      } catch (error) {
+        const err =
+          error instanceof WalletError
+            ? error
+            : new WalletError('unknown', t('wallet.sign.error_unknown'), error);
+        setSigningState('failed');
+        setLastSigningError(err);
+        return { status: 'failed', error: err };
+      }
     },
-    [t],
+    [ensureAdapter, signingState, t],
   );
 
   return (
@@ -435,6 +469,8 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         lastConnectedNetwork,
         isRestoring,
         lastRestoreOutcome,
+        signingState,
+        lastSigningError,
         connect,
         reconnect,
         adoptLinkedAccount,

--- a/apps/mobile/contexts/WalletContext.tsx
+++ b/apps/mobile/contexts/WalletContext.tsx
@@ -6,11 +6,7 @@ import { useEnvironment } from './EnvironmentContext';
 import { storage, WalletNetworkTag, sanitizePublicKey } from '../lib/storage';
 import { WalletError } from '../lib/wallet/errors';
 import { getDefaultWalletAdapter } from '../lib/wallet/registry';
-import {
-  WalletAdapter,
-  WalletSigningResult,
-  WalletSigningState,
-} from '../lib/wallet/types';
+import { WalletAdapter, WalletSigningResult, WalletSigningState } from '../lib/wallet/types';
 
 export type WalletStatus =
   | 'disconnected'
@@ -90,11 +86,9 @@ function createDeferred<T>(): Deferred<T> {
 export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [publicKey, setPublicKey] = useState<string | null>(null);
   const [status, setStatus] = useState<WalletStatus>('disconnected');
-  const [lastConnectedNetwork, setLastConnectedNetwork] =
-    useState<WalletNetworkTag | null>(null);
+  const [lastConnectedNetwork, setLastConnectedNetwork] = useState<WalletNetworkTag | null>(null);
   const [isRestoring, setIsRestoring] = useState(true);
-  const [lastRestoreOutcome, setLastRestoreOutcome] =
-    useState<WalletRestoreOutcome | null>(null);
+  const [lastRestoreOutcome, setLastRestoreOutcome] = useState<WalletRestoreOutcome | null>(null);
   const [signingState, setSigningState] = useState<WalletSigningState>('idle');
   const [lastSigningError, setLastSigningError] = useState<WalletError | null>(null);
   const { t } = useLocalization();
@@ -290,11 +284,9 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }, []);
 
   const promptAdapterAction = useCallback(
-    (
-      intent: 'connect' | 'reconnect',
-      action: () => Promise<void>,
-    ): Promise<void> => {
-      const title = intent === 'reconnect' ? t('wallet.reconnect.title') : t('wallet.connect.title');
+    (intent: 'connect' | 'reconnect', action: () => Promise<void>): Promise<void> => {
+      const title =
+        intent === 'reconnect' ? t('wallet.reconnect.title') : t('wallet.connect.title');
       const message =
         intent === 'reconnect'
           ? t('wallet.reconnect.message', { network: environment })
@@ -403,10 +395,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       if (signingState === 'signing' || signingState === 'pending') {
         return {
           status: 'failed',
-          error: new WalletError(
-            'not_available',
-            t('wallet.sign.error_concurrent'),
-          ),
+          error: new WalletError('not_available', t('wallet.sign.error_concurrent')),
         };
       }
 
@@ -425,18 +414,18 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
           // Defensive timeout: if the wallet app never calls back, fail open
           // after five minutes so the UI is not stuck forever.
-          const timeoutId = setTimeout(() => {
-            if (pendingSignRef.current === deferred) {
-              pendingSignRef.current = null;
-              const err = new WalletError(
-                'unknown',
-                t('wallet.sign.error_timeout'),
-              );
-              setSigningState('failed');
-              setLastSigningError(err);
-              deferred.resolve({ status: 'failed', error: err });
-            }
-          }, 5 * 60 * 1000);
+          const timeoutId = setTimeout(
+            () => {
+              if (pendingSignRef.current === deferred) {
+                pendingSignRef.current = null;
+                const err = new WalletError('unknown', t('wallet.sign.error_timeout'));
+                setSigningState('failed');
+                setLastSigningError(err);
+                deferred.resolve({ status: 'failed', error: err });
+              }
+            },
+            5 * 60 * 1000,
+          );
 
           const finalResult = await deferred.promise;
           clearTimeout(timeoutId);

--- a/apps/mobile/lib/wallet/adapters/mock-adapter.ts
+++ b/apps/mobile/lib/wallet/adapters/mock-adapter.ts
@@ -1,22 +1,16 @@
 import { WalletError } from '../errors';
-import {
-  WalletAdapter,
-  WalletConnectionResult,
-  WalletSigningResult,
-} from '../types';
+import { WalletAdapter, WalletConnectionResult, WalletSigningResult } from '../types';
 
 /**
  * Deterministic mock public key used across dev flows so tests and demos
  * have a stable address without exposing real credentials.
  */
-const MOCK_PUBLIC_KEY =
-  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const MOCK_PUBLIC_KEY = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
 
 function generateMockTxHash(): string {
-  return Array.from(
-    { length: 64 },
-    () => '0123456789abcdef'[Math.floor(Math.random() * 16)],
-  ).join('');
+  return Array.from({ length: 64 }, () => '0123456789abcdef'[Math.floor(Math.random() * 16)]).join(
+    '',
+  );
 }
 
 /**
@@ -39,10 +33,7 @@ export class MockWalletAdapter implements WalletAdapter {
     if (!this.enabled) {
       return {
         status: 'failed',
-        error: new WalletError(
-          'not_available',
-          'Mock wallet is disabled in production builds.',
-        ),
+        error: new WalletError('not_available', 'Mock wallet is disabled in production builds.'),
       };
     }
 
@@ -53,10 +44,7 @@ export class MockWalletAdapter implements WalletAdapter {
     if (!this.enabled) {
       return {
         status: 'failed',
-        error: new WalletError(
-          'not_available',
-          'Mock wallet is disabled in production builds.',
-        ),
+        error: new WalletError('not_available', 'Mock wallet is disabled in production builds.'),
       };
     }
 

--- a/apps/mobile/lib/wallet/adapters/mock-adapter.ts
+++ b/apps/mobile/lib/wallet/adapters/mock-adapter.ts
@@ -1,0 +1,66 @@
+import { WalletError } from '../errors';
+import {
+  WalletAdapter,
+  WalletConnectionResult,
+  WalletSigningResult,
+} from '../types';
+
+/**
+ * Deterministic mock public key used across dev flows so tests and demos
+ * have a stable address without exposing real credentials.
+ */
+const MOCK_PUBLIC_KEY =
+  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+function generateMockTxHash(): string {
+  return Array.from(
+    { length: 64 },
+    () => '0123456789abcdef'[Math.floor(Math.random() * 16)],
+  ).join('');
+}
+
+/**
+ * Mock wallet adapter for local development and CI.
+ *
+ * This adapter is gated by `enabled`; the registry only enables it in
+ * development builds. It must never become the default in production.
+ */
+export class MockWalletAdapter implements WalletAdapter {
+  readonly id = 'mock';
+  readonly name = 'Mock Stellar Wallet';
+
+  constructor(private readonly enabled: boolean) {}
+
+  isAvailable(): boolean {
+    return this.enabled;
+  }
+
+  async connect(): Promise<WalletConnectionResult> {
+    if (!this.enabled) {
+      return {
+        status: 'failed',
+        error: new WalletError(
+          'not_available',
+          'Mock wallet is disabled in production builds.',
+        ),
+      };
+    }
+
+    return { status: 'connected', pubkey: MOCK_PUBLIC_KEY };
+  }
+
+  async signXdr(_xdr: string): Promise<WalletSigningResult> {
+    if (!this.enabled) {
+      return {
+        status: 'failed',
+        error: new WalletError(
+          'not_available',
+          'Mock wallet is disabled in production builds.',
+        ),
+      };
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 800));
+    return { status: 'success', txHash: generateMockTxHash() };
+  }
+}

--- a/apps/mobile/lib/wallet/adapters/sep7-adapter.ts
+++ b/apps/mobile/lib/wallet/adapters/sep7-adapter.ts
@@ -1,10 +1,6 @@
 import * as Linking from 'expo-linking';
 import { WalletError } from '../errors';
-import {
-  WalletAdapter,
-  WalletConnectionResult,
-  WalletSigningResult,
-} from '../types';
+import { WalletAdapter, WalletConnectionResult, WalletSigningResult } from '../types';
 
 /**
  * SEP-0007 deep-link wallet adapter.
@@ -26,7 +22,9 @@ export class Sep7WalletAdapter implements WalletAdapter {
 
   async isAvailable(): Promise<boolean> {
     try {
-      return await Linking.canOpenURL('web+stellar:pay?destination=GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF&amount=0');
+      return await Linking.canOpenURL(
+        'web+stellar:pay?destination=GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF&amount=0',
+      );
     } catch {
       return false;
     }

--- a/apps/mobile/lib/wallet/adapters/sep7-adapter.ts
+++ b/apps/mobile/lib/wallet/adapters/sep7-adapter.ts
@@ -1,0 +1,87 @@
+import * as Linking from 'expo-linking';
+import { WalletError } from '../errors';
+import {
+  WalletAdapter,
+  WalletConnectionResult,
+  WalletSigningResult,
+} from '../types';
+
+/**
+ * SEP-0007 deep-link wallet adapter.
+ *
+ * Uses `web+stellar:` URIs to delegate transaction signing to an installed
+ * Stellar wallet (e.g. Lobstr, Albedo). This is the production signing path
+ * for the mobile app because it does not require bundling the Stellar SDK or
+ * holding private keys in-app.
+ */
+export class Sep7WalletAdapter implements WalletAdapter {
+  readonly id = 'sep7';
+  readonly name = 'Stellar Wallet (SEP-0007)';
+
+  private callbackUrl: string;
+
+  constructor(callbackScheme = 'wallet-callback') {
+    this.callbackUrl = encodeURIComponent(Linking.createURL(callbackScheme));
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      return await Linking.canOpenURL('web+stellar:pay?destination=GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF&amount=0');
+    } catch {
+      return false;
+    }
+  }
+
+  async connect(): Promise<WalletConnectionResult> {
+    // SEP-0007 does not define an auth URI, so we use a minimal pay URI as a
+    // wallet-discovery handshake. The actual public key is received via the
+    // deep-link callback in the host context.
+    const url = `web+stellar:pay?destination=GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF&amount=0&callback=${this.callbackUrl}`;
+
+    const canOpen = await this.isAvailable();
+    if (!canOpen) {
+      return {
+        status: 'failed',
+        error: new WalletError(
+          'missing_wallet',
+          'No Stellar wallet app installed to handle the connection request.',
+        ),
+      };
+    }
+
+    await Linking.openURL(url);
+    return { status: 'connected' };
+  }
+
+  async signXdr(xdr: string): Promise<WalletSigningResult> {
+    const url = `web+stellar:tx?xdr=${encodeURIComponent(xdr)}&callback=${this.callbackUrl}`;
+
+    const canOpen = await this.isAvailable();
+    if (!canOpen) {
+      return {
+        status: 'failed',
+        error: new WalletError(
+          'missing_wallet',
+          'No Stellar wallet app installed to handle the signature request.',
+        ),
+      };
+    }
+
+    try {
+      await Linking.openURL(url);
+      // The signed result (or rejection) arrives asynchronously through the
+      // deep-link callback. The context layer is responsible for correlating
+      // the callback with the pending signing promise.
+      return { status: 'pending' };
+    } catch (error) {
+      return {
+        status: 'failed',
+        error: new WalletError(
+          'unsupported_device',
+          'Could not open the wallet app on this device.',
+          error,
+        ),
+      };
+    }
+  }
+}

--- a/apps/mobile/lib/wallet/errors.ts
+++ b/apps/mobile/lib/wallet/errors.ts
@@ -1,0 +1,26 @@
+/**
+ * Wallet error codes surfaced by the adapter layer.
+ *
+ * These are intentionally coarse-grained: the UI maps each code to a
+ * user-friendly message. Callers should avoid parsing error messages.
+ */
+export type WalletErrorCode =
+  | 'not_available'
+  | 'missing_wallet'
+  | 'unsupported_device'
+  | 'rejected'
+  | 'unknown';
+
+/**
+ * Typed error raised by wallet adapters.
+ */
+export class WalletError extends Error {
+  constructor(
+    public readonly code: WalletErrorCode,
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'WalletError';
+  }
+}

--- a/apps/mobile/lib/wallet/registry.ts
+++ b/apps/mobile/lib/wallet/registry.ts
@@ -11,9 +11,7 @@ import { WalletAdapter } from './types';
  * included in development builds and is intentionally last so it cannot be
  * accidentally preferred in production.
  */
-export function createWalletAdapterRegistry(
-  isDevelopment = config.isDevelopment,
-): WalletAdapter[] {
+export function createWalletAdapterRegistry(isDevelopment = config.isDevelopment): WalletAdapter[] {
   const adapters: WalletAdapter[] = [new Sep7WalletAdapter()];
 
   if (isDevelopment) {

--- a/apps/mobile/lib/wallet/registry.ts
+++ b/apps/mobile/lib/wallet/registry.ts
@@ -1,0 +1,43 @@
+import { config } from '../config';
+import { MockWalletAdapter } from './adapters/mock-adapter';
+import { Sep7WalletAdapter } from './adapters/sep7-adapter';
+import { WalletAdapter } from './types';
+
+/**
+ * Registry of supported wallet adapters.
+ *
+ * Order matters: the first available adapter is selected as the default.
+ * The production SEP-0007 adapter is always first. The mock adapter is only
+ * included in development builds and is intentionally last so it cannot be
+ * accidentally preferred in production.
+ */
+export function createWalletAdapterRegistry(
+  isDevelopment = config.isDevelopment,
+): WalletAdapter[] {
+  const adapters: WalletAdapter[] = [new Sep7WalletAdapter()];
+
+  if (isDevelopment) {
+    adapters.push(new MockWalletAdapter(true));
+  }
+
+  return adapters;
+}
+
+/**
+ * Return the first available adapter for the current environment.
+ */
+export async function getDefaultWalletAdapter(
+  isDevelopment = config.isDevelopment,
+): Promise<WalletAdapter> {
+  const adapters = createWalletAdapterRegistry(isDevelopment);
+
+  for (const adapter of adapters) {
+    if (await adapter.isAvailable()) {
+      return adapter;
+    }
+  }
+
+  // Fall back to the production adapter even if isAvailable() is false; the
+  // adapter will surface a clear `missing_wallet` error when invoked.
+  return adapters[0];
+}

--- a/apps/mobile/lib/wallet/types.ts
+++ b/apps/mobile/lib/wallet/types.ts
@@ -6,13 +6,7 @@ import { WalletError } from './errors';
  * Kept separate from the connection lifecycle so screens can show
  * "Connected" while the wallet is actively signing a transaction.
  */
-export type WalletSigningState =
-  | 'idle'
-  | 'signing'
-  | 'pending'
-  | 'success'
-  | 'rejected'
-  | 'failed';
+export type WalletSigningState = 'idle' | 'signing' | 'pending' | 'success' | 'rejected' | 'failed';
 
 /**
  * Result returned by a signing attempt.

--- a/apps/mobile/lib/wallet/types.ts
+++ b/apps/mobile/lib/wallet/types.ts
@@ -1,0 +1,71 @@
+import { WalletError } from './errors';
+
+/**
+ * Lifecycle states for a signing request.
+ *
+ * Kept separate from the connection lifecycle so screens can show
+ * "Connected" while the wallet is actively signing a transaction.
+ */
+export type WalletSigningState =
+  | 'idle'
+  | 'signing'
+  | 'pending'
+  | 'success'
+  | 'rejected'
+  | 'failed';
+
+/**
+ * Result returned by a signing attempt.
+ *
+ * `pending` is used by deep-link adapters: the wallet app has been opened
+ * and the final result will arrive asynchronously via the app's URL handler.
+ */
+export interface WalletSigningResult {
+  status: 'success' | 'rejected' | 'failed' | 'pending';
+  txHash?: string;
+  error?: WalletError;
+}
+
+/**
+ * Result returned by a connection attempt.
+ */
+export interface WalletConnectionResult {
+  status: 'connected' | 'rejected' | 'failed';
+  pubkey?: string;
+}
+
+/**
+ * Abstraction over a Stellar-compatible mobile wallet.
+ *
+ * New providers can be added by implementing this interface and registering
+ * the adapter in `registry.ts`.
+ */
+export interface WalletAdapter {
+  readonly id: string;
+  readonly name: string;
+
+  /**
+   * True if the current device/runtime can use this adapter.
+   * For example, SEP-0007 adapters check whether a wallet app handles
+   * `web+stellar:` links.
+   */
+  isAvailable(): Promise<boolean> | boolean;
+
+  /**
+   * Initiate a wallet connection and return the public key when possible.
+   *
+   * Deep-link-based adapters may return `{ status: 'connected' }` without a
+   * public key because the user completes authorization in the wallet app and
+   * the host app receives the pubkey asynchronously.
+   */
+  connect(): Promise<WalletConnectionResult>;
+
+  /**
+   * Request a signature for a base64-encoded Stellar transaction envelope.
+   *
+   * Deep-link-based adapters return the result asynchronously via the app's
+   * URL handler. The context layer correlates the callback with the pending
+   * signing promise.
+   */
+  signXdr(xdr: string): Promise<WalletSigningResult>;
+}

--- a/apps/mobile/locales/en/common.json
+++ b/apps/mobile/locales/en/common.json
@@ -415,11 +415,10 @@
   "wallet": {
     "connect": {
       "title": "Connect Wallet",
-      "message": "Connect a Stellar wallet to {{network}}. This is the first time connecting on this network.",
-      "mock_button": "Mock Testnet Wallet",
-      "deep_link_button": "Deep Link (SEP-0007)",
-      "no_wallet_title": "No Wallet Found",
-      "no_wallet_message": "Could not find a Stellar wallet supporting SEP-0007 deep links."
+      "message": "Connect a Stellar wallet to {{network}}. This will open your wallet app to authorize the connection.",
+      "continue_button": "Open Wallet App",
+      "error_title": "Connection Failed",
+      "error_message": "Could not connect the wallet."
     },
     "reconnect": {
       "title": "Reconnect to {{network}}",
@@ -444,17 +443,22 @@
       "connected": "Connected",
       "network_mismatch": "Reconnect Required",
       "restore_failed": "Restore Failed",
-      "signing": "Signing",
       "rejected": "Rejected"
     },
     "sign": {
       "title": "Sign Transaction",
-      "message": "A transaction requires your signature.",
-      "reject": "Reject",
-      "sign_mock": "Sign (Mock)",
-      "open_app": "Open Wallet App",
-      "error_title": "Error",
-      "error_no_wallet": "No wallet app installed to handle signature."
+      "message": "A transaction requires your signature. This will open your wallet app.",
+      "error_failed": "The wallet reported a signing failure.",
+      "error_unknown": "Unexpected wallet response.",
+      "error_timeout": "Wallet did not respond in time. Please try again.",
+      "error_concurrent": "A signing request is already in progress."
+    },
+    "error": {
+      "not_available": "This wallet option is not available right now.",
+      "missing_wallet": "No Stellar wallet app found. Install a compatible wallet and try again.",
+      "unsupported_device": "This device cannot open the wallet app.",
+      "rejected": "Wallet connection was rejected.",
+      "unknown": "Something went wrong with the wallet. Please try again."
     }
   }
 }

--- a/apps/mobile/locales/zh/common.json
+++ b/apps/mobile/locales/zh/common.json
@@ -351,11 +351,10 @@
   "wallet": {
     "connect": {
       "title": "连接钱包",
-      "message": "在 {{network}} 连接一个 Stellar 钱包。这是您首次在此网络连接。",
-      "mock_button": "模拟测试网钱包",
-      "deep_link_button": "深度链接 (SEP-0007)",
-      "no_wallet_title": "未找到钱包",
-      "no_wallet_message": "未找到支持 SEP-0007 深度链接的 Stellar 钱包。"
+      "message": "在 {{network}} 连接 Stellar 钱包。这将打开您的钱包应用以授权连接。",
+      "continue_button": "打开钱包应用",
+      "error_title": "连接失败",
+      "error_message": "无法连接钱包。"
     },
     "reconnect": {
       "title": "重新连接到 {{network}}",
@@ -380,17 +379,22 @@
       "connected": "已连接",
       "network_mismatch": "需要重新连接",
       "restore_failed": "恢复失败",
-      "signing": "签名中",
       "rejected": "已拒绝"
     },
     "sign": {
       "title": "签名交易",
-      "message": "一笔交易需要您的签名。",
-      "reject": "拒绝",
-      "sign_mock": "签名（模拟）",
-      "open_app": "打开钱包 App",
-      "error_title": "错误",
-      "error_no_wallet": "未安装可用于签名的钱包应用。"
+      "message": "一笔交易需要您的签名。这将打开您的钱包应用。",
+      "error_failed": "钱包报告签名失败。",
+      "error_unknown": "钱包返回了意外响应。",
+      "error_timeout": "钱包未在时间内响应，请重试。",
+      "error_concurrent": "已有签名请求正在进行中。"
+    },
+    "error": {
+      "not_available": "当前无法使用该钱包选项。",
+      "missing_wallet": "未找到 Stellar 钱包应用。请安装兼容的钱包后重试。",
+      "unsupported_device": "此设备无法打开钱包应用。",
+      "rejected": "钱包连接被拒绝。",
+      "unknown": "钱包出现未知问题，请重试。"
     }
   }
 }


### PR DESCRIPTION
Closes #1015

## Summary

Replaces the mock-first mobile wallet signing path with a production-style Stellar wallet adapter layer. The SEP-0007 deep-link adapter is now the default signing mechanism; the mock adapter is gated to development builds only. Connection status and signing status are separated in both the state layer and the UI copy.

## #1015 — Production wallet adapter replacing mock signing path

- Added a `WalletAdapter` abstraction under `apps/mobile/lib/wallet/`:
  - `types.ts` defines the adapter interface and a dedicated `WalletSigningState`.
  - `errors.ts` introduces typed `WalletError` codes for missing wallet, unsupported device, rejection, and generic failures.
  - `adapters/sep7-adapter.ts` implements production SEP-0007 signing via `web+stellar:` deep links.
  - `adapters/mock-adapter.ts` provides a deterministic dev-only adapter.
  - `registry.ts` selects the first available adapter, always preferring SEP-0007 over mock.
- Refactored `WalletContext`:
  - Removed `'signing'` from `WalletStatus`; added independent `signingState` and `lastSigningError`.
  - `signAndSubmitXdr` delegates to the active adapter and waits for deep-link callbacks with a defensive timeout.
  - Handles rejected, failed, missing-wallet, unsupported-device, timeout, and concurrent-signing cases explicitly.
- Removed the hard-coded `'AAAA_MOCK_XDR_FOR_TESTNET_DEMO'` fallback in `app/(tabs)/projects/[id].tsx`; signing now requires a real `unsignedXdr` from the backend.
- Updated English and Chinese locale strings to remove mock-specific labels and add explicit wallet error messages.

## Verification

- Reviewed all changed files for import correctness, type consistency, and state-flow safety.
- Confirmed no remaining references to the old mock XDR fallback or mock-specific UI keys.
- `npm run tsc` and `npm run lint` could not be executed locally because `apps/mobile` does not currently have `node_modules` installed. Type-checking will need to run in CI once dependencies are available.

## Notes for reviewers

- The SEP-0007 adapter intentionally does not bundle `@stellar/stellar-sdk`; the mobile app continues to delegate XDR construction to the backend, consistent with `lib/crowdfund.ts`.
- The deep-link callback handler prioritizes pending signing callbacks over connection callbacks so the two flows do not collide.
- Future wallet providers can be added by implementing `WalletAdapter` and registering the implementation in `registry.ts`.