### PR TITLE
docs(adr): add architecture decision records and ADR governance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,9 @@ git checkout -b docs/short-description
 - Prefer small, reviewable commits.
 - Add/update tests when behavior changes.
 - Update docs when behavior, setup, or usage changes.
+- Add or update an ADR when the change introduces or revises a significant architectural decision, platform boundary, operational pattern, or contract/governance approach.
+
+When an issue changes how services are split, how the backend integrates with Python or external systems, how on-chain state or upgradeability works, or what persistence/eventing pattern is used, the PR should include an ADR entry in [doc/adr/README.md](doc/adr/README.md) and link the related implementation summary or feature write-up.
 
 4. Run validation locally
 - Run the relevant lint/test commands for your area:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ For a step-by-step guide to running the complete LumenPulse stack locally—incl
 
 LumenPulse has migrated to Stellar/Soroban architecture. For details on changes from prior chain assumptions, completed migrations, and legacy cleanup, see [Stellar Migration Notes](document/STELLAR_MIGRATION_NOTES.md).
 
+## Architecture Decisions
+
+The repository keeps design rationale alongside implementation notes. The ADR log captures why key choices were made and which trade-offs were considered: [doc/adr/README.md](doc/adr/README.md).
+
+Related implementation summaries remain cross-referenced there so the historical write-ups and the decision records stay connected.
+
 ## Tech Stack
 ### Frontend
 - Next.js 15: App router, server components, and streaming.

--- a/doc/adr/ADR-0001-monorepo-layout.md
+++ b/doc/adr/ADR-0001-monorepo-layout.md
@@ -1,0 +1,43 @@
+# ADR-0001: Monorepo layout
+
+- Status: Accepted
+- Date: 2026-08-25
+
+## Context
+
+The platform spans web application code, backend APIs, data-processing workflows, and on-chain Soroban contracts. These systems have overlapping tooling, shared environment conventions, and occasional cross-cutting concerns, but they also evolve at different speeds and with different technology constraints.
+
+A single repository was needed to keep product, backend, and contract work aligned without forcing every team to ship from isolated repositories. At the same time, the codebase needed clear boundaries so backend, Python services, and on-chain contracts could be versioned and tested independently.
+
+## Options considered
+
+1. Single application repository with everything mixed together.
+   - Pros: simplest setup and shared tooling.
+   - Cons: high coupling, poor isolation, slower CI, and unclear ownership boundaries between application layers.
+
+2. Separate repositories for each domain.
+   - Pros: strong isolation and independent releases.
+   - Cons: duplicated config, slower cross-domain changes, harder contract-to-backend coordination, and less visibility into the full system.
+
+3. Monorepo with workspaces and toolchain boundaries.
+   - Pros: shared root tooling, reuse of common scripts, independent package execution, and a single place to reason about the full platform.
+   - Cons: requires stronger conventions around dependency boundaries and repo hygiene.
+
+## Decision
+
+We use a monorepo rooted at the repository, with package boundaries enforced by `pnpm` workspaces and TurboRepo for JavaScript/TypeScript areas, while contract and Python code remain as explicit workspace or service boundaries rather than ad hoc script folders.
+
+The monorepo is the default unit of delivery, but each product area still has its own build, test, and deployment workflow. This keeps the repo cohesive without collapsing distinct runtime concerns into a single deployable unit.
+
+## Consequences
+
+- We get a single source of truth for the platform, which lowers onboarding and review friction.
+- Changes that span multiple areas are easier to coordinate because code, docs, and config live in one repository.
+- CI and local execution must be organized carefully to avoid cross-service coupling and accidental dependency drift.
+- Contributors must respect workspace boundaries; infrastructure changes may affect multiple packages and require broader validation.
+
+## Related implementation summaries
+
+- [README.md](../../README.md)
+- [apps/backend/IMPLEMENTATION_SUMMARY.md](../../apps/backend/IMPLEMENTATION_SUMMARY.md)
+- [apps/onchain/IMPLEMENTATION_SUMMARY.md](../../apps/onchain/IMPLEMENTATION_SUMMARY.md)

--- a/doc/adr/ADR-0002-transactional-outbox.md
+++ b/doc/adr/ADR-0002-transactional-outbox.md
@@ -1,0 +1,43 @@
+# ADR-0002: Transactional outbox for reliable side effects
+
+- Status: Accepted
+- Date: 2026-08-25
+
+## Context
+
+The backend needs to emit notifications, trigger downstream jobs, and integrate with the Python analytics pipeline without risking partial state. A naive approach of firing side effects directly from the application transaction can leave the database and external systems out of sync if the process crashes after the database writes but before the downstream call succeeds.
+
+This is especially important for event-driven flows such as contract processing, webhook fan-out, and notification delivery, where the source-of-truth database update and the side effect must be kept consistent.
+
+## Options considered
+
+1. Fire downstream calls directly in the same transaction.
+   - Pros: simple implementation and immediate delivery.
+   - Cons: creates coupling to external systems, makes the database transaction dependent on network behavior, and risks partial writes or duplicate processing.
+
+2. Publish events via an in-memory queue or direct broker call outside the DB transaction.
+   - Pros: fast and decoupled from persistence.
+   - Cons: loses reliability guarantees when the application crashes between committing and dispatching; also makes replay and auditing harder.
+
+3. Use a transactional outbox.
+   - Pros: preserves atomicity at the database boundary, enables durable replay, and keeps downstream delivery as an independent concern.
+   - Cons: requires an outbox table, polling/dispatch job, and operational monitoring.
+
+## Decision
+
+We persist domain state and outbox entries in the same database transaction. A scheduled worker polls pending outbox rows, dispatches them to the appropriate downstream system, and marks the record as processed or failed. Failed events remain in the store for inspection or replay.
+
+This makes the primary database transaction the source of truth while allowing downstream processing to be retried, audited, and recovered independently.
+
+## Consequences
+
+- The backend can safely record business state and later dispatch side effects without breaking transactional consistency.
+- Outbox events can be retried after transient failures, which is critical for asynchronous systems.
+- Extra operational complexity is introduced via the outbox table, a dispatch loop, and failure-state handling.
+- The system must tolerate eventual consistency between the business transaction and the downstream side effect.
+
+## Related implementation summaries
+
+- [apps/backend/IMPLEMENTATION_SUMMARY.md](../../apps/backend/IMPLEMENTATION_SUMMARY.md)
+- [apps/backend/IMPLEMENTATION_SUMMARY_DEAD_LETTER_QUEUE.md](../../apps/backend/IMPLEMENTATION_SUMMARY_DEAD_LETTER_QUEUE.md)
+- [apps/backend/src/outbox/outbox.service.ts](../../apps/backend/src/outbox/outbox.service.ts)

--- a/doc/adr/ADR-0003-python-service-split.md
+++ b/doc/adr/ADR-0003-python-service-split.md
@@ -1,0 +1,43 @@
+# ADR-0003: Separate Python service for analytics and inference
+
+- Status: Accepted
+- Date: 2026-08-25
+
+## Context
+
+The platform includes model-driven workloads such as sentiment scoring, anomaly detection, and data-processing jobs. These workloads rely on Python libraries, heavier runtime dependencies, and execution patterns that do not belong naturally inside the NestJS backend process.
+
+The backend already owns API orchestration, authentication, and database concerns. Embedding the data science runtime directly into the backend would mix a rapidly-changing inference stack with a user-facing application lifecycle and would increase deployment and dependency risk.
+
+## Options considered
+
+1. Run Python workloads inline inside the backend process.
+   - Pros: simpler first implementation and fewer network boundaries.
+   - Cons: couples a production API to Python package management, model lifecycle, and long-running analytics tasks; increases startup and operational risk.
+
+2. Keep Python as a dedicated service that exposes HTTP or queue-based APIs.
+   - Pros: cleaner dependency isolation, independent deployment, easier model experimentation, and resilience when the analytics service is unavailable.
+   - Cons: adds network latency and requires contract definitions between services.
+
+3. Use asynchronous workers inside the same backend codebase without a dedicated service.
+   - Pros: less deployment complexity than a full service.
+   - Cons: still mixes operational concerns and makes performance tuning harder.
+
+## Decision
+
+We split Python data-processing and inference work into a dedicated service boundary, with the backend calling it over a narrow interface instead of embedding the Python runtime directly. The backend treats the service as a dependency that may be temporarily unavailable and handles degraded operation explicitly.
+
+This keeps model pipelines, experimental libraries, and analytics automation outside the critical path of request handling while preserving a clear integration contract between services.
+
+## Consequences
+
+- The backend remains focused on request orchestration and domain logic.
+- Data-processing and machine-learning workflows can evolve independently without forcing backend deployments.
+- Workflow reliability depends on service health, timeout policy, and retry semantics.
+- Additional integration work is required for API contracts, observability, and graceful fallback behavior.
+
+## Related implementation summaries
+
+- [apps/backend/IMPLEMENTATION_SUMMARY.md](../../apps/backend/IMPLEMENTATION_SUMMARY.md)
+- [apps/backend/IMPLEMENTATION_SUMMARY_DEAD_LETTER_QUEUE.md](../../apps/backend/IMPLEMENTATION_SUMMARY_DEAD_LETTER_QUEUE.md)
+- [apps/data-processing/ROUND_ANOMALY_DETECTION_IMPLEMENTATION.md](../../apps/data-processing/ROUND_ANOMALY_DETECTION_IMPLEMENTATION.md)

--- a/doc/adr/ADR-0004-soroban-state-split.md
+++ b/doc/adr/ADR-0004-soroban-state-split.md
@@ -1,0 +1,43 @@
+# ADR-0004: Split Soroban state by domain and contract boundary
+
+- Status: Accepted
+- Date: 2026-08-25
+
+## Context
+
+The on-chain platform contains multiple kinds of state: protocol configuration, user-facing asset flows, project and round management, and upgradeable governance or timelock logic. A single monolithic contract would quickly accumulate unrelated responsibilities and make upgrades, audits, and failure isolation harder.
+
+The repository also contains examples of state that should not be flattened into a single storage model because different mission-critical concerns need different permissions, lifecycle assumptions, and upgrade cadence.
+
+## Options considered
+
+1. Keep a single large contract for all on-chain state.
+   - Pros: simpler initial setup and fewer cross-contract calls.
+   - Cons: coupling between unrelated domains, harder upgrade risk, weaker access boundaries, and more difficult auditing.
+
+2. Split by lifecycle or business domain with explicit contracts for registry, vault, token, and protocol state.
+   - Pros: each contract owns a narrower state model, upgrade boundaries are clearer, and the system becomes easier to reason about.
+   - Cons: requires careful coordination between contracts and more initial design complexity.
+
+3. Use a hybrid model with some shared registry state and a few domain-specific contracts.
+   - Pros: balances flexibility with maintainability.
+   - Cons: can drift into unclear ownership if the boundaries are not explicit.
+
+## Decision
+
+We model the on-chain system as a set of contract modules that own separate state domains, with registry and configuration data kept distinct from operational logic. The contract layer is designed around explicit domain responsibilities rather than a monolithic storage layout.
+
+This preserves upgrade boundaries and makes it easier to reason about which contract owns which state and which admin or governance flows may modify it.
+
+## Consequences
+
+- State ownership is more explicit, which improves contract safety and auditability.
+- Cross-contract integration is required for business flows, increasing coordination work.
+- Upgrades become more predictable because each contract does not share unrelated state.
+- Some operations require multiple contracts to be updated together, which means feature changes must consider the full contract boundary map.
+
+## Related implementation summaries
+
+- [apps/onchain/IMPLEMENTATION_SUMMARY.md](../../apps/onchain/IMPLEMENTATION_SUMMARY.md)
+- [document/SMART_CONTRACTS.md](../../document/SMART_CONTRACTS.md)
+- [apps/backend/IMPLEMENTATION_SUMMARY_CONTRACT_ROTATION.md](../../apps/backend/IMPLEMENTATION_SUMMARY_CONTRACT_ROTATION.md)

--- a/doc/adr/ADR-0005-contract-upgrade-timelock.md
+++ b/doc/adr/ADR-0005-contract-upgrade-timelock.md
@@ -1,0 +1,43 @@
+# ADR-0005: Contract upgrade and timelock guardrail
+
+- Status: Accepted
+- Date: 2026-08-25
+
+## Context
+
+Soroban contracts can be upgraded in place, which is powerful but also introduces governance and operational risk. Without a delay or approval mechanism, an admin can replace logic immediately, making mistakes difficult to contain and leaving no safety window for review or rollback.
+
+The platform therefore needs a way to rotate contract IDs, upgrade implementation logic, or change admin responsibilities while keeping a minimum delay and an explicit queue of pending operations.
+
+## Options considered
+
+1. Direct upgrade without a timelock.
+   - Pros: simple operational flow and minimal ceremony.
+   - Cons: high risk of mistakes, poor auditability, and no time for human review or emergency response.
+
+2. Governance-only upgrade behind a full on-chain vote system.
+   - Pros: highly transparent and decentralized.
+   - Cons: too heavy for the platform's immediate operational model and slower to react to real operational change.
+
+3. Timelocked queue with explicit execution and grace-period controls.
+   - Pros: provides review time, enforcement of admin boundaries, and better security posture without requiring full governance infrastructure.
+   - Cons: adds operational complexity and a small amount of lag before changes take effect.
+
+## Decision
+
+We adopt a timelock-based upgrade pattern: contract operations are queued, validated, and only executed after a configured delay. The admin may propose or queue actions, but execution remains gated by delay and status checks so a mistaken change has a window for detection and intervention.
+
+The implementation aligns with a clear separation between proposing an action and executing it, which is essential for upgrade safety and operational review.
+
+## Consequences
+
+- Contract upgrades and admin changes become reviewable and less likely to be accidental.
+- There is an intentional delay before some privileged actions take effect, which can slow emergency changes.
+- The system requires careful audit records for queued operations and execution history.
+- Contributors and operators must understand that admin privileges remain powerful even with timelock controls.
+
+## Related implementation summaries
+
+- [apps/backend/IMPLEMENTATION_SUMMARY_CONTRACT_ROTATION.md](../../apps/backend/IMPLEMENTATION_SUMMARY_CONTRACT_ROTATION.md)
+- [apps/backend/FEATURE_CONTRACT_ROTATION.md](../../apps/backend/FEATURE_CONTRACT_ROTATION.md)
+- [document/SMART_CONTRACTS.md](../../document/SMART_CONTRACTS.md)

--- a/doc/adr/ADR-0006-dead-letter-queue.md
+++ b/doc/adr/ADR-0006-dead-letter-queue.md
@@ -1,0 +1,43 @@
+# ADR-0006: Dead-letter queue and replayable event handling
+
+- Status: Accepted
+- Date: 2026-08-25
+
+## Context
+
+The platform ingests blockchain events and other asynchronous payloads that may fail for reasons outside the main business transaction. Errors can include schema drift, transient downstream dependency issues, contract state changes, or malformed payloads. A system that simply drops or retries in memory is not sufficient for operational safety.
+
+The team needs a way to preserve failed work, inspect the exact failure context, and replay it with an explicit audit trail. This is essential for debugging production issues without losing event integrity.
+
+## Options considered
+
+1. Retry in process only and log failures.
+   - Pros: minimal infrastructure and easiest initial implementation.
+   - Cons: loses failed payloads when the process restarts, makes root-cause analysis weak, and does not give maintainers a safe replay path.
+
+2. Drop failed events after a limited retry count.
+   - Pros: simple to reason about and low storage cost.
+   - Cons: data loss and poor operator confidence; impossible to recover from real production issues without re-ingestion.
+
+3. Persist failed events to a dead-letter store with replay support.
+   - Pros: preserves context, supports inspection and manual recovery, and provides a safe operational fallback.
+   - Cons: requires storage, an API for inspection, and clear replay semantics.
+
+## Decision
+
+We persist failed events to a dead-letter queue with replay metadata, failure history, and maintainable status transitions. The system records the last error, preserves the original payload, and only replays when a maintainer or operator chooses to do so under explicit safeguards.
+
+This gives the platform a durable failure recovery path without letting retry loops block the main event processor indefinitely.
+
+## Consequences
+
+- Operational failures become inspectable rather than silently lost.
+- The system can recover from transient infrastructure faults and reprocess known-good events after fixes are in place.
+- Additional storage, query, and review workflows are required.
+- Replay semantics must remain idempotent so recovery does not create duplicate side effects.
+
+## Related implementation summaries
+
+- [apps/backend/IMPLEMENTATION_SUMMARY_DEAD_LETTER_QUEUE.md](../../apps/backend/IMPLEMENTATION_SUMMARY_DEAD_LETTER_QUEUE.md)
+- [apps/backend/IMPLEMENTATION_SUMMARY_OUTBOUND_OBSERVABILITY.md](../../apps/backend/IMPLEMENTATION_SUMMARY_OUTBOUND_OBSERVABILITY.md)
+- [apps/backend/src/soroban-events/soroban-events.processor.ts](../../apps/backend/src/soroban-events/soroban-events.processor.ts)

--- a/doc/adr/README.md
+++ b/doc/adr/README.md
@@ -1,0 +1,80 @@
+# Architecture Decision Records
+
+This directory records the major architectural and operational decisions that shape the LumenPulse platform. ADRs capture the context, the trade-offs we considered, the decision we made, and the consequences of that decision so future contributors do not have to rediscover the same debate during review.
+
+## Purpose
+
+ADR records are the canonical place for the rationale behind design choices that affect:
+
+- service boundaries and runtime topology
+- database or eventing patterns
+- monorepo and workspace structure
+- contract state layout and upgradeability
+- operational resilience and retry semantics
+- cross-language or cross-service integration
+
+## Numbering
+
+- ADRs use a monotonically increasing numeric sequence: `ADR-0001`, `ADR-0002`, `ADR-0003`, and so on.
+- The number is assigned when the ADR is created and must not be reused.
+- The next ADR should always use the next unassigned number.
+
+## Status lifecycle
+
+ADR status follows a simple lifecycle:
+
+- `Proposed`: the decision is being discussed and has not yet been accepted.
+- `Accepted`: the decision has been chosen and is now the working baseline.
+- `Superseded`: a newer ADR replaced it.
+- `Rejected`: the option was considered but deliberately not adopted.
+- `Deprecated`: the decision remains in the repository for historical context, but the team no longer relies on it.
+
+A decision may move from `Proposed` to `Accepted` after implementation and review. If a later ADR changes the direction, the older ADR should be marked `Superseded` or `Deprecated` and linked from the new record.
+
+## Template
+
+Each ADR should follow this structure:
+
+```md
+# ADR-000N: <Title>
+
+- Status: Accepted
+- Date: YYYY-MM-DD
+
+## Context
+Describe the problem, the background constraints, and the forces driving the decision.
+
+## Options considered
+List the alternatives, including the trade-offs and why they were not chosen.
+
+## Decision
+State the chosen approach in clear terms.
+
+## Consequences
+Describe the impact, the expected downsides, and the operational follow-through.
+
+## Related implementation summaries
+- [path/to/implementation-summary.md](path/to/implementation-summary.md)
+```
+
+## Current ADR index
+
+1. [ADR-0001: Monorepo layout](./ADR-0001-monorepo-layout.md)
+2. [ADR-0002: Transactional outbox for reliable side effects](./ADR-0002-transactional-outbox.md)
+3. [ADR-0003: Separate Python service for analytics and inference](./ADR-0003-python-service-split.md)
+4. [ADR-0004: Split Soroban state by domain and contract boundary](./ADR-0004-soroban-state-split.md)
+5. [ADR-0005: Contract upgrade and timelock guardrail](./ADR-0005-contract-upgrade-timelock.md)
+6. [ADR-0006: Dead-letter queue and replayable event handling](./ADR-0006-dead-letter-queue.md)
+
+## Related implementation summaries and feature write-ups
+
+These summaries document what was built; the ADRs explain why the design was chosen. The two sets should be read together:
+
+- [apps/backend/IMPLEMENTATION_SUMMARY.md](../../apps/backend/IMPLEMENTATION_SUMMARY.md)
+- [apps/backend/IMPLEMENTATION_SUMMARY_CONTRACT_ROTATION.md](../../apps/backend/IMPLEMENTATION_SUMMARY_CONTRACT_ROTATION.md)
+- [apps/backend/IMPLEMENTATION_SUMMARY_DEAD_LETTER_QUEUE.md](../../apps/backend/IMPLEMENTATION_SUMMARY_DEAD_LETTER_QUEUE.md)
+- [apps/backend/FEATURE_CONTRACT_ROTATION.md](../../apps/backend/FEATURE_CONTRACT_ROTATION.md)
+- [apps/onchain/IMPLEMENTATION_SUMMARY.md](../../apps/onchain/IMPLEMENTATION_SUMMARY.md)
+- [CI_FIX_SUMMARY.md](../../CI_FIX_SUMMARY.md)
+
+When a PR changes architectural assumptions or introduces a new operational mechanism, update the relevant ADR and add a cross-reference to the implementation summary that accompanies the change.


### PR DESCRIPTION
This PR adds a formal ADR process to the repository and backfills the major architectural decisions that were previously undocumented.

What changed
Added the ADR index and template in the documentation tree
Added six ADRs covering:
monorepo layout
transactional outbox
Python service split
Soroban state split
contract upgrade and timelock guardrails
dead-letter queue and replay strategy
Updated contributor guidance to require ADRs for significant architectural changes
Added cross-references from the root docs so implementation summaries and ADRs remain connected

closes #1258

