### PR TITLE
feat(reconciliation): alert on drift thresholds

### DIFF
--- a/apps/backend/src/metrics/metrics.service.ts
+++ b/apps/backend/src/metrics/metrics.service.ts
@@ -38,6 +38,11 @@ export class MetricsService implements OnModuleInit {
   private readonly horizonErrors: Counter<string>;
   private readonly horizonRequests: Counter<string>;
 
+  // Reconciliation monitoring //
+  private readonly reconciliationDriftCounter: Counter<string>;
+  private readonly reconciliationDriftDelta: Gauge<string>;
+  private readonly reconciliationThreshold: Gauge<string>;
+
   // Running totals for the rolling-average sentiment gauge
   private sentimentSum = 0;
   private sentimentCount = 0;
@@ -153,6 +158,27 @@ export class MetricsService implements OnModuleInit {
       name: 'horizon_http_requests_total',
       help: 'Total Horizon API requests by method',
       labelNames: ['method'] as const,
+      registers: [this.registry],
+    });
+
+    this.reconciliationDriftCounter = new Counter({
+      name: 'lumenpulse_reconciliation_drift_total',
+      help: 'Total reconciliation drift breaches by dataset and severity',
+      labelNames: ['dataset', 'severity'] as const,
+      registers: [this.registry],
+    });
+
+    this.reconciliationDriftDelta = new Gauge({
+      name: 'lumenpulse_reconciliation_drift_delta',
+      help: 'Latest reconciliation drift delta observed by dataset and severity',
+      labelNames: ['dataset', 'severity'] as const,
+      registers: [this.registry],
+    });
+
+    this.reconciliationThreshold = new Gauge({
+      name: 'lumenpulse_reconciliation_threshold',
+      help: 'Configured reconciliation drift threshold by dataset and severity',
+      labelNames: ['dataset', 'severity'] as const,
       registers: [this.registry],
     });
   }
@@ -321,6 +347,24 @@ export class MetricsService implements OnModuleInit {
    */
   recordHorizonError(method: string, statusCode: string): void {
     this.horizonErrors.inc({ method, status_code: statusCode });
+  }
+
+  recordReconciliationDrift(
+    dataset: string,
+    severity: 'warning' | 'critical',
+    delta: number,
+  ): void {
+    const labels = { dataset, severity };
+    this.reconciliationDriftCounter.inc(labels);
+    this.reconciliationDriftDelta.labels(labels).set(delta);
+  }
+
+  setReconciliationThreshold(
+    dataset: string,
+    severity: 'warning' | 'critical',
+    threshold: number,
+  ): void {
+    this.reconciliationThreshold.labels({ dataset, severity }).set(threshold);
   }
 
   //Dynamic metric helpers (legacy API)

--- a/apps/backend/src/reconciliation/entities/reconciliation-job.entity.ts
+++ b/apps/backend/src/reconciliation/entities/reconciliation-job.entity.ts
@@ -12,6 +12,8 @@ export enum ReconciliationStatus {
   FAILED = 'failed',
 }
 
+export type DriftSeverity = 'none' | 'warning' | 'critical';
+
 export interface DriftRecord {
   userId: string;
   assetCode: string;
@@ -20,6 +22,7 @@ export interface DriftRecord {
   upstreamAmount: string;
   delta: string;
   repaired: boolean;
+  severity: DriftSeverity;
 }
 
 @Entity('reconciliation_jobs')

--- a/apps/backend/src/reconciliation/reconciliation.service.spec.ts
+++ b/apps/backend/src/reconciliation/reconciliation.service.spec.ts
@@ -1,0 +1,22 @@
+import {
+  evaluateDriftSeverity,
+  ReconciliationThresholds,
+} from './reconciliation.service';
+
+describe('evaluateDriftSeverity', () => {
+  const thresholds: ReconciliationThresholds = {
+    warning: 1,
+    critical: 5,
+  };
+
+  it.each([
+    [0, 'none'],
+    [0.999, 'none'],
+    [1, 'warning'],
+    [4.999, 'warning'],
+    [5, 'critical'],
+    [6, 'critical'],
+  ])('classifies delta %p as %p', (delta, expected) => {
+    expect(evaluateDriftSeverity(delta, thresholds)).toBe(expected);
+  });
+});

--- a/apps/backend/src/reconciliation/reconciliation.service.ts
+++ b/apps/backend/src/reconciliation/reconciliation.service.ts
@@ -10,9 +10,25 @@ import {
   ReconciliationStatus,
 } from './entities/reconciliation-job.entity';
 import { QueryProfilerService } from '../common/profiling/query-profiler.service';
+import { ConfigService } from '@nestjs/config';
+import { MetricsService } from '../metrics/metrics.service';
 
-/** Tolerance for floating-point drift (0.0000001 XLM) */
-const DRIFT_THRESHOLD = 1e-7;
+export const RECONCILIATION_DATASET = 'portfolio_assets';
+export interface ReconciliationThresholds {
+  warning: number;
+  critical: number;
+}
+
+export type DriftSeverity = 'none' | 'warning' | 'critical';
+
+export function evaluateDriftSeverity(
+  delta: number,
+  thresholds: ReconciliationThresholds,
+): DriftSeverity {
+  if (delta >= thresholds.critical) return 'critical';
+  if (delta >= thresholds.warning) return 'warning';
+  return 'none';
+}
 
 @Injectable()
 export class ReconciliationService {
@@ -27,7 +43,29 @@ export class ReconciliationService {
     private readonly userRepo: Repository<User>,
     private readonly stellarBalanceService: StellarBalanceService,
     private readonly profiler: QueryProfilerService,
+    private readonly configService: ConfigService,
+    private readonly metricsService: MetricsService,
   ) {}
+
+  private getThresholds(): ReconciliationThresholds {
+    const warning = this.getPositiveConfig(
+      'RECONCILIATION_PORTFOLIO_ASSETS_WARNING_THRESHOLD',
+      1e-7,
+    );
+    const critical = this.getPositiveConfig(
+      'RECONCILIATION_PORTFOLIO_ASSETS_CRITICAL_THRESHOLD',
+      1e-5,
+    );
+    if (critical < warning) {
+      throw new Error('Reconciliation critical threshold must be >= warning threshold');
+    }
+    return { warning, critical };
+  }
+
+  private getPositiveConfig(key: string, fallback: number): number {
+    const value = Number(this.configService.get<string>(key, String(fallback)));
+    return Number.isFinite(value) && value >= 0 ? value : fallback;
+  }
 
   /**
    * Run a full reconciliation pass across all users with linked Stellar accounts.
@@ -58,6 +96,17 @@ export class ReconciliationService {
     );
 
     const driftDetails: DriftRecord[] = [];
+    const thresholds = this.getThresholds();
+    this.metricsService.setReconciliationThreshold(
+      RECONCILIATION_DATASET,
+      'warning',
+      thresholds.warning,
+    );
+    this.metricsService.setReconciliationThreshold(
+      RECONCILIATION_DATASET,
+      'critical',
+      thresholds.critical,
+    );
     let usersProcessed = 0;
     let driftsDetected = 0;
     let driftsRepaired = 0;
@@ -74,6 +123,7 @@ export class ReconciliationService {
           const drifts = await this.reconcileUser(
             user.id,
             user.stellarPublicKey,
+            thresholds,
           );
           driftsDetected += drifts.length;
           driftsRepaired += drifts.filter((d) => d.repaired).length;
@@ -117,6 +167,7 @@ export class ReconciliationService {
   private async reconcileUser(
     userId: string,
     publicKey: string,
+    thresholds: ReconciliationThresholds,
   ): Promise<DriftRecord[]> {
     const [upstreamBalances, storedAssets] = await Promise.all([
       this.stellarBalanceService.getAccountBalances(publicKey),
@@ -139,6 +190,8 @@ export class ReconciliationService {
 
       if (!stored) {
         // Asset exists on-chain but not in DB — insert it
+        const missingDelta = Math.abs(parseFloat(upstream.balance));
+        const missingSeverity = evaluateDriftSeverity(missingDelta, thresholds);
         const newAsset = this.assetRepo.create({
           userId,
           assetCode: upstream.assetCode,
@@ -153,9 +206,17 @@ export class ReconciliationService {
           assetIssuer: upstream.assetIssuer,
           storedAmount: '0',
           upstreamAmount: upstream.balance,
-          delta: upstream.balance,
+          delta: missingDelta.toFixed(8),
           repaired: true,
+          severity: missingSeverity,
         });
+        if (missingSeverity !== 'none') {
+          this.metricsService.recordReconciliationDrift(
+            RECONCILIATION_DATASET,
+            missingSeverity,
+            missingDelta,
+          );
+        }
 
         this.logger.warn(
           `[DRIFT] User ${userId}: ${upstream.assetCode} missing in DB — inserted ${upstream.balance}`,
@@ -165,8 +226,9 @@ export class ReconciliationService {
 
       const storedAmt = parseFloat(stored.amount);
       const delta = Math.abs(upstreamAmt - storedAmt);
+      const severity = evaluateDriftSeverity(delta, thresholds);
 
-      if (delta > DRIFT_THRESHOLD) {
+      if (severity !== 'none') {
         const drift: DriftRecord = {
           userId,
           assetCode: upstream.assetCode,
@@ -175,12 +237,18 @@ export class ReconciliationService {
           upstreamAmount: upstream.balance,
           delta: delta.toFixed(8),
           repaired: false,
+          severity,
         };
 
         // Repair: update stored amount to match upstream
         stored.amount = upstream.balance;
         await this.assetRepo.save(stored);
         drift.repaired = true;
+        this.metricsService.recordReconciliationDrift(
+          RECONCILIATION_DATASET,
+          severity,
+          delta,
+        );
 
         drifts.push(drift);
 
@@ -194,19 +262,29 @@ export class ReconciliationService {
 
     // Any remaining stored assets have no upstream counterpart — zero them out
     for (const [, orphan] of storedMap) {
+      const orphanDelta = Math.abs(parseFloat(orphan.amount));
+      const orphanSeverity = evaluateDriftSeverity(orphanDelta, thresholds);
       const drift: DriftRecord = {
         userId,
         assetCode: orphan.assetCode,
         assetIssuer: orphan.assetIssuer,
         storedAmount: orphan.amount,
         upstreamAmount: '0',
-        delta: orphan.amount,
+        delta: orphanDelta.toFixed(8),
         repaired: false,
+        severity: orphanSeverity,
       };
 
       orphan.amount = '0';
       await this.assetRepo.save(orphan);
       drift.repaired = true;
+      if (orphanSeverity !== 'none') {
+        this.metricsService.recordReconciliationDrift(
+          RECONCILIATION_DATASET,
+          orphanSeverity,
+          orphanDelta,
+        );
+      }
 
       drifts.push(drift);
 

--- a/document/RECONCILIATION_ALERTING_RUNBOOK.md
+++ b/document/RECONCILIATION_ALERTING_RUNBOOK.md
@@ -1,0 +1,19 @@
+# Reconciliation Alerting Runbook
+
+Reconciliation alerts identify differences between live Stellar balances and the `portfolio_assets` read model.
+
+## Configuration
+
+Set these backend environment variables in the same units as the stored asset amount:
+
+- `RECONCILIATION_PORTFOLIO_ASSETS_WARNING_THRESHOLD` (default: `0.0000001`)
+- `RECONCILIATION_PORTFOLIO_ASSETS_CRITICAL_THRESHOLD` (default: `0.00001`)
+
+The critical threshold must be greater than or equal to the warning threshold.
+
+## Response
+
+1. Inspect the `dataset` and `severity` labels on `lumenpulse_reconciliation_drift_total`.
+2. Query recent reconciliation jobs at `GET /admin/reconciliation` and inspect `driftDetails` for `userId`, asset code, issuer, stored amount, upstream amount, delta, and repair status.
+3. Confirm the corresponding Stellar account and determine whether the read model or upstream balance is authoritative.
+4. Re-run reconciliation after correcting the underlying cause and verify that the alert clears.

--- a/lumenpulse-grafana-dashboard.json
+++ b/lumenpulse-grafana-dashboard.json
@@ -352,6 +352,37 @@
           "refId": "A"
         }
       ]
+    },
+
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "Reconciliation Drift Breaches",
+      "description": "Drift breaches by reconciled dataset and severity",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 34 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (dataset, severity) (increase(lumenpulse_reconciliation_drift_total[10m]))",
+          "legendFormat": "{{dataset}} / {{severity}}",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "lumenpulse_reconciliation_drift_delta",
+          "legendFormat": "{{dataset}} max delta ({{severity}})",
+          "refId": "B"
+        }
+      ]
     }
 
   ],

--- a/prometheus-rules.yml
+++ b/prometheus-rules.yml
@@ -99,6 +99,38 @@ groups:
           summary: 'High job failure rate'
           description: '{{ .Labels.queue_name }} has > 10% job failures (current: {{ $value | humanize }}/sec)'
 
+      # ==========================
+      # Reconciliation Drift Alerts
+      # ==========================
+
+      - alert: ReconciliationDriftWarning
+        expr: |
+          sum by (dataset) (
+            increase(lumenpulse_reconciliation_drift_total{severity="warning"}[10m])
+          ) > 0
+        for: 5m
+        labels:
+          severity: warning
+          service: backend
+        annotations:
+          summary: 'Reconciliation drift warning'
+          description: '{{ .Labels.dataset }} has recorded warning-level drift breaches in the last 10 minutes'
+          runbook: 'document/RECONCILIATION_ALERTING_RUNBOOK.md'
+
+      - alert: ReconciliationDriftCritical
+        expr: |
+          sum by (dataset) (
+            increase(lumenpulse_reconciliation_drift_total{severity="critical"}[10m])
+          ) > 0
+        for: 1m
+        labels:
+          severity: critical
+          service: backend
+        annotations:
+          summary: 'Critical reconciliation drift'
+          description: '{{ .Labels.dataset }} has recorded critical drift breaches in the last 10 minutes'
+          runbook: 'document/RECONCILIATION_ALERTING_RUNBOOK.md'
+
       # ====================
       # Ingestion Dataset SLA Alerts
       # ====================


### PR DESCRIPTION
closes #1202 
## Summary

Added configurable warning and critical drift thresholds for reconciliation datasets. Threshold breaches now include severity details, emit Prometheus metrics, trigger alerts, and appear in the Grafana dashboard. Added boundary tests and an alerting runbook.

## Linked Issue

Closes #1202

## Type of Change

- [x] feat
- [ ] fix
- [x] docs
- [ ] refactor
- [x] test
- [ ] chore

## Validation

- [ ] Lint passed for affected area(s)
- [x] Tests passed for affected area(s)
- [x] Manual verification completed (monitoring configuration parsing and backend build)

## Documentation

- [x] Documentation updated (alerting runbook added)
- [ ] Screenshots/videos attached for UI changes (N/A)

## Checklist

- [ ] Branch name uses `feat/`, `fix/`, or `docs`
- [x] Commit messages follow Conventional Commits
- [x] PR scope matches linked issue acceptance criteria