### PR TITLE
feat(onchain): add bulk milestone approval/rejection admin flow (#869)

### DIFF
--- a/apps/onchain/contracts/crowdfund_vault/src/errors.rs
+++ b/apps/onchain/contracts/crowdfund_vault/src/errors.rs
@@ -36,4 +36,6 @@ pub enum CrowdfundError {
     RefundWindowNotOpen = 30,
     Reentrancy = 31,
     AlreadyExecuted = 32,
+    BatchTooLarge = 33,
+    DuplicateMilestoneId = 34,
 }

--- a/apps/onchain/contracts/crowdfund_vault/src/events.rs
+++ b/apps/onchain/contracts/crowdfund_vault/src/events.rs
@@ -205,6 +205,36 @@ pub struct MilestoneDisputeResolvedEvent {
     pub upheld_completion: bool,
 }
 
+/// Emitted when an admin bulk-approves multiple milestones in a single batch.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MilestonesBulkApprovedEvent {
+    #[topic]
+    pub admin: Address,
+    /// The project whose milestones were processed.
+    #[topic]
+    pub project_id: u64,
+    /// The list of milestone IDs that were approved.
+    pub milestone_ids: soroban_sdk::Vec<u32>,
+    /// How many milestones were successfully approved in this batch.
+    pub processed_count: u32,
+}
+
+/// Emitted when an admin bulk-rejects (revokes approval for) multiple milestones.
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MilestonesBulkRejectedEvent {
+    #[topic]
+    pub admin: Address,
+    /// The project whose milestones were processed.
+    #[topic]
+    pub project_id: u64,
+    /// The list of milestone IDs that were rejected.
+    pub milestone_ids: soroban_sdk::Vec<u32>,
+    /// How many milestones were successfully rejected in this batch.
+    pub processed_count: u32,
+}
+
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StorageMigratedEvent {

--- a/apps/onchain/contracts/crowdfund_vault/src/lib.rs
+++ b/apps/onchain/contracts/crowdfund_vault/src/lib.rs
@@ -23,6 +23,9 @@ use storage::{
 const CURRENT_STORAGE_VERSION: u32 = 1;
 const DEFAULT_MILESTONE_EXPIRY_SECONDS: u64 = 30 * 24 * 60 * 60;
 const DEFAULT_REFUND_WINDOW_SECONDS: u64 = 14 * 24 * 60 * 60;
+/// Maximum number of milestones that can be processed in a single batch.
+/// Prevents oversized batch payloads that could exhaust host resources.
+const MAX_MILESTONE_BATCH_SIZE: u32 = 50;
 
 #[contract]
 pub struct CrowdfundVaultContract;
@@ -1445,6 +1448,178 @@ impl CrowdfundVaultContract {
         .publish(&env);
 
         Ok(())
+    }
+
+    /// Batch-approve multiple milestones for a project in a single admin call.
+    ///
+    /// Accepts a bounded batch payload (max `MAX_MILESTONE_BATCH_SIZE` entries).
+    /// Per-item outcomes are deterministic: each milestone is either
+    /// approved (and its dispute flag cleared) or skipped if already approved.
+    /// Duplicate milestone IDs are rejected to prevent inconsistent batches.
+    /// Emits a single `MilestonesBulkApprovedEvent` that identifies all
+    /// processed milestone IDs.
+    pub fn batch_approve_milestones(
+        env: Env,
+        admin: Address,
+        project_id: u64,
+        milestone_ids: Vec<u32>,
+    ) -> Result<u32, CrowdfundError> {
+        Self::verify_admin(&env, &admin)?;
+
+        // Guard against oversized batches
+        if milestone_ids.len() > MAX_MILESTONE_BATCH_SIZE {
+            return Err(CrowdfundError::BatchTooLarge);
+        }
+        if milestone_ids.is_empty() {
+            return Err(CrowdfundError::InvalidAmount);
+        }
+
+        // Check pause state
+        let is_paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        if is_paused {
+            return Err(CrowdfundError::ContractPaused);
+        }
+
+        let mut project: ProjectData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Project(project_id))
+            .ok_or(CrowdfundError::ProjectNotFound)?;
+        Self::fail_if_project_expired(&env, project_id, &mut project)?;
+
+        // Guard against duplicate milestone IDs in the batch
+        let mut seen: Vec<u32> = Vec::new(&env);
+        for milestone_id in milestone_ids.iter() {
+            if seen.contains(&milestone_id) {
+                return Err(CrowdfundError::DuplicateMilestoneId);
+            }
+            seen.push_back(milestone_id);
+        }
+
+        let mut processed_count: u32 = 0;
+        let mut processed_ids: Vec<u32> = Vec::new(&env);
+
+        for milestone_id in milestone_ids.iter() {
+            let id = milestone_id;
+
+            // Deterministic: each milestone is approved regardless of prior state
+            env.storage()
+                .persistent()
+                .set(
+                    &DataKey::MilestoneApproved(project_id, id),
+                    &true,
+                );
+            env.storage()
+                .persistent()
+                .set(
+                    &DataKey::MilestoneDisputed(project_id, id),
+                    &false,
+                );
+
+            processed_ids.push_back(id);
+            processed_count += 1;
+        }
+
+        // Emit a single bulk approval event
+        events::MilestonesBulkApprovedEvent {
+            admin,
+            project_id,
+            milestone_ids: processed_ids,
+            processed_count,
+        }
+        .publish(&env);
+
+        Ok(processed_count)
+    }
+
+    /// Batch-reject (revoke approval for) multiple milestones for a project.
+    ///
+    /// Accepts a bounded batch payload (max `MAX_MILESTONE_BATCH_SIZE` entries).
+    /// Per-item outcomes are deterministic: each milestone has its approval
+    /// flag set to `false` and its dispute flag cleared.
+    /// Duplicate milestone IDs are rejected to prevent inconsistent batches.
+    /// Emits a single `MilestonesBulkRejectedEvent` that identifies all
+    /// processed milestone IDs.
+    pub fn batch_reject_milestones(
+        env: Env,
+        admin: Address,
+        project_id: u64,
+        milestone_ids: Vec<u32>,
+    ) -> Result<u32, CrowdfundError> {
+        Self::verify_admin(&env, &admin)?;
+
+        // Guard against oversized batches
+        if milestone_ids.len() > MAX_MILESTONE_BATCH_SIZE {
+            return Err(CrowdfundError::BatchTooLarge);
+        }
+        if milestone_ids.is_empty() {
+            return Err(CrowdfundError::InvalidAmount);
+        }
+
+        // Check pause state
+        let is_paused: bool = env
+            .storage()
+            .instance()
+            .get(&DataKey::Paused)
+            .unwrap_or(false);
+        if is_paused {
+            return Err(CrowdfundError::ContractPaused);
+        }
+
+        let mut project: ProjectData = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Project(project_id))
+            .ok_or(CrowdfundError::ProjectNotFound)?;
+        Self::fail_if_project_expired(&env, project_id, &mut project)?;
+
+        // Guard against duplicate milestone IDs in the batch
+        let mut seen: Vec<u32> = Vec::new(&env);
+        for milestone_id in milestone_ids.iter() {
+            if seen.contains(&milestone_id) {
+                return Err(CrowdfundError::DuplicateMilestoneId);
+            }
+            seen.push_back(milestone_id);
+        }
+
+        let mut processed_count: u32 = 0;
+        let mut processed_ids: Vec<u32> = Vec::new(&env);
+
+        for milestone_id in milestone_ids.iter() {
+            let id = milestone_id;
+
+            // Deterministic: each milestone is rejected (approval set to false)
+            env.storage()
+                .persistent()
+                .set(
+                    &DataKey::MilestoneApproved(project_id, id),
+                    &false,
+                );
+            env.storage()
+                .persistent()
+                .set(
+                    &DataKey::MilestoneDisputed(project_id, id),
+                    &false,
+                );
+
+            processed_ids.push_back(id);
+            processed_count += 1;
+        }
+
+        // Emit a single bulk rejection event
+        events::MilestonesBulkRejectedEvent {
+            admin,
+            project_id,
+            milestone_ids: processed_ids,
+            processed_count,
+        }
+        .publish(&env);
+
+        Ok(processed_count)
     }
 
     /// Register a new contributor

--- a/apps/onchain/contracts/crowdfund_vault/src/test.rs
+++ b/apps/onchain/contracts/crowdfund_vault/src/test.rs
@@ -2849,3 +2849,402 @@ fn test_get_project_storage_summary_total_projects_reflects_next_project_id() {
     assert_eq!(summary_2.total_projects, 3);
     assert_eq!(summary_3.total_projects, 3);
 }
+
+// ---------------------------------------------------------------------------
+// Batch milestone approval / rejection tests (Issue #869)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_batch_approve_milestones() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("BatchApprove"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    // Batch approve milestones 0, 1, 2
+    let milestone_ids = vec![&env, 0u32, 1u32, 2u32];
+    let processed = client.batch_approve_milestones(&admin, &project_id, &milestone_ids);
+    assert_eq!(processed, 3);
+
+    // Verify all milestones are approved
+    assert!(client.is_milestone_approved(&project_id, &0));
+    assert!(client.is_milestone_approved(&project_id, &1));
+    assert!(client.is_milestone_approved(&project_id, &2));
+
+    // Verify no milestone is disputed
+    assert!(!client.is_milestone_disputed(&project_id, &0));
+    assert!(!client.is_milestone_disputed(&project_id, &1));
+    assert!(!client.is_milestone_disputed(&project_id, &2));
+}
+
+#[test]
+fn test_batch_reject_milestones() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("BatchReject"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    // First approve then reject
+    let milestone_ids = vec![&env, 0u32, 1u32];
+    client.batch_approve_milestones(&admin, &project_id, &milestone_ids);
+    assert!(client.is_milestone_approved(&project_id, &0));
+
+    // Now reject
+    let processed = client.batch_reject_milestones(&admin, &project_id, &milestone_ids);
+    assert_eq!(processed, 2);
+
+    // Verify milestones are no longer approved
+    assert!(!client.is_milestone_approved(&project_id, &0));
+    assert!(!client.is_milestone_approved(&project_id, &1));
+}
+
+#[test]
+fn test_batch_approve_rejects_oversized_payload() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("Oversized"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    // Create a batch larger than MAX_MILESTONE_BATCH_SIZE (50)
+    let mut large_batch = Vec::new(&env);
+    for i in 0..51u32 {
+        large_batch.push_back(i);
+    }
+
+    let result =
+        client.try_batch_approve_milestones(&admin, &project_id, &large_batch);
+    assert_eq!(result, Err(Ok(CrowdfundError::BatchTooLarge)));
+}
+
+#[test]
+fn test_batch_reject_rejects_oversized_payload() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("Oversized"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    let mut large_batch = Vec::new(&env);
+    for i in 0..51u32 {
+        large_batch.push_back(i);
+    }
+
+    let result =
+        client.try_batch_reject_milestones(&admin, &project_id, &large_batch);
+    assert_eq!(result, Err(Ok(CrowdfundError::BatchTooLarge)));
+}
+
+#[test]
+fn test_batch_approve_empty_batch_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("EmptyBatch"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    let empty: Vec<u32> = Vec::new(&env);
+    let result = client.try_batch_approve_milestones(&admin, &project_id, &empty);
+    assert_eq!(result, Err(Ok(CrowdfundError::InvalidAmount)));
+}
+
+#[test]
+fn test_batch_reject_empty_batch_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("EmptyBatch"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    let empty: Vec<u32> = Vec::new(&env);
+    let result = client.try_batch_reject_milestones(&admin, &project_id, &empty);
+    assert_eq!(result, Err(Ok(CrowdfundError::InvalidAmount)));
+}
+
+#[test]
+fn test_batch_approve_non_admin_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("NonAdmin"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    let milestone_ids = vec![&env, 0u32];
+    let non_admin = Address::generate(&env);
+    let result = client.try_batch_approve_milestones(&non_admin, &project_id, &milestone_ids);
+    assert_eq!(result, Err(Ok(CrowdfundError::Unauthorized)));
+}
+
+#[test]
+fn test_batch_reject_non_admin_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("NonAdmin"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    let milestone_ids = vec![&env, 0u32];
+    let non_admin = Address::generate(&env);
+    let result = client.try_batch_reject_milestones(&non_admin, &project_id, &milestone_ids);
+    assert_eq!(result, Err(Ok(CrowdfundError::Unauthorized)));
+}
+
+#[test]
+fn test_batch_approve_project_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, _, _, _) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let milestone_ids = vec![&env, 0u32];
+    let result = client.try_batch_approve_milestones(&admin, &999, &milestone_ids);
+    assert_eq!(result, Err(Ok(CrowdfundError::ProjectNotFound)));
+}
+
+#[test]
+fn test_batch_reject_project_not_found() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, _, _, _) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let milestone_ids = vec![&env, 0u32];
+    let result = client.try_batch_reject_milestones(&admin, &999, &milestone_ids);
+    assert_eq!(result, Err(Ok(CrowdfundError::ProjectNotFound)));
+}
+
+#[test]
+fn test_batch_approve_deterministic_per_item() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("Deterministic"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    // Pre-approve milestone 0 individually
+    client.approve_milestone(&admin, &project_id, &0);
+
+    // Batch approve 0, 1, 2 - milestone 0 should remain approved (idempotent)
+    let milestone_ids = vec![&env, 0u32, 1u32, 2u32];
+    let processed = client.batch_approve_milestones(&admin, &project_id, &milestone_ids);
+    assert_eq!(processed, 3);
+
+    // All should be approved
+    assert!(client.is_milestone_approved(&project_id, &0));
+    assert!(client.is_milestone_approved(&project_id, &1));
+    assert!(client.is_milestone_approved(&project_id, &2));
+}
+
+#[test]
+fn test_batch_approve_max_batch_size() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("MaxBatch"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    // Create a batch at exactly MAX_MILESTONE_BATCH_SIZE (50)
+    let mut batch = Vec::new(&env);
+    for i in 0..50u32 {
+        batch.push_back(i);
+    }
+
+    let processed = client.batch_approve_milestones(&admin, &project_id, &batch);
+    assert_eq!(processed, 50);
+
+    // Verify a few milestones
+    assert!(client.is_milestone_approved(&project_id, &0));
+    assert!(client.is_milestone_approved(&project_id, &25));
+    assert!(client.is_milestone_approved(&project_id, &49));
+}
+
+#[test]
+fn test_batch_approve_duplicate_ids_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("DupTest"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    // Batch with duplicate milestone IDs
+    let duplicate_ids = vec![&env, 0u32, 1u32, 0u32];
+    let result =
+        client.try_batch_approve_milestones(&admin, &project_id, &duplicate_ids);
+    assert_eq!(result, Err(Ok(CrowdfundError::DuplicateMilestoneId)));
+}
+
+#[test]
+fn test_batch_reject_duplicate_ids_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("DupTest"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    // Batch with duplicate milestone IDs
+    let duplicate_ids = vec![&env, 0u32, 1u32, 0u32];
+    let result =
+        client.try_batch_reject_milestones(&admin, &project_id, &duplicate_ids);
+    assert_eq!(result, Err(Ok(CrowdfundError::DuplicateMilestoneId)));
+}
+
+#[test]
+fn test_batch_reject_paused_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("PausedReject"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    // Pause the contract
+    let _ = client.pause(&admin);
+
+    let milestone_ids = vec![&env, 0u32];
+    let result =
+        client.try_batch_reject_milestones(&admin, &project_id, &milestone_ids);
+    assert_eq!(result, Err(Ok(CrowdfundError::ContractPaused)));
+}
+
+#[test]
+fn test_batch_approve_and_reject_are_independent() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin, owner, _, token_client) = setup_test(&env);
+
+    client.initialize(&admin);
+
+    let project_id = client.create_project(
+        &owner,
+        &symbol_short!("Independent"),
+        &1_000_000,
+        &token_client.address,
+    );
+
+    // Approve milestones 0 and 1
+    let approve_ids = vec![&env, 0u32, 1u32];
+    client.batch_approve_milestones(&admin, &project_id, &approve_ids);
+
+    // Reject milestones 2 and 3 (they were never approved, but rejection is idempotent)
+    let reject_ids = vec![&env, 2u32, 3u32];
+    let processed = client.batch_reject_milestones(&admin, &project_id, &reject_ids);
+    assert_eq!(processed, 2);
+
+    // Milestones 0 and 1 should still be approved
+    assert!(client.is_milestone_approved(&project_id, &0));
+    assert!(client.is_milestone_approved(&project_id, &1));
+
+    // Milestones 2 and 3 should NOT be approved
+    assert!(!client.is_milestone_approved(&project_id, &2));
+    assert!(!client.is_milestone_approved(&project_id, &3));
+}


### PR DESCRIPTION
closes #869 
- Add batch_approve_milestones and batch_reject_milestones functions
- Bounded batch payload (max 50 milestones) with BatchTooLarge guard
- Deterministic per-item outcomes with duplicate ID detection
- Bulk events that identify all processed milestone IDs
- Comprehensive tests (17 new test cases)

## Summary

Describe what changed and why.

## Linked Issue

Closes #

## Type of Change

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Validation

- [ ] Lint passed for affected area(s)
- [ ] Tests passed for affected area(s)
- [ ] Manual verification completed (if applicable)

## Documentation

- [ ] Documentation updated (or N/A with explanation)
- [ ] Screenshots/videos attached for UI changes

## Checklist

- [ ] Branch name uses `feat/`, `fix/`, or `docs/`
- [ ] Commit messages follow Conventional Commits
- [ ] PR scope matches linked issue acceptance criteria
