### PR TITLE
feat: alert suppression and dedup rules engine (#1058)

### DIFF
--- a/apps/data-processing/.env.example
+++ b/apps/data-processing/.env.example
@@ -49,6 +49,16 @@ RATE_LIMIT_DEFAULT=100/minute
 RATE_LIMIT_STRICT=10/minute
 RATE_LIMIT_ENABLED=true
 
+# Alert Suppression & Dedup Rules Engine (#1058)
+# Path to YAML rule configuration (default: config/alert_rules.yaml)
+ALERT_RULES_PATH=
+# JSON string override for rules (takes precedence over YAML file)
+ALERT_RULES_JSON=
+# Fallback dedup window when no rules file is found (default: 300)
+ALERT_DEDUP_WINDOW_SECONDS=300
+# Path to suppression state persistence file
+ALERT_SUPPRESSION_STORE_PATH=./data/alert_suppression.json
+
 # Network Configuration (mainnet or testnet)
 NETWORK=mainnet
 

--- a/apps/data-processing/config/alert_rules.yaml
+++ b/apps/data-processing/config/alert_rules.yaml
@@ -1,0 +1,29 @@
+suppression_rules:
+  - type: repeat_alert
+    name: "dedup_indexer_lag"
+    window_seconds: 300
+    key_fields: ["metric_name", "source", "severity"]
+
+  - type: repeat_alert
+    name: "dedup_source_failures"
+    window_seconds: 60
+    key_fields: ["source", "failure_type"]
+
+  - type: noisy_condition
+    name: "rate_limit_source_failures"
+    window_seconds: 300
+    key_fields: ["source", "alert_type"]
+    rate_limit: 10
+    max_suppressions: 50
+
+  - type: severity_threshold
+    name: "suppress_healthy_alerts"
+    window_seconds: 0
+    key_fields: ["alert_type"]
+    min_severity: "warning"
+
+  - type: alert_type
+    name: "dedup_contract_lag"
+    window_seconds: 300
+    key_fields: ["domain", "severity"]
+    alert_types: ["contract_lag"]

--- a/apps/data-processing/src/alert_engine/__init__.py
+++ b/apps/data-processing/src/alert_engine/__init__.py
@@ -1,0 +1,15 @@
+from src.alert_engine.engine import AlertSuppressionEngine
+from src.alert_engine.rule import SuppressionRule, RepeatAlertRule, NoisyConditionRule
+from src.alert_engine.config import load_rules_from_yaml, load_rules_from_env
+
+engine = AlertSuppressionEngine()
+
+__all__ = [
+    "AlertSuppressionEngine",
+    "SuppressionRule",
+    "RepeatAlertRule",
+    "NoisyConditionRule",
+    "load_rules_from_yaml",
+    "load_rules_from_env",
+    "engine",
+]

--- a/apps/data-processing/src/alert_engine/config.py
+++ b/apps/data-processing/src/alert_engine/config.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from src.alert_engine.rule import (
+    AlertTypeRule,
+    NoisyConditionRule,
+    RepeatAlertRule,
+    SeverityThresholdRule,
+    SuppressionRule,
+    build_rules_from_config,
+)
+
+DEFAULT_RULES_YAML = """
+suppression_rules:
+  - type: repeat_alert
+    name: "dedup_indexer_lag"
+    window_seconds: 300
+    key_fields: ["metric_name", "source", "severity"]
+
+  - type: repeat_alert
+    name: "dedup_source_failures"
+    window_seconds: 60
+    key_fields: ["source", "failure_type"]
+
+  - type: noisy_condition
+    name: "rate_limit_source_failures"
+    window_seconds: 300
+    key_fields: ["source", "alert_type"]
+    rate_limit: 10
+    max_suppressions: 50
+
+  - type: severity_threshold
+    name: "suppress_healthy_alerts"
+    window_seconds: 0
+    key_fields: ["alert_type"]
+    min_severity: "warning"
+
+  - type: alert_type
+    name: "dedup_contract_lag"
+    window_seconds: 300
+    key_fields: ["domain", "severity"]
+    alert_types: ["contract_lag"]
+"""
+
+
+def load_rules_from_yaml(filepath: Optional[str] = None) -> List[SuppressionRule]:
+    try:
+        import yaml
+    except ImportError:
+        return load_rules_from_env()
+
+    filepath = filepath or os.getenv(
+        "ALERT_RULES_PATH",
+        os.path.join(os.path.dirname(__file__), "..", "..", "config", "alert_rules.yaml"),
+    )
+
+    if filepath and os.path.exists(filepath):
+        with open(filepath, "r") as f:
+            data = yaml.safe_load(f)
+        if data and "suppression_rules" in data:
+            return build_rules_from_config(data["suppression_rules"])
+
+    import json
+    env_rules = os.getenv("ALERT_RULES_JSON")
+    if env_rules:
+        try:
+            data = json.loads(env_rules)
+            if isinstance(data, list):
+                return build_rules_from_config(data)
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    return _default_rules()
+
+
+def load_rules_from_env() -> List[SuppressionRule]:
+    rules: List[SuppressionRule] = []
+
+    window = float(os.getenv("ALERT_DEDUP_WINDOW_SECONDS", "300"))
+    rules.append(RepeatAlertRule(
+        name="dedup_all",
+        window_seconds=window,
+        key_fields=["alert_type", "metric_name", "severity"],
+    ))
+
+    return rules
+
+
+def _default_rules() -> List[SuppressionRule]:
+    return [
+        RepeatAlertRule(
+            name="dedup_indexer_lag",
+            window_seconds=300,
+            key_fields=["metric_name", "source", "severity"],
+        ),
+        RepeatAlertRule(
+            name="dedup_source_failures",
+            window_seconds=60,
+            key_fields=["source", "failure_type"],
+        ),
+        NoisyConditionRule(
+            name="rate_limit_source_failures",
+            window_seconds=300,
+            key_fields=["source", "alert_type"],
+            rate_limit=10,
+            max_suppressions=50,
+        ),
+        SeverityThresholdRule(
+            name="suppress_healthy_alerts",
+            window_seconds=0,
+            key_fields=["alert_type"],
+            min_severity="warning",
+        ),
+        AlertTypeRule(
+            name="dedup_contract_lag",
+            window_seconds=300,
+            key_fields=["domain", "severity"],
+            alert_types=["contract_lag"],
+        ),
+    ]

--- a/apps/data-processing/src/alert_engine/engine.py
+++ b/apps/data-processing/src/alert_engine/engine.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from src.alert_engine.config import load_rules_from_yaml
+from src.alert_engine.rule import SuppressionRule
+from src.alert_engine.storage import SuppressionStore
+from src.utils.logger import setup_logger
+
+engine_logger = setup_logger("lumenpulse.alert_engine")
+
+
+@dataclass
+class SuppressionDecision:
+    emit: bool
+    rule_name: str
+    dedup_key: str
+    reason: str
+    since_first_seen: Optional[float] = None
+    suppress_count: int = 0
+    emit_count: int = 0
+
+
+class AlertSuppressionEngine:
+    def __init__(
+        self,
+        rules: Optional[List[SuppressionRule]] = None,
+        storage_path: Optional[str] = None,
+    ):
+        self._rules = rules if rules is not None else load_rules_from_yaml()
+        store_path = storage_path or os.getenv(
+            "ALERT_SUPPRESSION_STORE_PATH",
+            "./data/alert_suppression.json",
+        )
+        self._store = SuppressionStore(storage_path=store_path)
+        self._suppressions_total = 0
+        self._emissions_total = 0
+
+    def evaluate(self, alert: Dict[str, Any]) -> SuppressionDecision:
+        now = datetime.now(timezone.utc)
+        for rule in self._rules:
+            if not rule.matches(alert):
+                continue
+
+            dedup_key = rule.compute_key(alert)
+            record = self._store.get(dedup_key)
+
+            if rule.max_suppressions is not None:
+                if record and record.suppress_count >= rule.max_suppressions:
+                    self._emissions_total += 1
+                    self._store.record_emitted(dedup_key, rule.name, alert)
+                    engine_logger.info(
+                        "ALERT_ENGINE emit(forced) key=%s rule=%s suppress_count=%d max=%d",
+                        dedup_key, rule.name, record.suppress_count, rule.max_suppressions,
+                    )
+                    return SuppressionDecision(
+                        emit=True,
+                        rule_name=rule.name,
+                        dedup_key=dedup_key,
+                        reason=f"forced_emit_after_{rule.max_suppressions}_suppressions",
+                        emit_count=record.emit_count + 1,
+                        suppress_count=record.suppress_count,
+                    )
+
+            if record is None:
+                self._emissions_total += 1
+                self._store.record_emitted(dedup_key, rule.name, alert)
+                engine_logger.info(
+                    "ALERT_ENGINE emit(first) key=%s rule=%s",
+                    dedup_key, rule.name,
+                )
+                return SuppressionDecision(
+                    emit=True,
+                    rule_name=rule.name,
+                    dedup_key=dedup_key,
+                    reason="first_occurrence",
+                    emit_count=1,
+                    suppress_count=0,
+                )
+
+            elapsed = (now - datetime.fromisoformat(record.last_attempt)).total_seconds()
+
+            if elapsed >= rule.window_seconds:
+                self._emissions_total += 1
+                self._store.record_emitted(dedup_key, rule.name, alert)
+                engine_logger.info(
+                    "ALERT_ENGINE emit(repeat,window_expired) key=%s rule=%s elapsed=%.1fs window=%.1fs",
+                    dedup_key, rule.name, elapsed, rule.window_seconds,
+                )
+                return SuppressionDecision(
+                    emit=True,
+                    rule_name=rule.name,
+                    dedup_key=dedup_key,
+                    reason="window_expired",
+                    since_first_seen=elapsed,
+                    emit_count=record.emit_count + 1,
+                    suppress_count=record.suppress_count,
+                )
+
+            self._suppressions_total += 1
+            self._store.record_suppressed(dedup_key, rule.name, alert)
+            engine_logger.info(
+                "ALERT_ENGINE suppress key=%s rule=%s elapsed=%.1fs window=%.1fs suppress_count=%d",
+                dedup_key, rule.name, elapsed, rule.window_seconds, record.suppress_count + 1,
+            )
+            return SuppressionDecision(
+                emit=False,
+                rule_name=rule.name,
+                dedup_key=dedup_key,
+                reason="suppressed_within_window",
+                since_first_seen=elapsed,
+                emit_count=record.emit_count,
+                suppress_count=record.suppress_count + 1,
+            )
+
+        self._emissions_total += 1
+        return SuppressionDecision(
+            emit=True,
+            rule_name="no_rule_match",
+            dedup_key="",
+            reason="no_matching_rule",
+        )
+
+    def evaluate_batch(
+        self, alerts: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        emitted: List[Dict[str, Any]] = []
+        suppressed: List[Dict[str, Any]] = []
+
+        for alert in alerts:
+            decision = self.evaluate(alert)
+            enriched = dict(alert)
+            enriched["_suppression"] = {
+                "dedup_key": decision.dedup_key,
+                "rule_name": decision.rule_name,
+                "reason": decision.reason,
+            }
+            if decision.emit:
+                emitted.append(enriched)
+            else:
+                suppressed.append(enriched)
+
+        if suppressed:
+            engine_logger.warning(
+                "ALERT_ENGINE batch: %d emitted, %d suppressed",
+                len(emitted), len(suppressed),
+            )
+
+        return emitted
+
+    @property
+    def stats(self) -> Dict[str, Any]:
+        return {
+            "rules": [r.to_dict() for r in self._rules],
+            "suppressions_total": self._suppressions_total,
+            "emissions_total": self._emissions_total,
+            "store_records": len(self._store.records),
+        }
+
+    @property
+    def suppression_records(self) -> Dict[str, Any]:
+        return {k: v.to_dict() for k, v in self._store.records.items()}
+
+    def reload_rules(self, rules: Optional[List[SuppressionRule]] = None) -> None:
+        self._rules = rules or load_rules_from_yaml()
+        engine_logger.info("ALERT_ENGINE reloaded %d rules", len(self._rules))

--- a/apps/data-processing/src/alert_engine/rule.py
+++ b/apps/data-processing/src/alert_engine/rule.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class SuppressionRule(ABC):
+    name: str
+    window_seconds: float
+    key_fields: List[str] = field(default_factory=lambda: ["alert_type", "metric_name"])
+    max_suppressions: Optional[int] = None
+
+    @abstractmethod
+    def matches(self, alert: Dict[str, Any]) -> bool:
+        ...
+
+    def compute_key(self, alert: Dict[str, Any]) -> str:
+        parts = [alert.get(f, "") for f in self.key_fields]
+        raw = json.dumps(parts, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "window_seconds": self.window_seconds,
+            "key_fields": list(self.key_fields),
+            "max_suppressions": self.max_suppressions,
+        }
+
+
+@dataclass
+class RepeatAlertRule(SuppressionRule):
+    def matches(self, alert: Dict[str, Any]) -> bool:
+        return True
+
+
+@dataclass
+class NoisyConditionRule(SuppressionRule):
+    rate_limit: int = 5
+
+    def matches(self, alert: Dict[str, Any]) -> bool:
+        return True
+
+    def to_dict(self) -> Dict[str, Any]:
+        base = super().to_dict()
+        base["rate_limit"] = self.rate_limit
+        return base
+
+
+@dataclass
+class SeverityThresholdRule(SuppressionRule):
+    min_severity: str = "warning"
+
+    def matches(self, alert: Dict[str, Any]) -> bool:
+        severity = alert.get("severity", "").lower()
+        order = {"healthy": 0, "info": 1, "warning": 2, "critical": 3}
+        min_order = order.get(self.min_severity, 2)
+        return order.get(severity, 0) < min_order
+
+    def to_dict(self) -> Dict[str, Any]:
+        base = super().to_dict()
+        base["min_severity"] = self.min_severity
+        return base
+
+
+@dataclass
+class AlertTypeRule(SuppressionRule):
+    alert_types: List[str] = field(default_factory=list)
+
+    def matches(self, alert: Dict[str, Any]) -> bool:
+        return alert.get("alert_type", "") in self.alert_types
+
+    def to_dict(self) -> Dict[str, Any]:
+        base = super().to_dict()
+        base["alert_types"] = list(self.alert_types)
+        return base
+
+
+def build_rules_from_config(configs: List[Dict[str, Any]]) -> List[SuppressionRule]:
+    rules: List[SuppressionRule] = []
+    for cfg in configs:
+        rule_type = cfg.get("type", "repeat_alert")
+        params = {k: v for k, v in cfg.items() if k != "type"}
+        if rule_type == "repeat_alert":
+            rules.append(RepeatAlertRule(**params))
+        elif rule_type == "noisy_condition":
+            rules.append(NoisyConditionRule(**params))
+        elif rule_type == "severity_threshold":
+            rules.append(SeverityThresholdRule(**params))
+        elif rule_type == "alert_type":
+            rules.append(AlertTypeRule(**params))
+    return rules

--- a/apps/data-processing/src/alert_engine/storage.py
+++ b/apps/data-processing/src/alert_engine/storage.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class SuppressionRecord:
+    dedup_key: str
+    rule_name: str
+    first_seen: str
+    last_attempt: str
+    emit_count: int
+    suppress_count: int
+    last_alert: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class SuppressionStore:
+    def __init__(self, storage_path: str = "./data/alert_suppression.json"):
+        self.storage_path = Path(storage_path)
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        self._records: Dict[str, SuppressionRecord] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if self.storage_path.exists():
+            try:
+                with open(self.storage_path, "r") as f:
+                    raw = json.load(f)
+                for key, data in raw.items():
+                    self._records[key] = SuppressionRecord(**data)
+            except (json.JSONDecodeError, IOError):
+                self._records = {}
+
+    def _save(self) -> None:
+        raw = {k: v.to_dict() for k, v in self._records.items()}
+        with open(self.storage_path, "w") as f:
+            json.dump(raw, f, indent=2)
+
+    def get(self, dedup_key: str) -> Optional[SuppressionRecord]:
+        return self._records.get(dedup_key)
+
+    def record_emitted(self, dedup_key: str, rule_name: str, alert: Dict[str, Any]) -> SuppressionRecord:
+        now = datetime.now(timezone.utc).isoformat()
+        if dedup_key in self._records:
+            rec = self._records[dedup_key]
+            rec.emit_count += 1
+            rec.last_attempt = now
+            rec.last_alert = alert
+        else:
+            rec = SuppressionRecord(
+                dedup_key=dedup_key,
+                rule_name=rule_name,
+                first_seen=now,
+                last_attempt=now,
+                emit_count=1,
+                suppress_count=0,
+                last_alert=alert,
+            )
+            self._records[dedup_key] = rec
+        self._save()
+        return rec
+
+    def record_suppressed(self, dedup_key: str, rule_name: str, alert: Dict[str, Any]) -> SuppressionRecord:
+        now = datetime.now(timezone.utc).isoformat()
+        if dedup_key in self._records:
+            rec = self._records[dedup_key]
+            rec.suppress_count += 1
+            rec.last_attempt = now
+            rec.last_alert = alert
+        else:
+            rec = SuppressionRecord(
+                dedup_key=dedup_key,
+                rule_name=rule_name,
+                first_seen=now,
+                last_attempt=now,
+                emit_count=0,
+                suppress_count=1,
+                last_alert=alert,
+            )
+            self._records[dedup_key] = rec
+        self._save()
+        return rec
+
+    @property
+    def records(self) -> Dict[str, SuppressionRecord]:
+        return dict(self._records)
+
+    def clear(self) -> None:
+        self._records.clear()
+        self._save()

--- a/apps/data-processing/src/ingestion/ingestion_alerting.py
+++ b/apps/data-processing/src/ingestion/ingestion_alerting.py
@@ -19,12 +19,17 @@ from src.db.models import AnalyticsRecord
 from src.db.postgres_service import PostgresService
 from src.ingestion.stellar_fetcher import StellarDataFetcher
 from src.ingestion.stellar_ingestion_checks import _horizon_latest_ledger, _parse_iso_datetime
+from src.alert_engine.engine import AlertSuppressionEngine
 from src.utils.logger import setup_logger
 from src.utils.metrics import (
+    ALERT_SUPPRESSIONS_TOTAL,
+    ALERT_EMISSIONS_TOTAL,
     INDEXER_LAG_SECONDS,
     SOURCE_FAILURES_TOTAL,
     SOURCE_HEALTH,
 )
+
+_suppression_engine: AlertSuppressionEngine = None
 
 alert_logger = setup_logger("lumenpulse.ingestion_alerts")
 
@@ -128,6 +133,20 @@ def _emit_log_alert(
 
 _recent_failures: List[SourceFailureEvent] = []
 _last_cycle_result: Dict[str, Any] = {}
+_suppressed_alerts: List[Dict[str, Any]] = []
+
+
+def get_suppression_engine() -> AlertSuppressionEngine:
+    global _suppression_engine
+    if _suppression_engine is None:
+        _suppression_engine = AlertSuppressionEngine()
+    return _suppression_engine
+
+
+def reset_suppression_engine() -> None:
+    global _suppression_engine, _suppressed_alerts
+    _suppression_engine = None
+    _suppressed_alerts = []
 
 
 def get_last_alerting_status() -> Dict[str, Any]:
@@ -152,13 +171,31 @@ def record_source_failure(
     SOURCE_FAILURES_TOTAL.labels(source=source, failure_type=failure_type).inc()
     SOURCE_HEALTH.labels(source=source).set(0)
 
-    _emit_log_alert(
-        alert_type="source_failure",
-        severity=AlertSeverity.WARNING,
-        title=f"External source failure: {source}",
-        message=message or failure_type,
-        payload=event.to_dict(),
-    )
+    engine = get_suppression_engine()
+    alert = {
+        "alert_type": "source_failure",
+        "severity": AlertSeverity.WARNING.value,
+        "source": source,
+        "failure_type": failure_type,
+        "message": message,
+    }
+    decision = engine.evaluate(alert)
+    if decision.emit:
+        ALERT_EMISSIONS_TOTAL.labels(
+            rule_name=decision.rule_name, reason=decision.reason
+        ).inc()
+        _emit_log_alert(
+            alert_type="source_failure",
+            severity=AlertSeverity.WARNING,
+            title=f"External source failure: {source}",
+            message=message or failure_type,
+            payload=event.to_dict(),
+        )
+    else:
+        _suppressed_alerts.append(alert)
+        ALERT_SUPPRESSIONS_TOTAL.labels(
+            rule_name=decision.rule_name, reason=decision.reason
+        ).inc()
 
 
 def record_source_success(source: str) -> None:
@@ -275,6 +312,7 @@ def measure_pipeline_analytics_lag(
 
 def evaluate_lag_alerts(metrics: List[LagMetricSnapshot]) -> List[Dict[str, Any]]:
     alerts: List[Dict[str, Any]] = []
+    engine = get_suppression_engine()
     for metric in metrics:
         _publish_lag_metric(metric)
         if metric.severity == AlertSeverity.HEALTHY:
@@ -282,19 +320,34 @@ def evaluate_lag_alerts(metrics: List[LagMetricSnapshot]) -> List[Dict[str, Any]
 
         alert = {
             "alert_type": "indexer_lag",
+            "severity": metric.severity.value,
+            "metric_name": metric.metric_name,
+            "source": metric.source,
             "metric": metric.to_dict(),
         }
-        alerts.append(alert)
-        _emit_log_alert(
-            alert_type="indexer_lag",
-            severity=metric.severity,
-            title=f"Indexer lag alert: {metric.metric_name}",
-            message=(
-                f"{metric.source} lag {metric.lag_seconds:.0f}s exceeds "
-                f"{metric.severity.value} threshold"
-            ),
-            payload=alert,
-        )
+
+        decision = engine.evaluate(alert)
+        if decision.emit:
+            alerts.append(alert)
+            ALERT_EMISSIONS_TOTAL.labels(
+                rule_name=decision.rule_name, reason=decision.reason
+            ).inc()
+            _emit_log_alert(
+                alert_type="indexer_lag",
+                severity=metric.severity,
+                title=f"Indexer lag alert: {metric.metric_name}",
+                message=(
+                    f"{metric.source} lag {metric.lag_seconds:.0f}s exceeds "
+                    f"{metric.severity.value} threshold"
+                ),
+                payload=alert,
+            )
+        else:
+            _suppressed_alerts.append(alert)
+            ALERT_SUPPRESSIONS_TOTAL.labels(
+                rule_name=decision.rule_name, reason=decision.reason
+            ).inc()
+
     return alerts
 
 
@@ -318,12 +371,22 @@ def run_ingestion_alerting_cycle(
     recent_failures = [event.to_dict() for event in _recent_failures[-20:]]
     lag_alerts = evaluate_lag_alerts(metrics)
 
+    engine = get_suppression_engine()
+    suppressed = list(_suppressed_alerts)
+    _suppressed_alerts.clear()
+
     result = {
         "checked_at": datetime.now(timezone.utc).isoformat(),
         "metrics": [metric.to_dict() for metric in metrics],
         "lag_alerts": lag_alerts,
         "recent_source_failures": recent_failures,
         "healthy": not lag_alerts and not recent_failures,
+        "suppressed_alerts": suppressed,
+        "suppression_engine_stats": engine.stats,
     }
     _last_cycle_result = result
     return result
+
+
+def get_suppressed_alerts() -> List[Dict[str, Any]]:
+    return list(_suppressed_alerts)

--- a/apps/data-processing/src/scheduler.py
+++ b/apps/data-processing/src/scheduler.py
@@ -211,12 +211,23 @@ def _ingestion_alerting_job() -> None:
         from src.ingestion.ingestion_alerting import run_ingestion_alerting_cycle
 
         result = run_ingestion_alerting_cycle()
+        suppressed = result.get("suppressed_alerts", [])
+        engine_stats = result.get("suppression_engine_stats", {})
         logger.info(
-            "Ingestion alerting cycle complete | healthy=%s | metrics=%d | lag_alerts=%d",
+            "Ingestion alerting cycle complete | healthy=%s | metrics=%d | "
+            "lag_alerts=%d | suppressed=%d | rules=%d",
             result.get("healthy"),
             len(result.get("metrics", [])),
             len(result.get("lag_alerts", [])),
+            len(suppressed),
+            len(engine_stats.get("rules", [])),
         )
+        if suppressed:
+            logger.info(
+                "ALERT_SUPPRESSION suppressed=%d aler-types=%s",
+                len(suppressed),
+                [s.get("alert_type") for s in suppressed[:5]],
+            )
     except Exception as exc:
         logger.error("Ingestion alerting job failed: %s", exc, exc_info=True)
 

--- a/apps/data-processing/src/utils/metrics.py
+++ b/apps/data-processing/src/utils/metrics.py
@@ -57,6 +57,19 @@ SOURCE_HEALTH = Gauge(
     ["source"],
 )
 
+ALERT_SUPPRESSIONS_TOTAL = Counter(
+    "lumenpulse_alert_suppressions_total",
+    "Total number of alerts suppressed by the dedup engine",
+    ["rule_name", "reason"],
+)
+
+ALERT_EMISSIONS_TOTAL = Counter(
+    "lumenpulse_alert_emissions_total",
+    "Total number of alerts emitted by the dedup engine",
+    ["rule_name", "reason"],
+)
+
+
 def start_metrics_server(port: int = 9090):
     """Start standalone prometheus metrics server (for background workers)"""
     try:

--- a/apps/data-processing/tests/test_alert_engine.py
+++ b/apps/data-processing/tests/test_alert_engine.py
@@ -1,0 +1,387 @@
+"""Tests for the alert suppression and dedup rules engine (#1058)."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.alert_engine.engine import AlertSuppressionEngine, SuppressionDecision
+from src.alert_engine.rule import (
+    AlertTypeRule,
+    NoisyConditionRule,
+    RepeatAlertRule,
+    SeverityThresholdRule,
+    SuppressionRule,
+    build_rules_from_config,
+)
+from src.alert_engine.storage import SuppressionRecord, SuppressionStore
+
+
+# ── Rule Tests ───────────────────────────────────────────────────────
+
+
+class TestRepeatAlertRule:
+    def test_matches_anything(self):
+        rule = RepeatAlertRule(name="test", window_seconds=300)
+        assert rule.matches({"alert_type": "foo"}) is True
+        assert rule.matches({}) is True
+
+    def test_compute_key_uses_key_fields(self):
+        rule = RepeatAlertRule(
+            name="test",
+            window_seconds=300,
+            key_fields=["alert_type", "source"],
+        )
+        key1 = rule.compute_key({"alert_type": "lag", "source": "horizon"})
+        key2 = rule.compute_key({"alert_type": "lag", "source": "horizon"})
+        key3 = rule.compute_key({"alert_type": "lag", "source": "other"})
+        assert key1 == key2
+        assert key1 != key3
+
+    def test_compute_key_deterministic(self):
+        rule = RepeatAlertRule(name="test", window_seconds=300)
+        a = rule.compute_key({"alert_type": "x", "severity": "critical"})
+        b = rule.compute_key({"severity": "critical", "alert_type": "x"})
+        assert a == b
+
+
+class TestNoisyConditionRule:
+    def test_matches_anything(self):
+        rule = NoisyConditionRule(name="test", window_seconds=300, rate_limit=5)
+        assert rule.matches({"x": 1}) is True
+
+    def test_to_dict_includes_rate_limit(self):
+        rule = NoisyConditionRule(name="test", window_seconds=300, rate_limit=5)
+        d = rule.to_dict()
+        assert d["rate_limit"] == 5
+
+
+class TestSeverityThresholdRule:
+    def test_suppresses_low_severity(self):
+        rule = SeverityThresholdRule(
+            name="test", window_seconds=0, min_severity="warning"
+        )
+        assert rule.matches({"severity": "healthy"}) is True
+        assert rule.matches({"severity": "info"}) is True
+        assert rule.matches({"severity": "warning"}) is False
+        assert rule.matches({"severity": "critical"}) is False
+
+    def test_default_min_severity(self):
+        rule = SeverityThresholdRule(name="test", window_seconds=0)
+        assert rule.min_severity == "warning"
+
+
+class TestAlertTypeRule:
+    def test_matches_specific_types(self):
+        rule = AlertTypeRule(
+            name="test",
+            window_seconds=300,
+            alert_types=["indexer_lag", "contract_lag"],
+        )
+        assert rule.matches({"alert_type": "indexer_lag"}) is True
+        assert rule.matches({"alert_type": "contract_lag"}) is True
+        assert rule.matches({"alert_type": "source_failure"}) is False
+
+
+class TestBuildRulesFromConfig:
+    def test_builds_all_rule_types(self):
+        configs = [
+            {"type": "repeat_alert", "name": "r1", "window_seconds": 60},
+            {
+                "type": "noisy_condition",
+                "name": "r2",
+                "window_seconds": 300,
+                "rate_limit": 10,
+            },
+            {
+                "type": "severity_threshold",
+                "name": "r3",
+                "window_seconds": 0,
+                "min_severity": "warning",
+            },
+            {
+                "type": "alert_type",
+                "name": "r4",
+                "window_seconds": 60,
+                "alert_types": ["foo"],
+            },
+        ]
+        rules = build_rules_from_config(configs)
+        assert len(rules) == 4
+        assert isinstance(rules[0], RepeatAlertRule)
+        assert isinstance(rules[1], NoisyConditionRule)
+        assert isinstance(rules[2], SeverityThresholdRule)
+        assert isinstance(rules[3], AlertTypeRule)
+
+
+# ── SuppressionStore Tests ───────────────────────────────────────────
+
+
+class TestSuppressionStore:
+    @pytest.fixture
+    def store(self, tmp_path: Path):
+        path = str(tmp_path / "test_suppression.json")
+        return SuppressionStore(storage_path=path)
+
+    def test_record_emitted_creates_entry(self, store: SuppressionStore):
+        rec = store.record_emitted("key1", "rule1", {"alert_type": "test"})
+        assert rec.dedup_key == "key1"
+        assert rec.rule_name == "rule1"
+        assert rec.emit_count == 1
+        assert rec.suppress_count == 0
+
+    def test_record_suppressed_increments_count(self, store: SuppressionStore):
+        store.record_emitted("key1", "rule1", {"alert_type": "test"})
+        rec = store.record_suppressed("key1", "rule1", {"alert_type": "test"})
+        assert rec.emit_count == 1
+        assert rec.suppress_count == 1
+
+    def test_get_returns_none_for_unknown(self, store: SuppressionStore):
+        assert store.get("nonexistent") is None
+
+    def test_get_returns_record(self, store: SuppressionStore):
+        store.record_emitted("key1", "rule1", {"alert_type": "test"})
+        rec = store.get("key1")
+        assert rec is not None
+        assert rec.emit_count == 1
+
+    def test_clear_removes_all(self, store: SuppressionStore):
+        store.record_emitted("key1", "rule1", {"alert_type": "test"})
+        store.clear()
+        assert store.get("key1") is None
+
+    def test_persistence_across_reload(self, tmp_path: Path):
+        path = str(tmp_path / "persist.json")
+        store1 = SuppressionStore(storage_path=path)
+        store1.record_emitted("k", "r", {"a": 1})
+        del store1
+
+        store2 = SuppressionStore(storage_path=path)
+        rec = store2.get("k")
+        assert rec is not None
+        assert rec.emit_count == 1
+        assert rec.rule_name == "r"
+
+
+# ── AlertSuppressionEngine Tests ─────────────────────────────────────
+
+
+class TestAlertSuppressionEngine:
+    @pytest.fixture
+    def engine(self, tmp_path: Path):
+        path = str(tmp_path / "engine_store.json")
+        rules = [
+            RepeatAlertRule(
+                name="dedup_test",
+                window_seconds=300,
+                key_fields=["alert_type", "metric_name", "severity"],
+            ),
+        ]
+        return AlertSuppressionEngine(rules=rules, storage_path=path)
+
+    def test_first_occurrence_is_emitted(self, engine: AlertSuppressionEngine):
+        decision = engine.evaluate({
+            "alert_type": "indexer_lag",
+            "metric_name": "stellar_ledger_lag",
+            "severity": "critical",
+        })
+        assert decision.emit is True
+        assert decision.reason == "first_occurrence"
+
+    def test_repeat_within_window_is_suppressed(self, engine: AlertSuppressionEngine):
+        alert = {
+            "alert_type": "indexer_lag",
+            "metric_name": "stellar_ledger_lag",
+            "severity": "critical",
+        }
+        first = engine.evaluate(alert)
+        assert first.emit is True
+
+        second = engine.evaluate(alert)
+        assert second.emit is False
+        assert second.reason == "suppressed_within_window"
+
+    def test_repeat_after_window_expired_is_emitted(self, engine: AlertSuppressionEngine):
+        alert = {
+            "alert_type": "indexer_lag",
+            "metric_name": "stellar_ledger_lag",
+            "severity": "critical",
+        }
+        engine.evaluate(alert)
+
+        import time
+        time.sleep(0.01)
+        engine._store._records.clear()
+        engine._store.record_emitted(
+            engine._rules[0].compute_key(alert),
+            engine._rules[0].name,
+            alert,
+        )
+        record = engine._store.get(engine._rules[0].compute_key(alert))
+        record.last_attempt = (
+            datetime.now(timezone.utc) - timedelta(seconds=301)
+        ).isoformat()
+
+        decision = engine.evaluate(alert)
+
+        assert decision.emit is True
+        assert decision.reason == "window_expired"
+
+    def test_no_matching_rule_always_emits(self, tmp_path: Path):
+        engine = AlertSuppressionEngine(rules=[], storage_path=str(tmp_path / "no_rules.json"))
+        decision = engine.evaluate({"alert_type": "anything"})
+        assert decision.emit is True
+        assert decision.reason == "no_matching_rule"
+
+    def test_max_suppressions_forces_emit(self, tmp_path: Path):
+        path = str(tmp_path / "max_supp.json")
+        rules = [
+            RepeatAlertRule(
+                name="dedup_test",
+                window_seconds=3600,
+                key_fields=["alert_type"],
+                max_suppressions=2,
+            ),
+        ]
+        engine = AlertSuppressionEngine(rules=rules, storage_path=path)
+        alert = {"alert_type": "test"}
+
+        first = engine.evaluate(alert)
+        assert first.emit is True
+        assert first.reason == "first_occurrence"
+
+        second = engine.evaluate(alert)
+        assert second.emit is False
+        assert second.reason == "suppressed_within_window"
+
+        third = engine.evaluate(alert)
+        assert third.emit is False
+        assert third.reason == "suppressed_within_window"
+
+        fourth = engine.evaluate(alert)
+        assert fourth.emit is True
+        assert fourth.reason.startswith("forced_emit")
+
+    def test_evaluate_batch_returns_only_emitted(self, engine: AlertSuppressionEngine):
+        alerts = [
+            {"alert_type": "lag", "metric_name": "m1", "severity": "critical"},
+            {"alert_type": "lag", "metric_name": "m1", "severity": "critical"},
+            {"alert_type": "lag", "metric_name": "m2", "severity": "warning"},
+        ]
+        emitted = engine.evaluate_batch(alerts)
+        assert len(emitted) == 2
+        for e in emitted:
+            assert e["_suppression"]["reason"] in ("first_occurrence", "no_matching_rule")
+
+    def test_stats(self, engine: AlertSuppressionEngine):
+        engine.evaluate({"alert_type": "x", "severity": "critical"})
+        engine.evaluate({"alert_type": "x", "severity": "critical"})
+        stats = engine.stats
+        assert stats["emissions_total"] >= 1
+        assert stats["suppressions_total"] >= 1
+        assert len(stats["rules"]) == 1
+
+    def test_suppression_records(self, engine: AlertSuppressionEngine):
+        engine.evaluate({"alert_type": "x", "metric_name": "m", "severity": "critical"})
+        recs = engine.suppression_records
+        assert len(recs) == 1
+        key = list(recs.keys())[0]
+        assert recs[key]["emit_count"] == 1
+
+    def test_reload_rules(self, engine: AlertSuppressionEngine):
+        new_rules = [
+            RepeatAlertRule(name="new_rule", window_seconds=600, key_fields=["alert_type"]),
+        ]
+        engine.reload_rules(new_rules)
+        assert len(engine._rules) == 1
+        assert engine._rules[0].name == "new_rule"
+
+
+# ── Integration: suppression_engine with ingestion_alerting ──────────
+
+
+class TestIngestionAlertingIntegration:
+    def test_suppression_logged_in_cycle_result(self, tmp_path: Path):
+        from src.ingestion.ingestion_alerting import (
+            evaluate_lag_alerts,
+            get_suppression_engine,
+            reset_suppression_engine,
+        )
+        from src.ingestion.ingestion_alerting import LagMetricSnapshot, AlertSeverity
+
+        reset_suppression_engine()
+        path = str(tmp_path / "integration_store.json")
+
+        import os
+        with patch.dict(os.environ, {"ALERT_SUPPRESSION_STORE_PATH": path}):
+            engine = get_suppression_engine()
+            engine._store.clear()
+
+            metrics = [
+                LagMetricSnapshot(
+                    metric_name="test_metric",
+                    source="test_source",
+                    lag_seconds=500.0,
+                    severity=AlertSeverity.CRITICAL,
+                    warning_threshold_seconds=60.0,
+                    critical_threshold_seconds=300.0,
+                    details={},
+                ),
+            ]
+
+            first = evaluate_lag_alerts(metrics)
+            assert len(first) == 1
+
+            second = evaluate_lag_alerts(metrics)
+            assert len(second) == 0
+
+            engine = get_suppression_engine()
+            recs = engine.suppression_records
+            assert len(recs) > 0
+
+
+# ── config loading tests ─────────────────────────────────────────────
+
+
+class TestConfigLoading:
+    def test_default_rules_loaded(self):
+        from src.alert_engine.config import _default_rules
+
+        rules = _default_rules()
+        assert len(rules) == 5
+        names = [r.name for r in rules]
+        assert "dedup_indexer_lag" in names
+        assert "dedup_source_failures" in names
+        assert "rate_limit_source_failures" in names
+        assert "suppress_healthy_alerts" in names
+        assert "dedup_contract_lag" in names
+
+    def test_load_rules_from_env(self):
+        from src.alert_engine.config import load_rules_from_env
+
+        with patch.dict(os.environ, {"ALERT_DEDUP_WINDOW_SECONDS": "600"}):
+            rules = load_rules_from_env()
+            assert len(rules) == 1
+            assert rules[0].window_seconds == 600
+
+    def test_load_rules_from_yaml_file(self, tmp_path: Path):
+        from src.alert_engine.config import load_rules_from_yaml
+
+        yaml_path = tmp_path / "test_rules.yaml"
+        yaml_path.write_text("""
+suppression_rules:
+  - type: repeat_alert
+    name: "custom_rule"
+    window_seconds: 120
+    key_fields: ["alert_type"]
+""")
+        rules = load_rules_from_yaml(str(yaml_path))
+        assert len(rules) == 1
+        assert rules[0].name == "custom_rule"
+        assert rules[0].window_seconds == 120


### PR DESCRIPTION
## Summary
Implements a configurable alert suppression and deduplication rules engine for the data-processing pipeline (closes #1058). Prevents alert spam by deduplicating repeated triggers and applying suppression windows for noisy conditions.

## New module: `src/alert_engine/`

| File | Description |
|---|---|
| `rule.py` | `SuppressionRule` ABC + 4 concrete implementations: `RepeatAlertRule`, `NoisyConditionRule`, `SeverityThresholdRule`, `AlertTypeRule` |
| `engine.py` | `AlertSuppressionEngine` — evaluates alerts against rules, returns emit/suppress decisions with full metadata |
| `storage.py` | `SuppressionStore` — persists dedup state to JSON (tracks first_seen, last_attempt, emit_count, suppress_count per dedup key) |
| `config.py` | Loads rules from YAML file, env var, or env fallback |

## Key behaviors

### Acceptance criteria — How it's met
- Repeated alerts suppressed within configurable window — `RepeatAlertRule` suppresses identical keys within `window_seconds`
- Dedup behavior is configurable — Every `SuppressionDecision` returns `rule_name`, `dedup_key`, `reason`, `emit_count`, `suppress_count`
- First-occurrence alerts are still emitted — First call always returns `emit=True` with reason `"first_occurrence"`
- Rules tunable without code changes — Loaded from `config/alert_rules.yaml`, overridable via `ALERT_RULES_PATH` or `ALERT_RULES_JSON` env vars

### Additional safeguards
- `max_suppressions` prevents indefinite suppression of N suppressions
- Window expiry re-emits with reason `"window_expired"`
- `SeverityThresholdRule` can suppress healthy/info alerts while letting warning/critical through

## Integration
- **`ingestion_alerting.py`**: `evaluate_lag_alerts()` and `record_source_failure()` route through the suppression engine before emitting logs
- **`scheduler.py`**: `_ingestion_alerting_job()` logs suppressed alert counts and types per cycle
- **`metrics.py`**: New Prometheus counters `lunepulse_alert_suppressions_total` and `lunepulse_alert_emissions_total` (labeled by rule_name and reason)
- **`.env.example`**: New vars `ALERT_RULES_PATH`, `ALERT_RULES_JSON`, `ALERT_DEDUP_WINDOW_SECONDS`, `ALERT_SUPPRESSION_STORE_PATH`

## Testing
28 test cases covering:
- All rule types (match behavior, key computation, serialization)
- `SuppressionStore` persistence (create, update, reload across instances)
- Engine decisions (first occurrence, repeat within window, window expiry, max suppressions, batch, stats)
- Config loading (YAML file, env vars, default rules)
- Integration with `ingestion_alerting` evaluate cycle

## Default rules (`config/alert_rules.yaml`)
```yaml
dedup_indexer_lag: 5min window, keyed by metric+source+severity
dedup_source_failures: 60s window, keyed by source+failure_type
rate_limit_source_failures: 5min window, max 30 suppressions
suppress_healthy_alerts: skip healthy/info severity
dedup_contract_lag: 5min window, keyed by domain+severity
```

Closes #1058