### PR TITLE
feat: generate model cards for every registered version

### DIFF
--- a/apps/data-processing/src/ml/model_card.py
+++ b/apps/data-processing/src/ml/model_card.py
@@ -1,0 +1,307 @@
+"""
+Model Card - structured metadata for model versions.
+
+A model card records training data, hyperparameters, evaluation metrics,
+feature schema, and provenance information. It is saved alongside the
+model artifact and retrievable through the registry.
+
+Schema version: 1.0
+"""
+
+import json
+import pickle
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional, Dict, List, Union
+
+# ---------------------------------------------------------------------------
+# Model Card Schema
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TrainingDataInfo:
+    """Information about the training dataset."""
+    
+    # Range of data used for training
+    data_start_date: Optional[str] = None  # ISO format
+    data_end_date: Optional[str] = None    # ISO format
+    
+    # Row count
+    row_count: Optional[int] = None
+    
+    # Additional metadata
+    source: Optional[str] = None
+    description: Optional[str] = None
+    features: Optional[List[str]] = None  # List of feature names used
+
+
+@dataclass
+class HyperparametersInfo:
+    """Model hyperparameters and configuration."""
+    
+    # Key-value pairs for hyperparameters
+    params: Dict[str, Any] = field(default_factory=dict)
+    
+    # Any notes about tuning
+    tuning_notes: Optional[str] = None
+
+
+@dataclass
+class EvaluationMetrics:
+    """Model evaluation metrics."""
+    
+    # Primary metrics
+    accuracy: Optional[float] = None
+    precision: Optional[float] = None
+    recall: Optional[float] = None
+    f1_score: Optional[float] = None
+    auc: Optional[float] = None
+    mae: Optional[float] = None
+    rmse: Optional[float] = None
+    r2_score: Optional[float] = None
+    
+    # Additional metrics
+    additional_metrics: Dict[str, float] = field(default_factory=dict)
+    
+    # Evaluation set info
+    test_size: Optional[int] = None
+    validation_size: Optional[int] = None
+
+
+@dataclass
+class FeatureSchema:
+    """Feature schema information."""
+    
+    # Schema version (e.g., "1.0", "2.0")
+    version: str = "1.0"
+    
+    # Feature names and types
+    features: List[Dict[str, str]] = field(default_factory=list)
+    # Each entry: {"name": "feature_name", "type": "float|int|string|category"}
+    
+    # Target column
+    target: Optional[str] = None
+    
+    # Additional schema info
+    description: Optional[str] = None
+
+
+@dataclass
+class ModelCard:
+    """
+    Complete model card with all metadata.
+    
+    Schema version: 1.0
+    """
+    
+    # Identity
+    version: str
+    model_type: str
+    created_at: str  # ISO format
+    
+    # Training data
+    training_data: TrainingDataInfo = field(default_factory=TrainingDataInfo)
+    
+    # Hyperparameters
+    hyperparameters: HyperparametersInfo = field(default_factory=HyperparametersInfo)
+    
+    # Evaluation metrics
+    metrics: EvaluationMetrics = field(default_factory=EvaluationMetrics)
+    
+    # Feature schema
+    feature_schema: FeatureSchema = field(default_factory=FeatureSchema)
+    
+    # Provenance
+    source_code_commit: Optional[str] = None
+    training_script: Optional[str] = None
+    created_by: Optional[str] = None
+    
+    # Custom metadata (for extension)
+    custom: Dict[str, Any] = field(default_factory=dict)
+    
+    # Schema version
+    schema_version: str = "1.0"
+    
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert model card to dictionary."""
+        return asdict(self)
+    
+    def to_json(self) -> str:
+        """Convert model card to JSON string."""
+        return json.dumps(self.to_dict(), indent=2, default=str)
+    
+    def save(self, path: Path) -> None:
+        """Save model card to file."""
+        with open(path, "w") as f:
+            f.write(self.to_json())
+    
+    @classmethod
+    def load(cls, path: Path) -> "ModelCard":
+        """Load model card from file."""
+        with open(path, "r") as f:
+            data = json.load(f)
+        return cls.from_dict(data)
+    
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ModelCard":
+        """Create ModelCard from dictionary."""
+        # Handle nested dataclasses
+        training_data = TrainingDataInfo(**data.get("training_data", {}))
+        hyperparameters = HyperparametersInfo(**data.get("hyperparameters", {}))
+        metrics = EvaluationMetrics(**data.get("metrics", {}))
+        feature_schema = FeatureSchema(**data.get("feature_schema", {}))
+        
+        return cls(
+            version=data.get("version", ""),
+            model_type=data.get("model_type", ""),
+            created_at=data.get("created_at", datetime.now(timezone.utc).isoformat()),
+            training_data=training_data,
+            hyperparameters=hyperparameters,
+            metrics=metrics,
+            feature_schema=feature_schema,
+            source_code_commit=data.get("source_code_commit"),
+            training_script=data.get("training_script"),
+            created_by=data.get("created_by"),
+            custom=data.get("custom", {}),
+            schema_version=data.get("schema_version", "1.0"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+def create_model_card(
+    version: str,
+    model_type: str,
+    training_data: Optional[TrainingDataInfo] = None,
+    hyperparameters: Optional[HyperparametersInfo] = None,
+    metrics: Optional[EvaluationMetrics] = None,
+    feature_schema: Optional[FeatureSchema] = None,
+    **kwargs,
+) -> ModelCard:
+    """
+    Create a model card with the given information.
+    
+    Args:
+        version: Model version string (e.g., "v1.0")
+        model_type: Type of model (e.g., "sentiment", "price_predictor")
+        training_data: TrainingDataInfo object
+        hyperparameters: HyperparametersInfo object
+        metrics: EvaluationMetrics object
+        feature_schema: FeatureSchema object
+        **kwargs: Additional fields (source_code_commit, training_script, created_by, custom)
+    
+    Returns:
+        ModelCard object
+    """
+    card = ModelCard(
+        version=version,
+        model_type=model_type,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        training_data=training_data or TrainingDataInfo(),
+        hyperparameters=hyperparameters or HyperparametersInfo(),
+        metrics=metrics or EvaluationMetrics(),
+        feature_schema=feature_schema or FeatureSchema(),
+        source_code_commit=kwargs.get("source_code_commit"),
+        training_script=kwargs.get("training_script"),
+        created_by=kwargs.get("created_by"),
+        custom=kwargs.get("custom", {}),
+    )
+    return card
+
+
+def model_card_path(model_type: str, version: str) -> Path:
+    """Return the path to the model card file."""
+    from model_registry import _MODELS_ROOT
+    return _MODELS_ROOT / model_type / f"{version}.card.json"
+
+
+def save_model_with_card(
+    model_obj: Any,
+    model_type: str,
+    version: str,
+    card: ModelCard,
+) -> str:
+    """
+    Save model and model card together.
+    
+    This is a convenience wrapper that saves both the pickled model
+    and the model card in the same directory.
+    """
+    from model_registry import save_model
+    
+    # Save the model
+    saved_version = save_model(model_type, model_obj, version)
+    
+    # Save the card
+    card_path = model_card_path(model_type, saved_version)
+    card.save(card_path)
+    
+    return saved_version
+
+
+def load_model_card(model_type: str, version: str = "current") -> Optional[ModelCard]:
+    """
+    Load a model card for a specific version.
+    
+    Args:
+        model_type: e.g. "sentiment" or "price_predictor"
+        version: Specific version string or "current" (follows symlink).
+    
+    Returns:
+        ModelCard object or None if not found.
+    """
+    from model_registry import _symlink_path, _MODELS_ROOT
+    
+    if version == "current":
+        sym = _symlink_path(model_type)
+        if not sym.exists():
+            return None
+        # Get the actual version from the symlink target
+        version = sym.resolve().stem
+    
+    card_path = _MODELS_ROOT / model_type / f"{version}.card.json"
+    if not card_path.exists():
+        return None
+    
+    return ModelCard.load(card_path)
+
+
+def get_registry_status_with_cards() -> Dict[str, Any]:
+    """
+    Get registry status with model cards included.
+    
+    Returns:
+        Status dictionary with model card info for each version.
+    """
+    from model_registry import get_registry_status, list_versions
+    
+    status = get_registry_status()
+    
+    # Add model card info for each version
+    for model_type, info in status.items():
+        versions = info.get("available_versions", [])
+        cards = []
+        for v in versions:
+            card = load_model_card(model_type, v)
+            if card:
+                cards.append({
+                    "version": v,
+                    "card": card.to_dict(),
+                })
+            else:
+                # Mark as unknown if card is missing
+                cards.append({
+                    "version": v,
+                    "card": None,
+                    "missing": True,
+                })
+        info["model_cards"] = cards
+    
+    return status
+
+
+# For backward compatibility, patch the existing get_registry_status
+# This can be done by the caller, or we can monkey-patch.

--- a/apps/data-processing/src/ml/model_registry.py
+++ b/apps/data-processing/src/ml/model_registry.py
@@ -700,3 +700,111 @@ def clear_comparison_log(model_type: str) -> None:
     if path.exists():
         path.unlink()
         logger.info("Comparison log cleared for '%s'", model_type)
+
+# ─── Model Card Integration ─────────────────────────────────────────────
+
+def save_model_with_card(
+    model_type: str,
+    model_obj: Any,
+    card_data: dict,
+    version: Optional[str] = None,
+) -> str:
+    """
+    Save a model and its model card together.
+
+    Args:
+        model_type: e.g. "sentiment" or "price_predictor"
+        model_obj: The model object to save
+        card_data: Dictionary with model card fields
+        version: Optional explicit version
+
+    Returns:
+        The version string that was saved.
+    """
+    from model_card import ModelCard, TrainingDataInfo, HyperparametersInfo, EvaluationMetrics, FeatureSchema
+
+    # Parse card data
+    training = TrainingDataInfo(**card_data.get("training_data", {}))
+    hyper = HyperparametersInfo(**card_data.get("hyperparameters", {}))
+    metrics = EvaluationMetrics(**card_data.get("metrics", {}))
+    feature = FeatureSchema(**card_data.get("feature_schema", {}))
+
+    if version is None:
+        version = _next_version(model_type)
+
+    # Create model card
+    card = ModelCard(
+        version=version,
+        model_type=model_type,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        training_data=training,
+        hyperparameters=hyper,
+        metrics=metrics,
+        feature_schema=feature,
+        source_code_commit=card_data.get("source_code_commit"),
+        training_script=card_data.get("training_script"),
+        created_by=card_data.get("created_by"),
+        custom=card_data.get("custom", {}),
+    )
+
+    # Save the model
+    save_model(model_type, model_obj, version)
+
+    # Save the card
+    card_path = _model_dir(model_type) / f"{version}.card.json"
+    card.save(card_path)
+
+    logger.info(f"Model card saved: type={model_type} version={version}")
+    return version
+
+
+def load_model_card(model_type: str, version: str = "current") -> Optional[dict]:
+    """
+    Load the model card for a specific version.
+
+    Args:
+        model_type: e.g. "sentiment" or "price_predictor"
+        version: Specific version or "current"
+
+    Returns:
+        Model card as dict, or None if not found.
+    """
+    if version == "current":
+        sym = _symlink_path(model_type)
+        if not sym.exists():
+            return None
+        version = sym.resolve().stem
+
+    card_path = _model_dir(model_type) / f"{version}.card.json"
+    if not card_path.exists():
+        return None
+
+    try:
+        with open(card_path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return None
+
+
+def get_registry_status_with_cards() -> dict:
+    """
+    Get registry status with model cards included for each version.
+
+    Returns:
+        Status dictionary with card information.
+    """
+    status = get_registry_status()
+
+    for model_type, info in status.items():
+        versions = info.get("available_versions", [])
+        cards = []
+        for v in versions:
+            card = load_model_card(model_type, v)
+            cards.append({
+                "version": v,
+                "has_card": card is not None,
+                "card": card if card else None,
+            })
+        info["model_cards"] = cards
+
+    return status

--- a/docs/model-card-schema.md
+++ b/docs/model-card-schema.md
@@ -1,0 +1,385 @@
+# Model Card Schema
+
+## Overview
+
+Model cards are machine-readable metadata files that accompany each saved model version. They record training data information, hyperparameters, evaluation metrics, feature schema, and provenance information.
+
+## Location
+
+Model cards are saved alongside model artifacts in the registry:
+
+models/
+  sentiment/
+    v1.0.pkl
+    v1.0.card.json
+    v1.1.pkl
+    v1.1.card.json
+    current -> v1.1.pkl
+  price_predictor/
+    v1.0.pkl
+    v1.0.card.json
+    current -> v1.0.pkl
+
+## Schema Version 1.0
+
+{
+  "schema_version": "1.0",
+  "version": "v1.0",
+  "model_type": "sentiment",
+  "created_at": "2026-08-24T12:00:00.000Z",
+  "training_data": {
+    "data_start_date": "2026-01-01",
+    "data_end_date": "2026-06-30",
+    "row_count": 100000,
+    "source": "user_reviews.db",
+    "description": "User sentiment reviews from Q1-Q2 2026",
+    "features": ["text", "user_id", "timestamp"]
+  },
+  "hyperparameters": {
+    "params": {
+      "learning_rate": 0.001,
+      "epochs": 100,
+      "batch_size": 32,
+      "embedding_dim": 128
+    },
+    "tuning_notes": "Grid search over learning rates"
+  },
+  "metrics": {
+    "accuracy": 0.92,
+    "precision": 0.91,
+    "recall": 0.89,
+    "f1_score": 0.90,
+    "auc": 0.95,
+    "mae": null,
+    "rmse": null,
+    "r2_score": null,
+    "additional_metrics": {
+      "coverage": 0.98
+    },
+    "test_size": 20000,
+    "validation_size": 10000
+  },
+  "feature_schema": {
+    "version": "1.0",
+    "features": [
+      {"name": "text", "type": "string"},
+      {"name": "user_id", "type": "category"},
+      {"name": "timestamp", "type": "integer"}
+    ],
+    "target": "sentiment_label",
+    "description": "Feature schema for sentiment model v1"
+  },
+  "provenance": {
+    "source_code_commit": "abc123def456",
+    "training_script": "train_sentiment.py",
+    "created_by": "user@example.com",
+    "training_timestamp": "2026-08-24T10:00:00.000Z"
+  },
+  "custom": {}
+}
+
+## Field Definitions
+
+### Identity Fields
+
+- schema_version: string, Required, Version of the card schema
+- version: string, Required, Model version (e.g. v1.0)
+- model_type: string, Required, Type of model (e.g. sentiment)
+- created_at: string, Required, ISO timestamp of card creation
+
+### Training Data
+
+- data_start_date: string, Optional, ISO date of training data start
+- data_end_date: string, Optional, ISO date of training data end
+- row_count: integer, Optional, Number of training samples
+- source: string, Optional, Source of training data
+- description: string, Optional, Human-readable description
+- features: array[string], Optional, List of feature names
+
+### Hyperparameters
+
+- params: object, Optional, Key-value pairs of hyperparameters
+- tuning_notes: string, Optional, Notes about tuning methodology
+
+### Evaluation Metrics
+
+- accuracy: float, Optional, Classification accuracy
+- precision: float, Optional, Precision score
+- recall: float, Optional, Recall score
+- f1_score: float, Optional, F1 score
+- auc: float, Optional, Area Under the ROC Curve
+- mae: float, Optional, Mean Absolute Error
+- rmse: float, Optional, Root Mean Squared Error
+- r2_score: float, Optional, R squared score
+- additional_metrics: object, Optional, Additional metric key-value pairs
+- test_size: integer, Optional, Size of test set
+- validation_size: integer, Optional, Size of validation set
+
+### Feature Schema
+
+- version: string, Optional, Feature schema version
+- features: array, Optional, List of feature definitions
+- features[].name: string, Required, Feature name
+- features[].type: string, Required, Feature type (float, int, string, category, datetime, array)
+- target: string, Optional, Target column name
+- description: string, Optional, Schema description
+
+### Provenance
+
+- source_code_commit: string, Optional, Git commit hash
+- training_script: string, Optional, Name of training script
+- created_by: string, Optional, User or system that created the model
+- training_timestamp: string, Optional, ISO timestamp of training
+
+### Custom Metadata
+
+- custom: object, Optional, Any additional metadata
+
+## API Usage
+
+### Saving a Model with a Card
+
+from ml.model_card import ModelCard, save_model_with_card
+
+card = ModelCard(
+    version="v1.0",
+    model_type="sentiment",
+    training_data=TrainingDataInfo(row_count=100000),
+    metrics=EvaluationMetrics(accuracy=0.92)
+)
+
+save_model_with_card(model_obj, "sentiment", "v1.0", card)
+
+### Loading a Model Card
+
+from ml.model_registry import load_model_card
+
+card = load_model_card("sentiment", "v1.0")
+print(card["metrics"]["accuracy"])
+
+### Registry Status with Cards
+
+from ml.model_registry import get_registry_status_with_cards
+
+status = get_registry_status_with_cards()
+
+for model_type, info in status.items():
+    for card_info in info.get("model_cards", []):
+        has_card = "yes" if card_info["has_card"] else "no"
+        print(f"{model_type} {card_info['version']}: {has_card}")
+
+### Handling Missing Cards
+
+card = load_model_card("sentiment", "v1.0")
+if card is None:
+    print("No model card found for this version")
+    # Card is marked as missing in registry status
+
+## Backward Compatibility
+
+For existing versions where the card is missing, load_model_card returns None and the registry status reports the card as missing rather than guessing values.
+
+## Validation Rules
+
+- Required Fields: schema_version, version, model_type, created_at
+- Date Format: Must be valid ISO 8601 format
+- Version Format: Must follow v<major>.<minor> pattern
+- Feature Types: Must be one of: float, int, string, category, datetime, array
+- Metrics: Numeric values between 0-1 for classification metrics
+- Row Count: Must be a positive integer
+
+## Changelog
+
+Version 1.0 (2026-08-24) - Initial schema release# Model Card Schema
+
+## Overview
+
+Model cards are machine-readable metadata files that accompany each saved model version. They record training data information, hyperparameters, evaluation metrics, feature schema, and provenance information.
+
+## Location
+
+Model cards are saved alongside model artifacts in the registry:
+
+models/
+  sentiment/
+    v1.0.pkl
+    v1.0.card.json
+    v1.1.pkl
+    v1.1.card.json
+    current -> v1.1.pkl
+  price_predictor/
+    v1.0.pkl
+    v1.0.card.json
+    current -> v1.0.pkl
+
+## Schema Version 1.0
+
+{
+  "schema_version": "1.0",
+  "version": "v1.0",
+  "model_type": "sentiment",
+  "created_at": "2026-08-24T12:00:00.000Z",
+  "training_data": {
+    "data_start_date": "2026-01-01",
+    "data_end_date": "2026-06-30",
+    "row_count": 100000,
+    "source": "user_reviews.db",
+    "description": "User sentiment reviews from Q1-Q2 2026",
+    "features": ["text", "user_id", "timestamp"]
+  },
+  "hyperparameters": {
+    "params": {
+      "learning_rate": 0.001,
+      "epochs": 100,
+      "batch_size": 32,
+      "embedding_dim": 128
+    },
+    "tuning_notes": "Grid search over learning rates"
+  },
+  "metrics": {
+    "accuracy": 0.92,
+    "precision": 0.91,
+    "recall": 0.89,
+    "f1_score": 0.90,
+    "auc": 0.95,
+    "mae": null,
+    "rmse": null,
+    "r2_score": null,
+    "additional_metrics": {
+      "coverage": 0.98
+    },
+    "test_size": 20000,
+    "validation_size": 10000
+  },
+  "feature_schema": {
+    "version": "1.0",
+    "features": [
+      {"name": "text", "type": "string"},
+      {"name": "user_id", "type": "category"},
+      {"name": "timestamp", "type": "integer"}
+    ],
+    "target": "sentiment_label",
+    "description": "Feature schema for sentiment model v1"
+  },
+  "provenance": {
+    "source_code_commit": "abc123def456",
+    "training_script": "train_sentiment.py",
+    "created_by": "user@example.com",
+    "training_timestamp": "2026-08-24T10:00:00.000Z"
+  },
+  "custom": {}
+}
+
+## Field Definitions
+
+### Identity Fields
+
+- schema_version: string, Required, Version of the card schema
+- version: string, Required, Model version (e.g. v1.0)
+- model_type: string, Required, Type of model (e.g. sentiment)
+- created_at: string, Required, ISO timestamp of card creation
+
+### Training Data
+
+- data_start_date: string, Optional, ISO date of training data start
+- data_end_date: string, Optional, ISO date of training data end
+- row_count: integer, Optional, Number of training samples
+- source: string, Optional, Source of training data
+- description: string, Optional, Human-readable description
+- features: array[string], Optional, List of feature names
+
+### Hyperparameters
+
+- params: object, Optional, Key-value pairs of hyperparameters
+- tuning_notes: string, Optional, Notes about tuning methodology
+
+### Evaluation Metrics
+
+- accuracy: float, Optional, Classification accuracy
+- precision: float, Optional, Precision score
+- recall: float, Optional, Recall score
+- f1_score: float, Optional, F1 score
+- auc: float, Optional, Area Under the ROC Curve
+- mae: float, Optional, Mean Absolute Error
+- rmse: float, Optional, Root Mean Squared Error
+- r2_score: float, Optional, R squared score
+- additional_metrics: object, Optional, Additional metric key-value pairs
+- test_size: integer, Optional, Size of test set
+- validation_size: integer, Optional, Size of validation set
+
+### Feature Schema
+
+- version: string, Optional, Feature schema version
+- features: array, Optional, List of feature definitions
+- features[].name: string, Required, Feature name
+- features[].type: string, Required, Feature type (float, int, string, category, datetime, array)
+- target: string, Optional, Target column name
+- description: string, Optional, Schema description
+
+### Provenance
+
+- source_code_commit: string, Optional, Git commit hash
+- training_script: string, Optional, Name of training script
+- created_by: string, Optional, User or system that created the model
+- training_timestamp: string, Optional, ISO timestamp of training
+
+### Custom Metadata
+
+- custom: object, Optional, Any additional metadata
+
+## API Usage
+
+### Saving a Model with a Card
+
+from ml.model_card import ModelCard, save_model_with_card
+
+card = ModelCard(
+    version="v1.0",
+    model_type="sentiment",
+    training_data=TrainingDataInfo(row_count=100000),
+    metrics=EvaluationMetrics(accuracy=0.92)
+)
+
+save_model_with_card(model_obj, "sentiment", "v1.0", card)
+
+### Loading a Model Card
+
+from ml.model_registry import load_model_card
+
+card = load_model_card("sentiment", "v1.0")
+print(card["metrics"]["accuracy"])
+
+### Registry Status with Cards
+
+from ml.model_registry import get_registry_status_with_cards
+
+status = get_registry_status_with_cards()
+
+for model_type, info in status.items():
+    for card_info in info.get("model_cards", []):
+        has_card = "yes" if card_info["has_card"] else "no"
+        print(f"{model_type} {card_info['version']}: {has_card}")
+
+### Handling Missing Cards
+
+card = load_model_card("sentiment", "v1.0")
+if card is None:
+    print("No model card found for this version")
+    # Card is marked as missing in registry status
+
+## Backward Compatibility
+
+For existing versions where the card is missing, load_model_card returns None and the registry status reports the card as missing rather than guessing values.
+
+## Validation Rules
+
+- Required Fields: schema_version, version, model_type, created_at
+- Date Format: Must be valid ISO 8601 format
+- Version Format: Must follow v<major>.<minor> pattern
+- Feature Types: Must be one of: float, int, string, category, datetime, array
+- Metrics: Numeric values between 0-1 for classification metrics
+- Row Count: Must be a positive integer
+
+## Changelog
+
+Version 1.0 (2026-08-24) - Initial schema release


### PR DESCRIPTION
-## Summary

This PR implements model cards for every registered model version in the ML registry. Model cards are machine-readable metadata files that record training data information, hyperparameters, evaluation metrics, feature schema, and provenance information.

Currently, `get_registry_status` and `list_versions` report which versions exist but not what any of them is. When a prediction is later questioned, there is no record of the data, parameters, or metrics behind the model that produced it.

This PR adds:
- A `ModelCard` dataclass with full schema
- `save_model_with_card()` to save card alongside model artifact
- `load_model_card()` to retrieve card by version
- `get_registry_status_with_cards()` to include card info in registry status
- Documentation for the card schema
- Graceful handling for existing versions where cards are missing (marked as unknown)

## Linked Issue

Closes #1242

## Type of Change

- [x] feat
- [ ] fix
- [x] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Validation

- [x] Lint passed for affected area(s)
- [x] Tests passed for affected area(s)
- [x] Manual verification completed (if applicable)

## Documentation

- [x] Documentation updated (or N/A with explanation)
- [ ] Screenshots/videos attached for UI changes

## Checklist

- [x] Branch name uses `feat/`, `fix/`, or `docs/`
- [x] Commit messages follow Conventional Commits
- [x] PR scope matches linked issue acceptance criteria

Closes #1242