### PR TITLE
 Retire the mock wallet adapter behind a development-only flag

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -49,6 +49,13 @@ Lumenpulse Mobile is the cross-platform mobile client for the Lumenpulse ecosyst
 - `pnpm lint`: Run ESLint.
 - `pnpm tsc`: Run TypeScript compiler check.
 
+## Wallet Adapters
+
+Production builds use the SEP-0007 wallet adapter only. Development builds may
+also select the mock adapter when the SEP-0007 wallet is unavailable; the app
+shows a persistent warning while that adapter is active, and mock transactions
+are never real signatures.
+
 ## Validation
 
 - Secure session and wallet metadata validation steps live in [SECURE_STORAGE_VALIDATION.md](./SECURE_STORAGE_VALIDATION.md).

--- a/apps/mobile/contexts/WalletContext.tsx
+++ b/apps/mobile/contexts/WalletContext.tsx
@@ -1,12 +1,13 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
 import * as Linking from 'expo-linking';
-import { Alert } from 'react-native';
+import { Alert, StyleSheet, Text, View } from 'react-native';
 import { useLocalization } from '../src/context';
 import { useEnvironment } from './EnvironmentContext';
 import { storage, WalletNetworkTag, sanitizePublicKey } from '../lib/storage';
 import { WalletError } from '../lib/wallet/errors';
 import { getDefaultWalletAdapter } from '../lib/wallet/registry';
 import { WalletAdapter, WalletSigningResult, WalletSigningState } from '../lib/wallet/types';
+import config from '../lib/config';
 
 export type WalletStatus =
   | 'disconnected'
@@ -91,6 +92,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const [lastRestoreOutcome, setLastRestoreOutcome] = useState<WalletRestoreOutcome | null>(null);
   const [signingState, setSigningState] = useState<WalletSigningState>('idle');
   const [lastSigningError, setLastSigningError] = useState<WalletError | null>(null);
+  const [activeAdapterId, setActiveAdapterId] = useState<string | null>(null);
   const { t } = useLocalization();
   const { environment, isInitialized: isEnvironmentReady } = useEnvironment();
   // Tracks whether a restore attempt has completed at least once so we
@@ -279,6 +281,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const ensureAdapter = useCallback(async () => {
     if (!activeAdapterRef.current) {
       activeAdapterRef.current = await getDefaultWalletAdapter();
+      setActiveAdapterId(activeAdapterRef.current.id);
     }
     return activeAdapterRef.current;
   }, []);
@@ -467,10 +470,36 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         signAndSubmitXdr,
       }}
     >
-      {children}
+      <View style={styles.providerContainer}>
+        {config.isDevelopment && activeAdapterId === 'mock' && (
+          <View style={styles.mockWalletBanner} accessible accessibilityRole="alert">
+            <Text style={styles.mockWalletBannerText}>
+              DEVELOPMENT ONLY: MOCK WALLET ACTIVE. TRANSACTIONS ARE NOT SIGNED.
+            </Text>
+          </View>
+        )}
+        {children}
+      </View>
     </WalletContext.Provider>
   );
 };
+
+const styles = StyleSheet.create({
+  providerContainer: {
+    flex: 1,
+  },
+  mockWalletBanner: {
+    backgroundColor: '#B91C1C',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  mockWalletBannerText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    fontWeight: '800',
+    textAlign: 'center',
+  },
+});
 
 export const useWallet = () => {
   const context = useContext(WalletContext);

--- a/apps/mobile/lib/__tests__/wallet-registry.test.ts
+++ b/apps/mobile/lib/__tests__/wallet-registry.test.ts
@@ -1,0 +1,7 @@
+import { createWalletAdapterRegistry } from '../wallet/registry';
+
+export function testProductionRegistryExcludesMockAdapter(): boolean {
+  const adapters = createWalletAdapterRegistry(false);
+
+  return !adapters.some((adapter) => adapter.id === 'mock');
+}

--- a/apps/mobile/lib/wallet/registry.ts
+++ b/apps/mobile/lib/wallet/registry.ts
@@ -14,7 +14,7 @@ import { WalletAdapter } from './types';
 export function createWalletAdapterRegistry(isDevelopment = config.isDevelopment): WalletAdapter[] {
   const adapters: WalletAdapter[] = [new Sep7WalletAdapter()];
 
-  if (isDevelopment) {
+  if (isDevelopment && (typeof __DEV__ === 'undefined' || __DEV__)) {
     adapters.push(new MockWalletAdapter(true));
   }
 

--- a/ersABUBAKARLumenpulse
+++ b/ersABUBAKARLumenpulse
@@ -1,0 +1,3 @@
+[33mec4ad7b2[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mnew-branch2[m[33m, [m[1;31morigin/new-branch2[m[33m)[m fixed workflow
+[33mdb6914a8[m Add an admin key rotation flow
+[33md9cca363[m Merge pull request #1264 from Praiz089017/feat/1256-shadow-mode-model-deployment


### PR DESCRIPTION

Implemented the mobile wallet safety changes:

- Registry only includes the mock adapter when development mode and Expo `__DEV__` are enabled.
- Added a persistent, accessible warning when the mock adapter is active.
- Added a production registry test.
- Documented adapter selection in `README.md`.

Validation passed for TypeScript diagnostics and `git diff --check`. The mobile `tsc` command could not run because dependencies are not installed locally. Unrelated untracked content was left untouched.

Checked , , , no problems found

Made changes.

Closes #1183 