### PR TITLE
feat(protocol_registry): multi-admin quorum approval for privileged actions

### DIFF
--- a/apps/onchain/contracts/protocol_registry/src/errors.rs
+++ b/apps/onchain/contracts/protocol_registry/src/errors.rs
@@ -13,4 +13,28 @@ pub enum RegistryError {
     ContractPaused = 7,
     /// Attempted to register/update with a version ≤ the current recorded version.
     VersionNotIncremented = 8,
+    // ── Multi-admin quorum errors ───────────────────────────────
+    // Appended after the pre-existing codes so already-emitted discriminants
+    // keep their meaning for off-chain consumers.
+    /// A quorum-gated action was called before any quorum policy was installed.
+    QuorumNotConfigured = 9,
+    /// `configure_quorum` was called twice; use a `SetQuorumConfig` proposal to
+    /// rotate an existing signer set.
+    QuorumAlreadyConfigured = 10,
+    /// Empty signer set, zero weight, zero threshold, or a threshold larger
+    /// than the total signer weight (which would deadlock every action).
+    InvalidQuorumConfig = 11,
+    /// Signer set exceeds `quorum::MAX_SIGNERS`.
+    TooManySigners = 12,
+    ProposalNotFound = 13,
+    /// The proposal exists but has not yet collected enough weight.
+    ProposalNotApproved = 14,
+    /// This signer has already approved this proposal.
+    ProposalAlreadySigned = 15,
+    ProposalExpired = 16,
+    /// The proposal is executed, cancelled, or expired and can no longer move.
+    ProposalNotActive = 17,
+    /// The approved action (or its bound parameters) does not match the action
+    /// being executed.
+    WrongProposalAction = 18,
 }

--- a/apps/onchain/contracts/protocol_registry/src/events.rs
+++ b/apps/onchain/contracts/protocol_registry/src/events.rs
@@ -1,5 +1,7 @@
 use soroban_sdk::{contractevent, Address, Symbol};
 
+use crate::quorum::{ProposalStatus, RegistryAction};
+
 #[contractevent]
 pub struct InitializedEvent {
     pub admin: Address,
@@ -41,4 +43,57 @@ pub struct ModuleActivatedEvent {
 pub struct AdminTransferredEvent {
     pub old_admin: Address,
     pub new_admin: Address,
+}
+
+// ── Multi-admin quorum lifecycle ──────────────────────────────────
+// Every state transition is published so the approval trail for a privileged
+// change is auditable off-chain without replaying storage.
+
+#[contractevent]
+pub struct QuorumConfiguredEvent {
+    pub bootstrapper: Address,
+    pub threshold: u32,
+    pub signer_count: u32,
+}
+
+#[contractevent]
+pub struct QuorumReconfiguredEvent {
+    pub threshold: u32,
+    pub signer_count: u32,
+}
+
+#[contractevent]
+pub struct ProposalCreatedEvent {
+    #[topic]
+    pub proposal_id: u64,
+    pub proposer: Address,
+    pub action: RegistryAction,
+    pub weight_collected: u32,
+    pub threshold: u32,
+    pub status: ProposalStatus,
+}
+
+#[contractevent]
+pub struct SignatureCollectedEvent {
+    #[topic]
+    pub proposal_id: u64,
+    pub signer: Address,
+    pub weight_collected: u32,
+    pub threshold: u32,
+    pub status: ProposalStatus,
+}
+
+#[contractevent]
+pub struct ProposalExecutedEvent {
+    #[topic]
+    pub proposal_id: u64,
+    pub executor: Address,
+    pub action: RegistryAction,
+}
+
+#[contractevent]
+pub struct ProposalCancelledEvent {
+    #[topic]
+    pub proposal_id: u64,
+    pub signer: Address,
 }

--- a/apps/onchain/contracts/protocol_registry/src/lib.rs
+++ b/apps/onchain/contracts/protocol_registry/src/lib.rs
@@ -2,11 +2,17 @@
 
 mod errors;
 mod events;
+mod quorum;
 mod storage;
 
 use errors::RegistryError;
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Symbol};
+use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Symbol, Vec};
 use storage::{DataKey, ModuleEntry};
+
+pub use quorum::{
+    ModuleProposal, ProposalStatus, QuorumConfig, RegistryAction, RegistryProposal, Signer,
+    MAX_SIGNERS, PROPOSAL_TTL_SECS,
+};
 
 #[contract]
 pub struct ProtocolRegistryContract;
@@ -282,7 +288,295 @@ impl ProtocolRegistryContract {
         env.deployer().update_current_contract_wasm(new_wasm_hash);
         Ok(())
     }
+
+    // ══ Multi-admin quorum ═════════════════════════════════════════════════
+    //
+    // Every privileged action above also has a `*_via_quorum` counterpart that
+    // takes an approved proposal id instead of trusting a single admin. The
+    // admin-only functions are retained unchanged so existing deployments and
+    // tooling keep working; a deployment opts into multi-admin control by
+    // installing a quorum policy and using the gated entrypoints.
+
+    // ── Policy management ────────────────────────────────────────────────────
+
+    /// Install the initial quorum policy (signer set + approval threshold).
+    ///
+    /// The threshold is expressed in the same unit as signer weights, so a
+    /// plain "3-of-5" policy is five weight-1 signers with `threshold = 3`.
+    /// Rotating an existing policy requires a `SetQuorumConfig` proposal.
+    pub fn configure_quorum(
+        env: Env,
+        signers: Vec<Signer>,
+        threshold: u32,
+    ) -> Result<(), RegistryError> {
+        quorum::configure(&env, signers, threshold)
+    }
+
+    /// Replace the signer set / threshold. Requires an approved
+    /// `SetQuorumConfig` proposal, so the approver set cannot be taken over by
+    /// a single signer, nor by redirecting an admin-rotation approval.
+    pub fn set_quorum_config(
+        env: Env,
+        executor: Address,
+        proposal_id: u64,
+        signers: Vec<Signer>,
+        threshold: u32,
+    ) -> Result<(), RegistryError> {
+        quorum::consume_approval(
+            &env,
+            &executor,
+            proposal_id,
+            &RegistryAction::SetQuorumConfig,
+        )?;
+        quorum::replace_config(&env, signers, threshold)
+    }
+
+    // ── Proposal lifecycle ───────────────────────────────────────────────────
+
+    /// Submit a proposal for a privileged action. The proposer must be a
+    /// signer; its weight counts immediately.
+    pub fn propose_action(
+        env: Env,
+        proposer: Address,
+        action: RegistryAction,
+    ) -> Result<u64, RegistryError> {
+        quorum::propose(&env, proposer, action)
+    }
+
+    /// Approve an in-flight proposal. Re-signing fails with
+    /// `ProposalAlreadySigned`.
+    pub fn sign_proposal(
+        env: Env,
+        signer: Address,
+        proposal_id: u64,
+    ) -> Result<ProposalStatus, RegistryError> {
+        quorum::sign(&env, signer, proposal_id)
+    }
+
+    /// Cancel an in-flight proposal. Any signer may cancel.
+    pub fn cancel_proposal(
+        env: Env,
+        signer: Address,
+        proposal_id: u64,
+    ) -> Result<(), RegistryError> {
+        quorum::cancel(&env, signer, proposal_id)
+    }
+
+    /// Mark a lapsed proposal `Expired`. Permissionless.
+    pub fn expire_proposal(env: Env, proposal_id: u64) -> Result<(), RegistryError> {
+        quorum::expire(&env, proposal_id)
+    }
+
+    pub fn get_quorum_config(env: Env) -> Result<QuorumConfig, RegistryError> {
+        quorum::get_config(&env)
+    }
+
+    pub fn get_proposal(env: Env, proposal_id: u64) -> Result<RegistryProposal, RegistryError> {
+        quorum::get_proposal(&env, proposal_id)
+    }
+
+    pub fn get_next_proposal_id(env: Env) -> u64 {
+        quorum::next_proposal_id(&env)
+    }
+
+    // ── Quorum-gated actions ─────────────────────────────────────────────────
+
+    /// Register a module using an approved `RegisterModule` proposal.
+    ///
+    /// The proposal binds name/address/version, so the executor cannot swap in
+    /// a different address than the one the signers approved.
+    pub fn register_module_via_quorum(
+        env: Env,
+        executor: Address,
+        proposal_id: u64,
+        name: Symbol,
+        address: Address,
+        version: u32,
+    ) -> Result<(), RegistryError> {
+        Self::require_not_paused(&env)?;
+
+        let expected = RegistryAction::RegisterModule(ModuleProposal {
+            name: name.clone(),
+            address: address.clone(),
+            version,
+        });
+        quorum::consume_approval(&env, &executor, proposal_id, &expected)?;
+
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Module(name.clone()))
+        {
+            return Err(RegistryError::ModuleAlreadyRegistered);
+        }
+
+        let entry = ModuleEntry {
+            name: name.clone(),
+            address: address.clone(),
+            version,
+            registered_at: env.ledger().timestamp(),
+            is_active: true,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Module(name.clone()), &entry);
+
+        events::ModuleRegisteredEvent {
+            name,
+            address,
+            version,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Upgrade a module using an approved `UpdateModule` proposal.
+    pub fn update_module_via_quorum(
+        env: Env,
+        executor: Address,
+        proposal_id: u64,
+        name: Symbol,
+        new_address: Address,
+        new_version: u32,
+    ) -> Result<(), RegistryError> {
+        Self::require_not_paused(&env)?;
+
+        let expected = RegistryAction::UpdateModule(ModuleProposal {
+            name: name.clone(),
+            address: new_address.clone(),
+            version: new_version,
+        });
+        quorum::consume_approval(&env, &executor, proposal_id, &expected)?;
+
+        let mut entry: ModuleEntry = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Module(name.clone()))
+            .ok_or(RegistryError::ModuleNotFound)?;
+
+        if new_version <= entry.version {
+            return Err(RegistryError::VersionNotIncremented);
+        }
+
+        let old_address = entry.address.clone();
+        let old_version = entry.version;
+
+        entry.address = new_address.clone();
+        entry.version = new_version;
+        entry.registered_at = env.ledger().timestamp();
+        entry.is_active = true;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Module(name.clone()), &entry);
+
+        events::ModuleUpdatedEvent {
+            name,
+            old_address,
+            new_address,
+            old_version,
+            new_version,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Deactivate a module using an approved `DeactivateModule` proposal.
+    pub fn deactivate_module_via_quorum(
+        env: Env,
+        executor: Address,
+        proposal_id: u64,
+        name: Symbol,
+    ) -> Result<(), RegistryError> {
+        let expected = RegistryAction::DeactivateModule(name.clone());
+        quorum::consume_approval(&env, &executor, proposal_id, &expected)?;
+
+        let mut entry: ModuleEntry = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Module(name.clone()))
+            .ok_or(RegistryError::ModuleNotFound)?;
+
+        entry.is_active = false;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Module(name.clone()), &entry);
+
+        events::ModuleDeactivatedEvent {
+            name,
+            admin: executor,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Reactivate a module using an approved `ActivateModule` proposal.
+    pub fn activate_module_via_quorum(
+        env: Env,
+        executor: Address,
+        proposal_id: u64,
+        name: Symbol,
+    ) -> Result<(), RegistryError> {
+        Self::require_not_paused(&env)?;
+
+        let expected = RegistryAction::ActivateModule(name.clone());
+        quorum::consume_approval(&env, &executor, proposal_id, &expected)?;
+
+        let mut entry: ModuleEntry = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Module(name.clone()))
+            .ok_or(RegistryError::ModuleNotFound)?;
+
+        entry.is_active = true;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Module(name.clone()), &entry);
+
+        events::ModuleActivatedEvent {
+            name,
+            admin: executor,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Rotate the registry admin using an approved `SetAdmin` proposal.
+    pub fn set_admin_via_quorum(
+        env: Env,
+        executor: Address,
+        proposal_id: u64,
+        new_admin: Address,
+    ) -> Result<(), RegistryError> {
+        let expected = RegistryAction::SetAdmin(new_admin.clone());
+        quorum::consume_approval(&env, &executor, proposal_id, &expected)?;
+
+        let old_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(RegistryError::NotInitialized)?;
+
+        env.storage().instance().set(&DataKey::Admin, &new_admin);
+
+        events::AdminTransferredEvent {
+            old_admin,
+            new_admin,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
 }
 
+#[cfg(test)]
+mod quorum_test;
 #[cfg(test)]
 mod test;

--- a/apps/onchain/contracts/protocol_registry/src/quorum.rs
+++ b/apps/onchain/contracts/protocol_registry/src/quorum.rs
@@ -1,29 +1,25 @@
 //! N-of-M weighted quorum approval for privileged protocol-registry actions.
 //!
 //! The registry historically gated every privileged action behind a single
-//! `admin` address. This module adds a multi-admin approval lifecycle so that
-//! sensitive changes (module registration/upgrade, deactivation, admin
-//! rotation) require agreement from several signers before they can execute.
+//! `admin` address. This module adds a multi-admin approval lifecycle so
+//! sensitive changes require agreement from several signers before executing.
 //!
 //! Design notes:
-//!
-//! - Storage uses its own [`QuorumKey`] enum rather than extending the
-//!   pre-existing `storage::DataKey`. Soroban assigns XDR discriminants in
-//!   declaration order, so keeping the two key spaces separate means this
-//!   feature cannot shift the discriminants of already-deployed keys.
-//! - [`RegistryAction`] binds the action's *parameters* at proposal time. A
-//!   proposal approved to register `vault -> AAA v1` cannot be replayed at
-//!   execution time against a different address or version, because
-//!   [`consume_approval`] compares the whole action payload.
-//! - Weights are relative and the threshold is expressed in the same unit, so
-//!   a plain N-of-M policy is just "every signer has weight 1, threshold = N".
+//! - Storage uses its own `QuorumKey` enum rather than extending the existing
+//!   `storage::DataKey`. Soroban assigns XDR discriminants in declaration
+//!   order, so separate key spaces mean this feature cannot shift the
+//!   discriminants of already-deployed keys.
+//! - `RegistryAction` binds the action's parameters at proposal time, so an
+//!   approval cannot be replayed against different arguments.
+//! - Weights are relative and the threshold uses the same unit, so a plain
+//!   N-of-M policy is every signer at weight 1 with `threshold = N`.
 
 use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
 
 use crate::errors::RegistryError;
 use crate::events;
 
-/// Hard cap on the signer set size, to keep per-call iteration cost bounded.
+/// Hard cap on signer set size, to keep per-call iteration cost bounded.
 pub const MAX_SIGNERS: u32 = 10;
 
 /// Proposals expire 72 hours after creation if the threshold is never reached.
@@ -36,11 +32,8 @@ const LEDGER_BUMP: u32 = 241_920; // ~2 weeks
 #[contracttype]
 #[derive(Clone)]
 pub enum QuorumKey {
-    /// `QuorumConfig` — the signer set and threshold.
     Config,
-    /// `RegistryProposal` keyed by proposal id.
     Proposal(u64),
-    /// `u64` — monotonic proposal id counter.
     NextProposalId,
 }
 
@@ -49,7 +42,6 @@ pub enum QuorumKey {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Signer {
     pub address: Address,
-    /// Relative weight; the threshold is expressed in the same unit.
     pub weight: u32,
 }
 
@@ -58,15 +50,10 @@ pub struct Signer {
 #[derive(Clone, Debug)]
 pub struct QuorumConfig {
     pub signers: Vec<Signer>,
-    /// Total weight required before a proposal becomes executable.
     pub threshold: u32,
 }
 
 /// Parameters for a module registration or upgrade proposal.
-///
-/// Carried as a single struct so [`RegistryAction`] only needs single-field
-/// variants, and so the full parameter set is covered by the equality check in
-/// [`consume_approval`].
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModuleProposal {
@@ -75,23 +62,17 @@ pub struct ModuleProposal {
     pub version: u32,
 }
 
-/// The set of privileged registry actions that can be put to a quorum vote.
+/// Privileged registry actions that can be put to a quorum vote.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RegistryAction {
-    /// Register a brand new module.
     RegisterModule(ModuleProposal),
-    /// Point an existing module at a new address/version.
     UpdateModule(ModuleProposal),
-    /// Mark a module inactive so `resolve` refuses it.
     DeactivateModule(Symbol),
-    /// Re-enable a previously deactivated module.
     ActivateModule(Symbol),
-    /// Rotate the registry admin address.
     SetAdmin(Address),
-    /// Replace the quorum signer set / threshold. Distinct from `SetAdmin` so
-    /// an admin-rotation approval can never be redirected into a signer-set
-    /// takeover.
+    /// Distinct from `SetAdmin` so an admin-rotation approval can never be
+    /// redirected into a signer-set takeover.
     SetQuorumConfig,
 }
 
@@ -116,12 +97,11 @@ pub struct RegistryProposal {
     pub created_at: u64,
     pub expires_at: u64,
     pub status: ProposalStatus,
-    /// Addresses that have already approved; used to reject double-signing.
+    /// Addresses that already approved; used to reject double-signing.
     pub signers: Vec<Address>,
     pub weight_collected: u32,
 }
 
-/// Load the quorum config, or `QuorumNotConfigured` if it was never set up.
 pub(crate) fn get_config(env: &Env) -> Result<QuorumConfig, RegistryError> {
     env.storage()
         .instance()
@@ -129,12 +109,6 @@ pub(crate) fn get_config(env: &Env) -> Result<QuorumConfig, RegistryError> {
         .ok_or(RegistryError::QuorumNotConfigured)
 }
 
-/// Returns true once a quorum policy has been installed.
-pub(crate) fn is_configured(env: &Env) -> bool {
-    env.storage().instance().has(&QuorumKey::Config)
-}
-
-/// Locate the signer record for `addr`, or reject as `Unauthorized`.
 pub(crate) fn find_signer(config: &QuorumConfig, addr: &Address) -> Result<Signer, RegistryError> {
     for s in config.signers.iter() {
         if s.address == *addr {
@@ -144,7 +118,7 @@ pub(crate) fn find_signer(config: &QuorumConfig, addr: &Address) -> Result<Signe
     Err(RegistryError::Unauthorized)
 }
 
-/// Validate a candidate config: non-empty, bounded, and a reachable threshold.
+/// Validate a candidate config: non-empty, bounded, reachable threshold.
 ///
 /// Rejecting `threshold > total_weight` matters because such a policy would
 /// permanently deadlock every gated action.
@@ -170,7 +144,6 @@ pub(crate) fn validate_config(signers: &Vec<Signer>, threshold: u32) -> Result<(
     Ok(())
 }
 
-/// Fetch a proposal by id.
 pub(crate) fn get_proposal(env: &Env, proposal_id: u64) -> Result<RegistryProposal, RegistryError> {
     env.storage()
         .instance()
@@ -178,8 +151,7 @@ pub(crate) fn get_proposal(env: &Env, proposal_id: u64) -> Result<RegistryPropos
         .ok_or(RegistryError::ProposalNotFound)
 }
 
-/// The id the next proposal will receive. Read-only; does not advance the
-/// counter.
+/// The id the next proposal will receive. Read-only.
 pub(crate) fn next_proposal_id(env: &Env) -> u64 {
     env.storage()
         .instance()
@@ -199,29 +171,28 @@ fn assert_active(env: &Env, proposal: &RegistryProposal) -> Result<(), RegistryE
     Ok(())
 }
 
-/// Pop the next monotonic proposal id.
-fn next_id(env: &Env) -> u64 {
-    let id: u64 = next_proposal_id(env);
+fn take_next_id(env: &Env) -> u64 {
+    let id = next_proposal_id(env);
     env.storage()
         .instance()
         .set(&QuorumKey::NextProposalId, &(id + 1));
     id
 }
 
-fn bump_instance_ttl(env: &Env) {
+fn bump_ttl(env: &Env) {
     env.storage()
         .instance()
         .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
 }
 
-/// Install the initial quorum policy. The first signer bootstraps the policy
-/// and must authenticate the call.
+/// Install the initial quorum policy. The first signer bootstraps it and must
+/// authenticate the call.
 pub(crate) fn configure(
     env: &Env,
     signers: Vec<Signer>,
     threshold: u32,
 ) -> Result<(), RegistryError> {
-    if is_configured(env) {
+    if env.storage().instance().has(&QuorumKey::Config) {
         return Err(RegistryError::QuorumAlreadyConfigured);
     }
     validate_config(&signers, threshold)?;
@@ -235,7 +206,7 @@ pub(crate) fn configure(
     env.storage()
         .instance()
         .set(&QuorumKey::NextProposalId, &0u64);
-    bump_instance_ttl(env);
+    bump_ttl(env);
 
     events::QuorumConfiguredEvent {
         bootstrapper: bootstrapper.address,
@@ -248,7 +219,7 @@ pub(crate) fn configure(
 }
 
 /// Replace the signer set / threshold. Only reachable through an executed
-/// `SetQuorumConfig` proposal, so rotating the approver set is itself gated.
+/// `SetQuorumConfig` proposal.
 pub(crate) fn replace_config(
     env: &Env,
     signers: Vec<Signer>,
@@ -259,7 +230,7 @@ pub(crate) fn replace_config(
     let signer_count = signers.len();
     let config = QuorumConfig { signers, threshold };
     env.storage().instance().set(&QuorumKey::Config, &config);
-    bump_instance_ttl(env);
+    bump_ttl(env);
 
     events::QuorumReconfiguredEvent {
         threshold,
@@ -283,7 +254,7 @@ pub(crate) fn propose(
     let signer = find_signer(&config, &proposer)?;
 
     let now = env.ledger().timestamp();
-    let id = next_id(env);
+    let id = take_next_id(env);
 
     let mut signers_vec = Vec::new(env);
     signers_vec.push_back(proposer.clone());
@@ -309,7 +280,7 @@ pub(crate) fn propose(
     env.storage()
         .instance()
         .set(&QuorumKey::Proposal(id), &proposal);
-    bump_instance_ttl(env);
+    bump_ttl(env);
 
     events::ProposalCreatedEvent {
         proposal_id: id,
@@ -324,10 +295,8 @@ pub(crate) fn propose(
     Ok(id)
 }
 
-/// Add a signer's weight to an in-flight proposal.
-///
-/// Re-signing is rejected with `ProposalAlreadySigned`, so one approver cannot
-/// reach the threshold alone by calling this repeatedly.
+/// Add a signer's weight to an in-flight proposal. Re-signing is rejected, so
+/// one approver cannot reach the threshold alone by calling this repeatedly.
 pub(crate) fn sign(
     env: &Env,
     signer_addr: Address,
@@ -357,7 +326,7 @@ pub(crate) fn sign(
     env.storage()
         .instance()
         .set(&QuorumKey::Proposal(proposal_id), &proposal);
-    bump_instance_ttl(env);
+    bump_ttl(env);
 
     events::SignatureCollectedEvent {
         proposal_id,
@@ -371,11 +340,11 @@ pub(crate) fn sign(
     Ok(proposal.status)
 }
 
-/// Consume an approved proposal's authority exactly once and mark it Executed.
+/// Consume an approved proposal's authority exactly once, marking it Executed.
 ///
-/// Fails if the proposal is missing, not yet approved, expired, already
-/// executed, or if `expected_action` does not match the approved action -
-/// including its bound parameters.
+/// Fails if the proposal is missing, not approved, expired, already spent, or
+/// if `expected_action` differs from the approved action - including its bound
+/// parameters.
 pub(crate) fn consume_approval(
     env: &Env,
     executor: &Address,
@@ -402,7 +371,7 @@ pub(crate) fn consume_approval(
     env.storage()
         .instance()
         .set(&QuorumKey::Proposal(proposal_id), &proposal);
-    bump_instance_ttl(env);
+    bump_ttl(env);
 
     events::ProposalExecutedEvent {
         proposal_id,
@@ -436,7 +405,7 @@ pub(crate) fn cancel(
     env.storage()
         .instance()
         .set(&QuorumKey::Proposal(proposal_id), &proposal);
-    bump_instance_ttl(env);
+    bump_ttl(env);
 
     events::ProposalCancelledEvent {
         proposal_id,
@@ -465,7 +434,7 @@ pub(crate) fn expire(env: &Env, proposal_id: u64) -> Result<(), RegistryError> {
     env.storage()
         .instance()
         .set(&QuorumKey::Proposal(proposal_id), &proposal);
-    bump_instance_ttl(env);
+    bump_ttl(env);
 
     Ok(())
 }

--- a/apps/onchain/contracts/protocol_registry/src/quorum.rs
+++ b/apps/onchain/contracts/protocol_registry/src/quorum.rs
@@ -1,0 +1,481 @@
+//! N-of-M weighted quorum approval for privileged protocol-registry actions.
+//!
+//! The registry historically gated every privileged action behind a single
+//! `admin` address. This module adds a multi-admin approval lifecycle so that
+//! sensitive changes (module registration/upgrade, deactivation, admin
+//! rotation) require agreement from several signers before they can execute.
+//!
+//! Design notes:
+//!
+//! - Storage uses its own [`QuorumKey`] enum rather than extending the
+//!   pre-existing `storage::DataKey`. Soroban assigns XDR discriminants in
+//!   declaration order, so keeping the two key spaces separate means this
+//!   feature cannot shift the discriminants of already-deployed keys.
+//! - [`RegistryAction`] binds the action's *parameters* at proposal time. A
+//!   proposal approved to register `vault -> AAA v1` cannot be replayed at
+//!   execution time against a different address or version, because
+//!   [`consume_approval`] compares the whole action payload.
+//! - Weights are relative and the threshold is expressed in the same unit, so
+//!   a plain N-of-M policy is just "every signer has weight 1, threshold = N".
+
+use soroban_sdk::{contracttype, Address, Env, Symbol, Vec};
+
+use crate::errors::RegistryError;
+use crate::events;
+
+/// Hard cap on the signer set size, to keep per-call iteration cost bounded.
+pub const MAX_SIGNERS: u32 = 10;
+
+/// Proposals expire 72 hours after creation if the threshold is never reached.
+pub const PROPOSAL_TTL_SECS: u64 = 72 * 60 * 60;
+
+const LEDGER_THRESHOLD: u32 = 120_960; // ~1 week
+const LEDGER_BUMP: u32 = 241_920; // ~2 weeks
+
+/// Storage keys owned by the quorum module.
+#[contracttype]
+#[derive(Clone)]
+pub enum QuorumKey {
+    /// `QuorumConfig` — the signer set and threshold.
+    Config,
+    /// `RegistryProposal` keyed by proposal id.
+    Proposal(u64),
+    /// `u64` — monotonic proposal id counter.
+    NextProposalId,
+}
+
+/// A registered approver and its relative voting weight.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Signer {
+    pub address: Address,
+    /// Relative weight; the threshold is expressed in the same unit.
+    pub weight: u32,
+}
+
+/// N-of-M quorum configuration.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct QuorumConfig {
+    pub signers: Vec<Signer>,
+    /// Total weight required before a proposal becomes executable.
+    pub threshold: u32,
+}
+
+/// Parameters for a module registration or upgrade proposal.
+///
+/// Carried as a single struct so [`RegistryAction`] only needs single-field
+/// variants, and so the full parameter set is covered by the equality check in
+/// [`consume_approval`].
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModuleProposal {
+    pub name: Symbol,
+    pub address: Address,
+    pub version: u32,
+}
+
+/// The set of privileged registry actions that can be put to a quorum vote.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RegistryAction {
+    /// Register a brand new module.
+    RegisterModule(ModuleProposal),
+    /// Point an existing module at a new address/version.
+    UpdateModule(ModuleProposal),
+    /// Mark a module inactive so `resolve` refuses it.
+    DeactivateModule(Symbol),
+    /// Re-enable a previously deactivated module.
+    ActivateModule(Symbol),
+    /// Rotate the registry admin address.
+    SetAdmin(Address),
+    /// Replace the quorum signer set / threshold. Distinct from `SetAdmin` so
+    /// an admin-rotation approval can never be redirected into a signer-set
+    /// takeover.
+    SetQuorumConfig,
+}
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ProposalStatus {
+    Pending = 0,
+    Approved = 1,
+    Executed = 2,
+    Expired = 3,
+    Cancelled = 4,
+}
+
+/// On-chain record of a single registry proposal.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RegistryProposal {
+    pub id: u64,
+    pub action: RegistryAction,
+    pub proposer: Address,
+    pub created_at: u64,
+    pub expires_at: u64,
+    pub status: ProposalStatus,
+    /// Addresses that have already approved; used to reject double-signing.
+    pub signers: Vec<Address>,
+    pub weight_collected: u32,
+}
+
+/// Load the quorum config, or `QuorumNotConfigured` if it was never set up.
+pub(crate) fn get_config(env: &Env) -> Result<QuorumConfig, RegistryError> {
+    env.storage()
+        .instance()
+        .get(&QuorumKey::Config)
+        .ok_or(RegistryError::QuorumNotConfigured)
+}
+
+/// Returns true once a quorum policy has been installed.
+pub(crate) fn is_configured(env: &Env) -> bool {
+    env.storage().instance().has(&QuorumKey::Config)
+}
+
+/// Locate the signer record for `addr`, or reject as `Unauthorized`.
+pub(crate) fn find_signer(
+    config: &QuorumConfig,
+    addr: &Address,
+) -> Result<Signer, RegistryError> {
+    for s in config.signers.iter() {
+        if s.address == *addr {
+            return Ok(s);
+        }
+    }
+    Err(RegistryError::Unauthorized)
+}
+
+/// Validate a candidate config: non-empty, bounded, and a reachable threshold.
+///
+/// Rejecting `threshold > total_weight` matters because such a policy would
+/// permanently deadlock every gated action.
+pub(crate) fn validate_config(
+    signers: &Vec<Signer>,
+    threshold: u32,
+) -> Result<(), RegistryError> {
+    if signers.is_empty() || threshold == 0 {
+        return Err(RegistryError::InvalidQuorumConfig);
+    }
+    if signers.len() > MAX_SIGNERS {
+        return Err(RegistryError::TooManySigners);
+    }
+    let mut total: u32 = 0;
+    for s in signers.iter() {
+        if s.weight == 0 {
+            return Err(RegistryError::InvalidQuorumConfig);
+        }
+        total = total
+            .checked_add(s.weight)
+            .ok_or(RegistryError::InvalidQuorumConfig)?;
+    }
+    if threshold > total {
+        return Err(RegistryError::InvalidQuorumConfig);
+    }
+    Ok(())
+}
+
+/// Fetch a proposal by id.
+pub(crate) fn get_proposal(
+    env: &Env,
+    proposal_id: u64,
+) -> Result<RegistryProposal, RegistryError> {
+    env.storage()
+        .instance()
+        .get(&QuorumKey::Proposal(proposal_id))
+        .ok_or(RegistryError::ProposalNotFound)
+}
+
+/// Verify a proposal is still in flight (Pending or Approved, not expired).
+fn assert_active(env: &Env, proposal: &RegistryProposal) -> Result<(), RegistryError> {
+    match proposal.status {
+        ProposalStatus::Pending | ProposalStatus::Approved => {}
+        _ => return Err(RegistryError::ProposalNotActive),
+    }
+    if env.ledger().timestamp() > proposal.expires_at {
+        return Err(RegistryError::ProposalExpired);
+    }
+    Ok(())
+}
+
+/// Pop the next monotonic proposal id.
+fn next_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .instance()
+        .get(&QuorumKey::NextProposalId)
+        .unwrap_or(0);
+    env.storage()
+        .instance()
+        .set(&QuorumKey::NextProposalId, &(id + 1));
+    id
+}
+
+fn bump_instance_ttl(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(LEDGER_THRESHOLD, LEDGER_BUMP);
+}
+
+/// Install the initial quorum policy. The first signer bootstraps the policy
+/// and must authenticate the call.
+pub(crate) fn configure(
+    env: &Env,
+    signers: Vec<Signer>,
+    threshold: u32,
+) -> Result<(), RegistryError> {
+    if is_configured(env) {
+        return Err(RegistryError::QuorumAlreadyConfigured);
+    }
+    validate_config(&signers, threshold)?;
+
+    let bootstrapper = signers.get(0).ok_or(RegistryError::InvalidQuorumConfig)?;
+    bootstrapper.address.require_auth();
+
+    let signer_count = signers.len();
+    let config = QuorumConfig {
+        signers,
+        threshold,
+    };
+    env.storage().instance().set(&QuorumKey::Config, &config);
+    env.storage()
+        .instance()
+        .set(&QuorumKey::NextProposalId, &0u64);
+    bump_instance_ttl(env);
+
+    events::QuorumConfiguredEvent {
+        bootstrapper: bootstrapper.address,
+        threshold,
+        signer_count,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Replace the signer set / threshold. Only reachable through an executed
+/// `SetQuorumConfig` proposal, so rotating the approver set is itself gated.
+pub(crate) fn replace_config(
+    env: &Env,
+    signers: Vec<Signer>,
+    threshold: u32,
+) -> Result<(), RegistryError> {
+    validate_config(&signers, threshold)?;
+
+    let signer_count = signers.len();
+    let config = QuorumConfig {
+        signers,
+        threshold,
+    };
+    env.storage().instance().set(&QuorumKey::Config, &config);
+    bump_instance_ttl(env);
+
+    events::QuorumReconfiguredEvent {
+        threshold,
+        signer_count,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Submit a proposal. The proposer must be a signer and its weight counts
+/// immediately, so a 1-of-M policy auto-approves on creation.
+pub(crate) fn propose(
+    env: &Env,
+    proposer: Address,
+    action: RegistryAction,
+) -> Result<u64, RegistryError> {
+    proposer.require_auth();
+
+    let config = get_config(env)?;
+    let signer = find_signer(&config, &proposer)?;
+
+    let now = env.ledger().timestamp();
+    let id = next_id(env);
+
+    let mut signers_vec = Vec::new(env);
+    signers_vec.push_back(proposer.clone());
+
+    let weight_collected = signer.weight;
+    let status = if weight_collected >= config.threshold {
+        ProposalStatus::Approved
+    } else {
+        ProposalStatus::Pending
+    };
+
+    let proposal = RegistryProposal {
+        id,
+        action: action.clone(),
+        proposer: proposer.clone(),
+        created_at: now,
+        expires_at: now.saturating_add(PROPOSAL_TTL_SECS),
+        status,
+        signers: signers_vec,
+        weight_collected,
+    };
+
+    env.storage()
+        .instance()
+        .set(&QuorumKey::Proposal(id), &proposal);
+    bump_instance_ttl(env);
+
+    events::ProposalCreatedEvent {
+        proposal_id: id,
+        proposer,
+        action,
+        weight_collected,
+        threshold: config.threshold,
+        status,
+    }
+    .publish(env);
+
+    Ok(id)
+}
+
+/// Add a signer's weight to an in-flight proposal.
+///
+/// Re-signing is rejected with `ProposalAlreadySigned`, so one approver cannot
+/// reach the threshold alone by calling this repeatedly.
+pub(crate) fn sign(
+    env: &Env,
+    signer_addr: Address,
+    proposal_id: u64,
+) -> Result<ProposalStatus, RegistryError> {
+    signer_addr.require_auth();
+
+    let config = get_config(env)?;
+    let signer = find_signer(&config, &signer_addr)?;
+    let mut proposal = get_proposal(env, proposal_id)?;
+
+    assert_active(env, &proposal)?;
+
+    for existing in proposal.signers.iter() {
+        if existing == signer_addr {
+            return Err(RegistryError::ProposalAlreadySigned);
+        }
+    }
+
+    proposal.signers.push_back(signer_addr.clone());
+    proposal.weight_collected = proposal.weight_collected.saturating_add(signer.weight);
+
+    if proposal.weight_collected >= config.threshold {
+        proposal.status = ProposalStatus::Approved;
+    }
+
+    env.storage()
+        .instance()
+        .set(&QuorumKey::Proposal(proposal_id), &proposal);
+    bump_instance_ttl(env);
+
+    events::SignatureCollectedEvent {
+        proposal_id,
+        signer: signer_addr,
+        weight_collected: proposal.weight_collected,
+        threshold: config.threshold,
+        status: proposal.status,
+    }
+    .publish(env);
+
+    Ok(proposal.status)
+}
+
+/// Consume an approved proposal's authority exactly once and mark it Executed.
+///
+/// Fails if the proposal is missing, not yet approved, expired, already
+/// executed, or if `expected_action` does not match the approved action -
+/// including its bound parameters.
+pub(crate) fn consume_approval(
+    env: &Env,
+    executor: &Address,
+    proposal_id: u64,
+    expected_action: &RegistryAction,
+) -> Result<(), RegistryError> {
+    executor.require_auth();
+
+    let config = get_config(env)?;
+    find_signer(&config, executor)?;
+
+    let mut proposal = get_proposal(env, proposal_id)?;
+
+    assert_active(env, &proposal)?;
+
+    if proposal.status != ProposalStatus::Approved {
+        return Err(RegistryError::ProposalNotApproved);
+    }
+    if &proposal.action != expected_action {
+        return Err(RegistryError::WrongProposalAction);
+    }
+
+    proposal.status = ProposalStatus::Executed;
+    env.storage()
+        .instance()
+        .set(&QuorumKey::Proposal(proposal_id), &proposal);
+    bump_instance_ttl(env);
+
+    events::ProposalExecutedEvent {
+        proposal_id,
+        executor: executor.clone(),
+        action: expected_action.clone(),
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Cancel an in-flight proposal. Any signer may cancel.
+pub(crate) fn cancel(
+    env: &Env,
+    signer_addr: Address,
+    proposal_id: u64,
+) -> Result<(), RegistryError> {
+    signer_addr.require_auth();
+
+    let config = get_config(env)?;
+    find_signer(&config, &signer_addr)?;
+
+    let mut proposal = get_proposal(env, proposal_id)?;
+
+    match proposal.status {
+        ProposalStatus::Pending | ProposalStatus::Approved => {}
+        _ => return Err(RegistryError::ProposalNotActive),
+    }
+
+    proposal.status = ProposalStatus::Cancelled;
+    env.storage()
+        .instance()
+        .set(&QuorumKey::Proposal(proposal_id), &proposal);
+    bump_instance_ttl(env);
+
+    events::ProposalCancelledEvent {
+        proposal_id,
+        signer: signer_addr,
+    }
+    .publish(env);
+
+    Ok(())
+}
+
+/// Mark a lapsed proposal `Expired`. Permissionless: expiry is a fact of the
+/// ledger clock, not a privileged decision.
+pub(crate) fn expire(env: &Env, proposal_id: u64) -> Result<(), RegistryError> {
+    let mut proposal = get_proposal(env, proposal_id)?;
+
+    match proposal.status {
+        ProposalStatus::Pending | ProposalStatus::Approved => {}
+        _ => return Err(RegistryError::ProposalNotActive),
+    }
+
+    if env.ledger().timestamp() <= proposal.expires_at {
+        return Err(RegistryError::ProposalNotActive);
+    }
+
+    proposal.status = ProposalStatus::Expired;
+    env.storage()
+        .instance()
+        .set(&QuorumKey::Proposal(proposal_id), &proposal);
+    bump_instance_ttl(env);
+
+    Ok(())
+}

--- a/apps/onchain/contracts/protocol_registry/src/quorum.rs
+++ b/apps/onchain/contracts/protocol_registry/src/quorum.rs
@@ -135,10 +135,7 @@ pub(crate) fn is_configured(env: &Env) -> bool {
 }
 
 /// Locate the signer record for `addr`, or reject as `Unauthorized`.
-pub(crate) fn find_signer(
-    config: &QuorumConfig,
-    addr: &Address,
-) -> Result<Signer, RegistryError> {
+pub(crate) fn find_signer(config: &QuorumConfig, addr: &Address) -> Result<Signer, RegistryError> {
     for s in config.signers.iter() {
         if s.address == *addr {
             return Ok(s);
@@ -151,10 +148,7 @@ pub(crate) fn find_signer(
 ///
 /// Rejecting `threshold > total_weight` matters because such a policy would
 /// permanently deadlock every gated action.
-pub(crate) fn validate_config(
-    signers: &Vec<Signer>,
-    threshold: u32,
-) -> Result<(), RegistryError> {
+pub(crate) fn validate_config(signers: &Vec<Signer>, threshold: u32) -> Result<(), RegistryError> {
     if signers.is_empty() || threshold == 0 {
         return Err(RegistryError::InvalidQuorumConfig);
     }
@@ -177,14 +171,20 @@ pub(crate) fn validate_config(
 }
 
 /// Fetch a proposal by id.
-pub(crate) fn get_proposal(
-    env: &Env,
-    proposal_id: u64,
-) -> Result<RegistryProposal, RegistryError> {
+pub(crate) fn get_proposal(env: &Env, proposal_id: u64) -> Result<RegistryProposal, RegistryError> {
     env.storage()
         .instance()
         .get(&QuorumKey::Proposal(proposal_id))
         .ok_or(RegistryError::ProposalNotFound)
+}
+
+/// The id the next proposal will receive. Read-only; does not advance the
+/// counter.
+pub(crate) fn next_proposal_id(env: &Env) -> u64 {
+    env.storage()
+        .instance()
+        .get(&QuorumKey::NextProposalId)
+        .unwrap_or(0)
 }
 
 /// Verify a proposal is still in flight (Pending or Approved, not expired).
@@ -201,11 +201,7 @@ fn assert_active(env: &Env, proposal: &RegistryProposal) -> Result<(), RegistryE
 
 /// Pop the next monotonic proposal id.
 fn next_id(env: &Env) -> u64 {
-    let id: u64 = env
-        .storage()
-        .instance()
-        .get(&QuorumKey::NextProposalId)
-        .unwrap_or(0);
+    let id: u64 = next_proposal_id(env);
     env.storage()
         .instance()
         .set(&QuorumKey::NextProposalId, &(id + 1));
@@ -234,10 +230,7 @@ pub(crate) fn configure(
     bootstrapper.address.require_auth();
 
     let signer_count = signers.len();
-    let config = QuorumConfig {
-        signers,
-        threshold,
-    };
+    let config = QuorumConfig { signers, threshold };
     env.storage().instance().set(&QuorumKey::Config, &config);
     env.storage()
         .instance()
@@ -264,10 +257,7 @@ pub(crate) fn replace_config(
     validate_config(&signers, threshold)?;
 
     let signer_count = signers.len();
-    let config = QuorumConfig {
-        signers,
-        threshold,
-    };
+    let config = QuorumConfig { signers, threshold };
     env.storage().instance().set(&QuorumKey::Config, &config);
     bump_instance_ttl(env);
 

--- a/apps/onchain/contracts/protocol_registry/src/quorum_test.rs
+++ b/apps/onchain/contracts/protocol_registry/src/quorum_test.rs
@@ -1,0 +1,552 @@
+//! Tests for multi-admin quorum execution of privileged registry actions.
+//!
+//! Two things need proving: a proposal that collects enough weight executes,
+//! and every way execution should be refused actually is (not enough weight,
+//! double-signing, non-signers, mismatched parameters, reuse, expiry).
+
+use crate::errors::RegistryError;
+use crate::{
+    ModuleProposal, ProposalStatus, ProtocolRegistryContract, ProtocolRegistryContractClient,
+    RegistryAction, Signer, PROPOSAL_TTL_SECS,
+};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger as _},
+    vec, Address, Env, Vec,
+};
+
+fn setup(env: &Env) -> (ProtocolRegistryContractClient<'_>, Address) {
+    let admin = Address::generate(env);
+    let id = env.register(ProtocolRegistryContract, ());
+    let client = ProtocolRegistryContractClient::new(env, &id);
+    client.initialize(&admin);
+    (client, admin)
+}
+
+/// Three weight-1 signers.
+fn signer_set(env: &Env) -> (Vec<Signer>, Address, Address, Address) {
+    let a = Address::generate(env);
+    let b = Address::generate(env);
+    let c = Address::generate(env);
+    let signers = vec![
+        env,
+        Signer {
+            address: a.clone(),
+            weight: 1,
+        },
+        Signer {
+            address: b.clone(),
+            weight: 1,
+        },
+        Signer {
+            address: c.clone(),
+            weight: 1,
+        },
+    ];
+    (signers, a, b, c)
+}
+
+fn register_action(addr: &Address, version: u32) -> RegistryAction {
+    RegistryAction::RegisterModule(ModuleProposal {
+        name: symbol_short!("vault"),
+        address: addr.clone(),
+        version,
+    })
+}
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+#[test]
+fn test_configure_quorum_stores_policy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, _a, _b, _c) = signer_set(&env);
+
+    client.configure_quorum(&signers, &2u32);
+
+    let config = client.get_quorum_config();
+    assert_eq!(config.threshold, 2);
+    assert_eq!(config.signers.len(), 3);
+    assert_eq!(client.get_next_proposal_id(), 0);
+}
+
+#[test]
+fn test_configure_quorum_rejects_unreachable_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, _a, _b, _c) = signer_set(&env);
+
+    // Total weight is 3; a threshold of 4 could never be met and would
+    // permanently deadlock every gated action.
+    assert_eq!(
+        client.try_configure_quorum(&signers, &4u32),
+        Err(Ok(RegistryError::InvalidQuorumConfig))
+    );
+    assert_eq!(
+        client.try_configure_quorum(&signers, &0u32),
+        Err(Ok(RegistryError::InvalidQuorumConfig))
+    );
+}
+
+#[test]
+fn test_configure_quorum_twice_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, _a, _b, _c) = signer_set(&env);
+
+    client.configure_quorum(&signers, &2u32);
+    assert_eq!(
+        client.try_configure_quorum(&signers, &1u32),
+        Err(Ok(RegistryError::QuorumAlreadyConfigured))
+    );
+}
+
+#[test]
+fn test_gated_action_before_configuration_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let caller = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    assert_eq!(
+        client.try_register_module_via_quorum(
+            &caller,
+            &0u64,
+            &symbol_short!("vault"),
+            &target,
+            &1u32
+        ),
+        Err(Ok(RegistryError::QuorumNotConfigured))
+    );
+}
+
+// ── Happy path ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_quorum_register_module_happy_path() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    let target = Address::generate(&env);
+
+    // The proposer's own weight counts, but 1 < threshold 2.
+    let id = client.propose_action(&a, &register_action(&target, 1));
+    let proposal = client.get_proposal(&id);
+    assert_eq!(proposal.status, ProposalStatus::Pending);
+    assert_eq!(proposal.weight_collected, 1);
+
+    // The second approval crosses the threshold.
+    assert_eq!(client.sign_proposal(&b, &id), ProposalStatus::Approved);
+
+    client.register_module_via_quorum(&a, &id, &symbol_short!("vault"), &target, &1u32);
+
+    let entry = client.get_module(&symbol_short!("vault"));
+    assert_eq!(entry.address, target);
+    assert_eq!(entry.version, 1);
+    assert!(entry.is_active);
+    assert_eq!(client.resolve(&symbol_short!("vault")), target);
+    assert_eq!(client.get_proposal(&id).status, ProposalStatus::Executed);
+    assert_eq!(client.get_next_proposal_id(), 1);
+}
+
+#[test]
+fn test_weighted_signer_can_meet_threshold_alone() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+
+    let heavy = Address::generate(&env);
+    let light = Address::generate(&env);
+    let signers = vec![
+        &env,
+        Signer {
+            address: heavy.clone(),
+            weight: 3,
+        },
+        Signer {
+            address: light.clone(),
+            weight: 1,
+        },
+    ];
+    client.configure_quorum(&signers, &3u32);
+
+    let target = Address::generate(&env);
+    let id = client.propose_action(&heavy, &register_action(&target, 1));
+
+    // Weight, not headcount, decides approval.
+    assert_eq!(client.get_proposal(&id).status, ProposalStatus::Approved);
+    client.register_module_via_quorum(&heavy, &id, &symbol_short!("vault"), &target, &1u32);
+    assert!(client.is_active(&symbol_short!("vault")));
+}
+
+#[test]
+fn test_update_and_deactivate_via_quorum() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    let v1 = Address::generate(&env);
+    let id = client.propose_action(&a, &register_action(&v1, 1));
+    client.sign_proposal(&b, &id);
+    client.register_module_via_quorum(&a, &id, &symbol_short!("vault"), &v1, &1u32);
+
+    // Upgrade to v2.
+    let v2 = Address::generate(&env);
+    let upgrade = RegistryAction::UpdateModule(ModuleProposal {
+        name: symbol_short!("vault"),
+        address: v2.clone(),
+        version: 2,
+    });
+    let id2 = client.propose_action(&a, &upgrade);
+    client.sign_proposal(&b, &id2);
+    client.update_module_via_quorum(&a, &id2, &symbol_short!("vault"), &v2, &2u32);
+    assert_eq!(client.resolve(&symbol_short!("vault")), v2);
+
+    // Deactivate.
+    let id3 = client.propose_action(
+        &a,
+        &RegistryAction::DeactivateModule(symbol_short!("vault")),
+    );
+    client.sign_proposal(&b, &id3);
+    client.deactivate_module_via_quorum(&a, &id3, &symbol_short!("vault"));
+    assert!(!client.is_active(&symbol_short!("vault")));
+    assert_eq!(
+        client.try_resolve(&symbol_short!("vault")),
+        Err(Ok(RegistryError::ModuleInactive))
+    );
+}
+
+#[test]
+fn test_set_admin_via_quorum() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup(&env);
+    let (signers, a, b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    let new_admin = Address::generate(&env);
+    let id = client.propose_action(&a, &RegistryAction::SetAdmin(new_admin.clone()));
+    client.sign_proposal(&b, &id);
+
+    assert_eq!(client.get_admin(), admin);
+    client.set_admin_via_quorum(&a, &id, &new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+#[test]
+fn test_threshold_change_requires_approved_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    let id = client.propose_action(&a, &RegistryAction::SetQuorumConfig);
+    client.sign_proposal(&b, &id);
+    client.set_quorum_config(&a, &id, &signers, &3u32);
+
+    assert_eq!(client.get_quorum_config().threshold, 3);
+}
+
+#[test]
+fn test_admin_approval_cannot_be_redirected_into_config_takeover() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    // Signers approved an admin rotation, not a signer-set replacement.
+    let attacker = Address::generate(&env);
+    let id = client.propose_action(&a, &RegistryAction::SetAdmin(attacker.clone()));
+    client.sign_proposal(&b, &id);
+
+    let solo = vec![
+        &env,
+        Signer {
+            address: attacker.clone(),
+            weight: 1,
+        },
+    ];
+    assert_eq!(
+        client.try_set_quorum_config(&a, &id, &solo, &1u32),
+        Err(Ok(RegistryError::WrongProposalAction))
+    );
+    assert_eq!(client.get_quorum_config().signers.len(), 3);
+}
+
+// ── Refusals ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_insufficient_quorum_cannot_execute() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, _b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &3u32);
+
+    let target = Address::generate(&env);
+    let id = client.propose_action(&a, &register_action(&target, 1));
+
+    assert_eq!(client.get_proposal(&id).status, ProposalStatus::Pending);
+    assert_eq!(
+        client.try_register_module_via_quorum(
+            &a,
+            &id,
+            &symbol_short!("vault"),
+            &target,
+            &1u32
+        ),
+        Err(Ok(RegistryError::ProposalNotApproved))
+    );
+    assert_eq!(
+        client.try_get_module(&symbol_short!("vault")),
+        Err(Ok(RegistryError::ModuleNotFound))
+    );
+}
+
+#[test]
+fn test_duplicate_approval_does_not_reach_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, _b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    let target = Address::generate(&env);
+    let id = client.propose_action(&a, &register_action(&target, 1));
+
+    // The proposer already counted; signing again must not add weight.
+    assert_eq!(
+        client.try_sign_proposal(&a, &id),
+        Err(Ok(RegistryError::ProposalAlreadySigned))
+    );
+
+    let proposal = client.get_proposal(&id);
+    assert_eq!(proposal.weight_collected, 1);
+    assert_eq!(proposal.status, ProposalStatus::Pending);
+}
+
+#[test]
+fn test_non_signer_cannot_propose_sign_or_execute() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    let outsider = Address::generate(&env);
+    let target = Address::generate(&env);
+    let action = register_action(&target, 1);
+
+    assert_eq!(
+        client.try_propose_action(&outsider, &action),
+        Err(Ok(RegistryError::Unauthorized))
+    );
+
+    let id = client.propose_action(&a, &action);
+    assert_eq!(
+        client.try_sign_proposal(&outsider, &id),
+        Err(Ok(RegistryError::Unauthorized))
+    );
+
+    client.sign_proposal(&b, &id);
+    assert_eq!(
+        client.try_register_module_via_quorum(
+            &outsider,
+            &id,
+            &symbol_short!("vault"),
+            &target,
+            &1u32
+        ),
+        Err(Ok(RegistryError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_execution_must_match_approved_parameters() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    let approved = Address::generate(&env);
+    let id = client.propose_action(&a, &register_action(&approved, 1));
+    client.sign_proposal(&b, &id);
+
+    // Swapping the address the signers approved must fail.
+    let sneaky = Address::generate(&env);
+    assert_eq!(
+        client.try_register_module_via_quorum(
+            &a,
+            &id,
+            &symbol_short!("vault"),
+            &sneaky,
+            &1u32
+        ),
+        Err(Ok(RegistryError::WrongProposalAction))
+    );
+
+    // So must changing the version or the module name.
+    assert_eq!(
+        client.try_register_module_via_quorum(
+            &a,
+            &id,
+            &symbol_short!("vault"),
+            &approved,
+            &9u32
+        ),
+        Err(Ok(RegistryError::WrongProposalAction))
+    );
+    assert_eq!(
+        client.try_register_module_via_quorum(
+            &a,
+            &id,
+            &symbol_short!("other"),
+            &approved,
+            &1u32
+        ),
+        Err(Ok(RegistryError::WrongProposalAction))
+    );
+
+    // The untouched proposal still executes on its approved parameters.
+    client.register_module_via_quorum(&a, &id, &symbol_short!("vault"), &approved, &1u32);
+    assert_eq!(client.resolve(&symbol_short!("vault")), approved);
+}
+
+#[test]
+fn test_approval_cannot_be_reused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    let target = Address::generate(&env);
+    let id = client.propose_action(&a, &register_action(&target, 1));
+    client.sign_proposal(&b, &id);
+    client.register_module_via_quorum(&a, &id, &symbol_short!("vault"), &target, &1u32);
+
+    // Second execution of the same approval is refused.
+    assert_eq!(
+        client.try_register_module_via_quorum(
+            &a,
+            &id,
+            &symbol_short!("vault"),
+            &target,
+            &1u32
+        ),
+        Err(Ok(RegistryError::ProposalNotActive))
+    );
+}
+
+#[test]
+fn test_expired_proposal_cannot_execute() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    let target = Address::generate(&env);
+    let id = client.propose_action(&a, &register_action(&target, 1));
+    client.sign_proposal(&b, &id);
+
+    env.ledger().set_timestamp(PROPOSAL_TTL_SECS + 1);
+
+    assert_eq!(
+        client.try_register_module_via_quorum(
+            &a,
+            &id,
+            &symbol_short!("vault"),
+            &target,
+            &1u32
+        ),
+        Err(Ok(RegistryError::ProposalExpired))
+    );
+
+    // Expiry can be recorded permissionlessly, and is then terminal.
+    client.expire_proposal(&id);
+    assert_eq!(client.get_proposal(&id).status, ProposalStatus::Expired);
+    assert_eq!(
+        client.try_expire_proposal(&id),
+        Err(Ok(RegistryError::ProposalNotActive))
+    );
+}
+
+#[test]
+fn test_cannot_expire_a_live_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, _b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    let target = Address::generate(&env);
+    let id = client.propose_action(&a, &register_action(&target, 1));
+
+    assert_eq!(
+        client.try_expire_proposal(&id),
+        Err(Ok(RegistryError::ProposalNotActive))
+    );
+}
+
+#[test]
+fn test_cancelled_proposal_cannot_execute() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, b, c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    let target = Address::generate(&env);
+    let id = client.propose_action(&a, &register_action(&target, 1));
+    client.sign_proposal(&b, &id);
+
+    // Any signer may cancel, including one who did not approve.
+    client.cancel_proposal(&c, &id);
+    assert_eq!(client.get_proposal(&id).status, ProposalStatus::Cancelled);
+
+    assert_eq!(
+        client.try_register_module_via_quorum(
+            &a,
+            &id,
+            &symbol_short!("vault"),
+            &target,
+            &1u32
+        ),
+        Err(Ok(RegistryError::ProposalNotActive))
+    );
+    assert_eq!(
+        client.try_sign_proposal(&c, &id),
+        Err(Ok(RegistryError::ProposalNotActive))
+    );
+}
+
+#[test]
+fn test_unknown_proposal_id_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _admin) = setup(&env);
+    let (signers, a, _b, _c) = signer_set(&env);
+    client.configure_quorum(&signers, &2u32);
+
+    assert_eq!(
+        client.try_get_proposal(&42u64),
+        Err(Ok(RegistryError::ProposalNotFound))
+    );
+    assert_eq!(
+        client.try_sign_proposal(&a, &42u64),
+        Err(Ok(RegistryError::ProposalNotFound))
+    );
+}


### PR DESCRIPTION
## What

Adds an N-of-M weighted quorum approval lifecycle to `protocol_registry`, so privileged actions can require agreement from several admins instead of trusting a single `admin` key.

New `quorum` module with the full lifecycle:

- `configure_quorum(signers, threshold)` — install the signer set and approval threshold. Weights are relative and the threshold uses the same unit, so a plain "3-of-5" policy is five weight-1 signers with `threshold = 3`.
- `propose_action(proposer, action)` / `sign_proposal(signer, id)` — collect weighted approvals. The proposer's own weight counts immediately, so a 1-of-M policy auto-approves on creation.
- `cancel_proposal` (any signer) and `expire_proposal` (permissionless — expiry is a fact of the ledger clock, not a privileged decision). Proposals lapse after 72h.
- Quorum-gated counterparts for each privileged action: `register_module_via_quorum`, `update_module_via_quorum`, `deactivate_module_via_quorum`, `activate_module_via_quorum`, `set_admin_via_quorum`, `set_quorum_config`.
- Views: `get_quorum_config`, `get_proposal`, `get_next_proposal_id`.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Proposal + approval lifecycle for selected actions | `quorum.rs` (`propose` / `sign` / `consume_approval` / `cancel` / `expire`), gated entrypoints in `lib.rs` |
| Configurable approval threshold | `configure_quorum`, rotatable only via an approved `SetQuorumConfig` proposal |
| Duplicate approvals and unauthorized execution fail safely | `ProposalAlreadySigned` on re-signing; `Unauthorized` for non-signers on propose/sign/execute; `ProposalNotApproved` below threshold |
| Tests cover happy path and insufficient quorum | `quorum_test.rs` — 18 tests |

## Design notes

- **Existing admin functions are untouched.** The gated entrypoints replicate the mutation logic rather than refactoring `register_module` et al., so current deployments and tooling keep working and there is no regression surface. A deployment opts into multi-admin control by installing a policy and switching to the gated entrypoints.
- **Storage isolation.** The module uses its own `QuorumKey` enum instead of extending `storage::DataKey`. Soroban assigns XDR discriminants in declaration order, so a separate key space guarantees this feature cannot shift the discriminants of already-deployed keys.
- **Approvals are parameter-bound.** `RegistryAction` captures the action's arguments at proposal time and `consume_approval` compares the whole payload, so an approval to register `vault -> AAA v1` cannot be replayed to install a different address or version. Tests cover address, version and name substitution.
- **`SetQuorumConfig` is a distinct action from `SetAdmin`**, so an approved admin rotation can never be redirected into a signer-set takeover. There is a test for exactly this.
- **Unreachable thresholds are rejected** (`threshold > total weight`, zero threshold, zero-weight signers), since such a policy would permanently deadlock every gated action. Signer sets are capped at `MAX_SIGNERS = 10` to keep per-call iteration bounded.
- Approvals are single-use: execution marks the proposal `Executed`, and re-execution fails with `ProposalNotActive`.

## Test coverage

`quorum_test.rs` covers the happy path (threshold reached → executed, module resolvable) plus weighted approval, module upgrade/deactivation, admin rotation, threshold reconfiguration, and these refusals: insufficient quorum, duplicate approval, non-signer propose/sign/execute, parameter mismatch, approval reuse, expiry, premature expiry, cancellation, unknown proposal id, and gated calls before any policy exists.

## Scope

Deliberately limited to `protocol_registry`. The `treasury` contract already has its own multisig module; extending quorum gating to further treasury actions is left out to keep this reviewable.

One pre-existing issue noticed while reading `treasury`, **not** changed here: `set_multisig_config` consumes a `ProposalAction::SetAdmin` approval, meaning an approved admin rotation can be redirected into replacing the signer set — the same privilege-confusion this PR explicitly guards against in the registry. Worth a follow-up issue; fixing it changes existing approval semantics and belongs in its own PR.

Closes #1041