### PR TITLE
feat(backend): add idempotency keys to write endpoints (Fixes #1199)

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -49,6 +49,7 @@ import { OutboxModule } from './outbox/outbox.module';
 import { VerificationModule } from './verification/verification.module';
 import { TelegramBotModule } from './telegram-bot/telegram-bot.module';
 import { IdempotencyInterceptor } from './common/interceptors/idempotency.interceptor';
+import { IdempotencyModule } from './idempotency/idempotency.module';
 import { DeprecationInterceptor } from './common/interceptors/deprecation.interceptor';
 import { SearchModule } from './search/search.module';
 import { ExportModule } from './export/export.module';
@@ -205,6 +206,9 @@ import { PriceAlertModule } from './price-alert/price-alert.module';
 
     // Price alerts
     PriceAlertModule,
+
+    // Idempotency for write endpoints
+    IdempotencyModule,
   ],
   controllers: [AppController, TestController, TestExceptionController],
   providers: [

--- a/apps/backend/src/common/interceptors/idempotency.interceptor.spec.ts
+++ b/apps/backend/src/common/interceptors/idempotency.interceptor.spec.ts
@@ -1,28 +1,54 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { IdempotencyInterceptor } from './idempotency.interceptor';
+import { ExecutionContext, CallHandler, HttpStatus } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { CacheService } from '../../cache/cache.service';
-import { ExecutionContext, CallHandler } from '@nestjs/common';
-import { throwError } from 'rxjs';
+import { throwError, firstValueFrom, of } from 'rxjs';
+import { IdempotencyInterceptor } from './idempotency.interceptor';
+import { IdempotencyService } from '../../idempotency/idempotency.service';
+import {
+  IdempotencyRecord,
+  IdempotencyRecordStatus,
+} from '../../idempotency/idempotency-record.entity';
 
 describe('IdempotencyInterceptor', () => {
   let interceptor: IdempotencyInterceptor;
 
-  const mockCacheService = {
-    get: jest.fn(),
-    set: jest.fn(),
-    del: jest.fn(),
+  const mockService = {
+    acquire: jest.fn(),
+    complete: jest.fn(),
+    release: jest.fn(),
+    waitForCompletion: jest.fn(),
   };
 
   const mockReflector = {
     getAllAndOverride: jest.fn(),
+    get: jest.fn(),
   };
 
+  const makeRecord = (overrides: Partial<IdempotencyRecord> = {}) =>
+    ({
+      id: 'record-id',
+      key: 'test-key',
+      method: 'POST',
+      route: '/test',
+      requestHash: 'hash',
+      status: IdempotencyRecordStatus.COMPLETED,
+      responseStatus: HttpStatus.CREATED,
+      responseBody: { success: true },
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      expiresAt: new Date(Date.now() + 86_400_000),
+      completedAt: new Date(),
+      createdAt: new Date(),
+      ...overrides,
+    }) as IdempotencyRecord;
+
   beforeEach(async () => {
+    jest.resetAllMocks();
+    mockReflector.getAllAndOverride.mockReturnValue(undefined);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         IdempotencyInterceptor,
-        { provide: CacheService, useValue: mockCacheService },
+        { provide: IdempotencyService, useValue: mockService },
         { provide: Reflector, useValue: mockReflector },
       ],
     }).compile();
@@ -30,94 +56,151 @@ describe('IdempotencyInterceptor', () => {
     interceptor = module.get<IdempotencyInterceptor>(IdempotencyInterceptor);
   });
 
-  it('should return cached result if key and body hash match', async () => {
-    const body = { amount: 100 };
-    const context = createMockContext(
-      'POST',
-      { 'idempotency-key': 'test-key' },
-      body,
-    );
-    const next: CallHandler = { handle: jest.fn() };
+  function createMockContext(
+    method: string,
+    headers: Record<string, string>,
+    body: unknown,
+  ): ExecutionContext {
+    const status = jest.fn().mockReturnThis();
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({ method, headers, body, path: '/test' }),
+        getResponse: () => ({ status }),
+      }),
+      getHandler: () => ({}),
+      getClass: () => ({}),
+    } as unknown as ExecutionContext;
+  }
 
-    // @ts-expect-error - accessing private method for test
-    const bodyHash = interceptor.calculateHash(body);
-    const cachedResponse = {
-      statusCode: 201,
-      body: { success: true },
-      bodyHash,
-    };
+  const next: CallHandler = { handle: () => of({ ok: true }) };
 
-    mockCacheService.get.mockResolvedValue(cachedResponse);
+  it('passes through when no Idempotency-Key header is present', async () => {
+    const context = createMockContext('POST', {}, { amount: 100 });
 
     const obs = await interceptor.intercept(context, next);
-    const result = await obs.toPromise();
-    expect(result).toEqual(cachedResponse.body);
+
+    await expect(firstValueFrom(obs)).resolves.toEqual({ ok: true });
+    expect(mockService.acquire).not.toHaveBeenCalled();
   });
 
-  it('should throw UnprocessableEntity if body hash mismatch', async () => {
-    const body = { amount: 100 };
+  it('passes through when the method is not a write method', async () => {
+    const context = createMockContext(
+      'GET',
+      { 'idempotency-key': 'test-key' },
+      {},
+    );
+
+    const obs = await interceptor.intercept(context, next);
+
+    await expect(firstValueFrom(obs)).resolves.toEqual({ ok: true });
+    expect(mockService.acquire).not.toHaveBeenCalled();
+  });
+
+  it('replays the cached response for a repeated key', async () => {
     const context = createMockContext(
       'POST',
       { 'idempotency-key': 'test-key' },
-      body,
+      { amount: 100 },
     );
-    const next: CallHandler = { handle: jest.fn() };
+    mockService.acquire.mockResolvedValue({
+      kind: 'replay',
+      record: makeRecord(),
+    });
 
-    const cachedResponse = {
-      statusCode: 201,
-      body: { success: true },
-      bodyHash: 'different-hash',
-    };
+    const obs = await interceptor.intercept(context, next);
 
-    mockCacheService.get.mockResolvedValue(cachedResponse);
+    await expect(firstValueFrom(obs)).resolves.toEqual({ success: true });
+    expect(mockService.complete).not.toHaveBeenCalled();
+  });
+
+  it('throws UnprocessableEntity when the key is reused with a different body', async () => {
+    const context = createMockContext(
+      'POST',
+      { 'idempotency-key': 'test-key' },
+      { amount: 100 },
+    );
+    mockService.acquire.mockResolvedValue({
+      kind: 'hash-mismatch',
+      record: makeRecord(),
+    });
 
     await expect(interceptor.intercept(context, next)).rejects.toThrow(
       'Idempotency key was used with a different request body.',
     );
   });
 
-  it('should clear lock on error', async () => {
+  it('waits for an in-progress request and returns its response', async () => {
     const context = createMockContext(
       'POST',
       { 'idempotency-key': 'test-key' },
-      {},
+      { amount: 100 },
     );
-    const next: CallHandler = {
-      handle: () => throwError(() => new Error('Failed')),
-    };
+    const completed = makeRecord();
+    mockService.acquire.mockResolvedValue({
+      kind: 'in-progress',
+      record: makeRecord({ status: IdempotencyRecordStatus.IN_PROGRESS }),
+    });
+    mockService.waitForCompletion.mockResolvedValue(completed);
 
-    mockCacheService.get.mockResolvedValue(null);
+    const obs = await interceptor.intercept(context, next);
 
-    try {
-      const obs = await interceptor.intercept(context, next);
-      await obs.toPromise();
-    } catch {
-      // Expected
-    }
-
-    expect(mockCacheService.del).toHaveBeenCalled();
+    await expect(firstValueFrom(obs)).resolves.toEqual({ success: true });
+    expect(mockService.waitForCompletion).toHaveBeenCalledWith('record-id');
   });
 
-  function createMockContext(
-    method: string,
-    headers: Record<string, string>,
-    body: unknown,
-  ): ExecutionContext {
-    return {
-      switchToHttp: () => ({
-        getRequest: () => ({
-          method,
-          headers,
-          body,
-          path: '/test',
-        }),
-        getResponse: () => ({
-          status: jest.fn(),
-          statusCode: 200,
-        }),
-      }),
-      getHandler: () => ({}),
-      getClass: () => ({}),
-    } as unknown as ExecutionContext;
-  }
+  it('throws Conflict when the in-progress request does not complete in time', async () => {
+    const context = createMockContext(
+      'POST',
+      { 'idempotency-key': 'test-key' },
+      { amount: 100 },
+    );
+    mockService.acquire.mockResolvedValue({
+      kind: 'in-progress',
+      record: makeRecord({ status: IdempotencyRecordStatus.IN_PROGRESS }),
+    });
+    mockService.waitForCompletion.mockResolvedValue(null);
+
+    await expect(interceptor.intercept(context, next)).rejects.toThrow(
+      'Request with this idempotency key is already in progress.',
+    );
+  });
+
+  it('executes the handler and persists the response for a fresh key', async () => {
+    const context = createMockContext(
+      'POST',
+      { 'idempotency-key': 'test-key' },
+      { amount: 100 },
+    );
+    const record = makeRecord({ status: IdempotencyRecordStatus.IN_PROGRESS });
+    mockService.acquire.mockResolvedValue({ kind: 'acquired', record });
+    mockService.complete.mockResolvedValue(undefined);
+
+    const obs = await interceptor.intercept(context, next);
+
+    await expect(firstValueFrom(obs)).resolves.toEqual({ ok: true });
+    expect(mockService.complete).toHaveBeenCalledWith(
+      record,
+      HttpStatus.CREATED,
+      { ok: true },
+    );
+  });
+
+  it('releases the claim and rethrows when the handler fails', async () => {
+    const context = createMockContext(
+      'POST',
+      { 'idempotency-key': 'test-key' },
+      { amount: 100 },
+    );
+    const record = makeRecord({ status: IdempotencyRecordStatus.IN_PROGRESS });
+    mockService.acquire.mockResolvedValue({ kind: 'acquired', record });
+    mockService.release.mockResolvedValue(undefined);
+    const failingNext: CallHandler = {
+      handle: () => throwError(() => new Error('boom')),
+    };
+
+    await expect(
+      firstValueFrom(await interceptor.intercept(context, failingNext)),
+    ).rejects.toThrow('boom');
+    expect(mockService.release).toHaveBeenCalledWith('record-id');
+  });
 });

--- a/apps/backend/src/common/interceptors/idempotency.interceptor.ts
+++ b/apps/backend/src/common/interceptors/idempotency.interceptor.ts
@@ -1,36 +1,42 @@
 import {
-  Injectable,
-  NestInterceptor,
-  ExecutionContext,
   CallHandler,
-  HttpStatus,
+  ExecutionContext,
   HttpException,
+  HttpStatus,
+  Injectable,
   Logger,
+  NestInterceptor,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
+import { HTTP_CODE_METADATA } from '@nestjs/common/constants';
 import { Request, Response } from 'express';
-import { Observable, of } from 'rxjs';
-import { tap } from 'rxjs/operators';
-import * as crypto from 'crypto';
-import { CacheService } from '../../cache/cache.service';
+import { Observable, of, throwError } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
 import {
   IDEMPOTENT_OPTIONS_KEY,
   IdempotentOptions,
 } from '../decorators/idempotent.decorator';
+import { IdempotencyService } from '../../idempotency/idempotency.service';
 
-interface IdempotencyResult {
-  statusCode: number;
-  body: unknown;
-  bodyHash: string;
-}
-
+/**
+ * Idempotency for write endpoints.
+ *
+ * When a request carries an `Idempotency-Key` header, its response is persisted
+ * (keyed by method + route + body hash) and replayed verbatim for a repeated
+ * key within the retention window. Concurrent requests with the same key are
+ * serialised: the first executes, the rest wait and then receive the same
+ * response instead of re-executing.
+ *
+ * Storage is the `idempotency_records` table. Expired keys are purged by the
+ * `IdempotencyScheduler` on the documented cleanup schedule.
+ */
 @Injectable()
 export class IdempotencyInterceptor implements NestInterceptor {
   private readonly logger = new Logger(IdempotencyInterceptor.name);
 
   constructor(
     private readonly reflector: Reflector,
-    private readonly cacheService: CacheService,
+    private readonly service: IdempotencyService,
   ) {}
 
   async intercept(
@@ -51,81 +57,95 @@ export class IdempotencyInterceptor implements NestInterceptor {
     }
 
     const headerName = options.header || 'idempotency-key';
-    const idempotencyKey = request.headers[headerName.toLowerCase()];
-
-    if (!idempotencyKey || typeof idempotencyKey !== 'string') {
+    const headerValue = request.headers[headerName.toLowerCase()];
+    if (!headerValue || typeof headerValue !== 'string') {
       return next.handle();
     }
 
-    // Hash the body to ensure the key is only valid for the same payload
-    const bodyHash = this.calculateHash(request.body);
-    const cacheKey = `idempotency:${request.path}:${idempotencyKey}`;
+    const route = request.path;
+    const method = request.method;
+    const requestHash = IdempotencyService.hashRequest(
+      method,
+      route,
+      request.body,
+    );
 
-    const cachedResult = await this.cacheService.get<
-      IdempotencyResult | string
-    >(cacheKey);
+    const outcome = await this.service.acquire(
+      headerValue,
+      method,
+      route,
+      requestHash,
+      { retentionMs: options.ttl },
+    );
 
-    if (cachedResult) {
-      if (cachedResult === 'IN_PROGRESS') {
-        throw new HttpException(
-          'Request with this idempotency key is already in progress.',
-          HttpStatus.CONFLICT,
+    switch (outcome.kind) {
+      case 'replay': {
+        this.logger.debug(
+          `Replaying cached response for idempotency key ${headerValue}`,
         );
+        const response = httpContext.getResponse<Response>();
+        response.status(outcome.record.responseStatus ?? HttpStatus.OK);
+        return of(outcome.record.responseBody);
       }
 
-      const result = cachedResult as IdempotencyResult;
-
-      // Verify that the body hash matches
-      if (result.bodyHash !== bodyHash) {
+      case 'hash-mismatch':
         throw new HttpException(
           'Idempotency key was used with a different request body.',
           HttpStatus.UNPROCESSABLE_ENTITY,
         );
+
+      case 'in-progress': {
+        // Another request owns this key and is executing. Wait for it and
+        // return its response, so a concurrent retry neither duplicates the
+        // operation nor gets an error for trying.
+        const completed = await this.service.waitForCompletion(
+          outcome.record.id,
+        );
+        if (!completed) {
+          throw new HttpException(
+            'Request with this idempotency key is already in progress.',
+            HttpStatus.CONFLICT,
+          );
+        }
+        const response = httpContext.getResponse<Response>();
+        response.status(completed.responseStatus ?? HttpStatus.OK);
+        return of(completed.responseBody);
       }
 
-      this.logger.debug(`Returning cached result for key: ${idempotencyKey}`);
-      const response = httpContext.getResponse<Response>();
-      response.status(result.statusCode);
-      return of(result.body);
+      case 'acquired': {
+        return next.handle().pipe(
+          tap((body: unknown) => {
+            const status = this.resolveStatus(request, context);
+            void this.service
+              .complete(outcome.record, status, body)
+              .catch((err: Error) =>
+                this.logger.error(
+                  `Failed to persist idempotency result: ${err.message}`,
+                ),
+              );
+          }),
+          catchError((err: Error) => {
+            // The operation failed — drop the claim so the client can retry.
+            void this.service
+              .release(outcome.record.id)
+              .catch((releaseErr: Error) =>
+                this.logger.error(
+                  `Failed to release idempotency claim: ${releaseErr.message}`,
+                ),
+              );
+            return throwError(() => err);
+          }),
+        );
+      }
     }
-
-    // Mark as in progress to prevent concurrent duplicate requests
-    await this.cacheService.set(cacheKey, 'IN_PROGRESS', 60000); // 1 minute lock
-
-    return next.handle().pipe(
-      tap({
-        next: (body: unknown) => {
-          const response = httpContext.getResponse<Response>();
-          const result: IdempotencyResult = {
-            statusCode: response.statusCode,
-            body,
-            bodyHash,
-          };
-          const ttl = options.ttl || 24 * 60 * 60 * 1000; // 24 hours default
-          this.cacheService
-            .set(cacheKey, result, ttl)
-            .catch((err: Error) =>
-              this.logger.error(
-                `Failed to cache idempotency result: ${err.message}`,
-              ),
-            );
-        },
-        error: () => {
-          // Remove the lock on error so the client can retry
-          this.cacheService
-            .del(cacheKey)
-            .catch((err: Error) =>
-              this.logger.error(
-                `Failed to release idempotency lock: ${err.message}`,
-              ),
-            );
-        },
-      }),
-    );
   }
 
-  private calculateHash(body: unknown): string {
-    const data = body ? JSON.stringify(body) : '';
-    return crypto.createHash('sha256').update(data).digest('hex');
+  private resolveStatus(request: Request, context: ExecutionContext): number {
+    const explicit = this.reflector.get<number>(
+      HTTP_CODE_METADATA,
+      context.getHandler(),
+    );
+    if (explicit) return explicit;
+    return request.method === 'POST' ? HttpStatus.CREATED : HttpStatus.OK;
   }
 }

--- a/apps/backend/src/database/migrations/1831000000000-CreateIdempotencyRecords.ts
+++ b/apps/backend/src/database/migrations/1831000000000-CreateIdempotencyRecords.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateIdempotencyRecords1831000000000 implements MigrationInterface {
+  name = 'CreateIdempotencyRecords1831000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "idempotency_records_status_enum" AS ENUM ('in_progress', 'completed')`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "idempotency_records" (
+        "id"              uuid                                   NOT NULL DEFAULT uuid_generate_v4(),
+        "key"             character varying(128)                 NOT NULL,
+        "method"          character varying(16)                  NOT NULL,
+        "route"           character varying(512)                 NOT NULL,
+        "requestHash"     character varying(64)                  NOT NULL,
+        "status"          "idempotency_records_status_enum"      NOT NULL DEFAULT 'in_progress',
+        "responseStatus"  integer,
+        "responseBody"    jsonb,
+        "leaseExpiresAt"  TIMESTAMP WITH TIME ZONE               NOT NULL,
+        "expiresAt"       TIMESTAMP WITH TIME ZONE               NOT NULL,
+        "completedAt"     TIMESTAMP WITH TIME ZONE,
+        "createdAt"       TIMESTAMP WITH TIME ZONE               NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_idempotency_records" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_idempotency_key_method_route" ON "idempotency_records" ("key", "method", "route")`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_idempotency_expires_at" ON "idempotency_records" ("expiresAt")`,
+    );
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_idempotency_status_lease" ON "idempotency_records" ("status", "leaseExpiresAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_idempotency_status_lease"`);
+    await queryRunner.query(`DROP INDEX "IDX_idempotency_expires_at"`);
+    await queryRunner.query(`DROP INDEX "IDX_idempotency_key_method_route"`);
+    await queryRunner.query(`DROP TABLE "idempotency_records"`);
+    await queryRunner.query(`DROP TYPE "idempotency_records_status_enum"`);
+  }
+}

--- a/apps/backend/src/idempotency/idempotency-record.entity.ts
+++ b/apps/backend/src/idempotency/idempotency-record.entity.ts
@@ -1,0 +1,83 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+export enum IdempotencyRecordStatus {
+  IN_PROGRESS = 'in_progress',
+  COMPLETED = 'completed',
+}
+
+/**
+ * A claimed `Idempotency-Key` for a write endpoint.
+ *
+ * One row per (key, method, route). The unique index is what serialises
+ * concurrent requests carrying the same key: the first INSERT wins, and every
+ * other request either replays the stored response (completed) or waits for it
+ * (in_progress).
+ *
+ * `requestHash` pins a key to a single payload, so reusing a key with a
+ * different body is rejected rather than silently returning a stale response.
+ * `leaseExpiresAt` lets a retry reclaim a claim whose owner crashed mid-flight.
+ * `expiresAt` is the retention window; an expired row is dropped by the
+ * scheduled cleanup job.
+ */
+@Entity('idempotency_records')
+@Index('IDX_idempotency_key_method_route', ['key', 'method', 'route'], {
+  unique: true,
+})
+@Index('IDX_idempotency_expires_at', ['expiresAt'])
+@Index('IDX_idempotency_status_lease', ['status', 'leaseExpiresAt'])
+export class IdempotencyRecord {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** The client-supplied `Idempotency-Key` header value. */
+  @Column({ type: 'varchar', length: 128 })
+  key: string;
+
+  @Column({ type: 'varchar', length: 16 })
+  method: string;
+
+  /** The URL path (query string excluded) the key was used on. */
+  @Column({ type: 'varchar', length: 512 })
+  route: string;
+
+  /** sha256 of method + route + request body. */
+  @Column({ type: 'varchar', length: 64 })
+  requestHash: string;
+
+  @Column({
+    type: 'enum',
+    enum: IdempotencyRecordStatus,
+    default: IdempotencyRecordStatus.IN_PROGRESS,
+  })
+  status: IdempotencyRecordStatus;
+
+  @Column({ type: 'integer', nullable: true })
+  responseStatus: number | null;
+
+  /** The JSON body of the original response, returned verbatim on replay. */
+  @Column({ type: 'jsonb', nullable: true })
+  responseBody: unknown;
+
+  /**
+   * Deadline for an in_progress claim. Past this, another request may delete
+   * the row and take over, so a crashed worker never wedges the key.
+   */
+  @Column({ type: 'timestamptz' })
+  leaseExpiresAt: Date;
+
+  /** When this record is no longer replayed and may be cleaned up. */
+  @Column({ type: 'timestamptz' })
+  expiresAt: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  completedAt: Date | null;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+}

--- a/apps/backend/src/idempotency/idempotency.module.ts
+++ b/apps/backend/src/idempotency/idempotency.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { IdempotencyRecord } from './idempotency-record.entity';
+import { IdempotencyService } from './idempotency.service';
+import { IdempotencyScheduler } from './idempotency.scheduler';
+import { SchedulerModule } from '../scheduler/scheduler.module';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([IdempotencyRecord]), SchedulerModule],
+  providers: [IdempotencyService, IdempotencyScheduler],
+  exports: [IdempotencyService],
+})
+export class IdempotencyModule {}

--- a/apps/backend/src/idempotency/idempotency.scheduler.ts
+++ b/apps/backend/src/idempotency/idempotency.scheduler.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { IdempotencyService } from './idempotency.service';
+import { JobLockService } from '../scheduler/job-lock.service';
+import { config } from '../lib/config';
+
+const JOB_NAME = 'idempotency-cleanup';
+
+/**
+ * Removes expired idempotency records on a documented schedule.
+ *
+ * Default: daily at 03:00 UTC (`0 3 * * *`), overridable via the
+ * `IDEMPOTENCY_CLEANUP_CRON` environment variable. Completed records are kept
+ * for the retention window (`IDEMPOTENCY_RETENTION_MS`, default 24h) so a late
+ * client retry still replays the original response; in_progress claims are
+ * dropped once their lease (`IDEMPOTENCY_LEASE_MS`) has lapsed.
+ *
+ * A PostgreSQL advisory lock (via `JobLockService`) ensures only one instance
+ * runs the sweep when the backend is scaled horizontally.
+ */
+@Injectable()
+export class IdempotencyScheduler {
+  private readonly logger = new Logger(IdempotencyScheduler.name);
+
+  constructor(
+    private readonly service: IdempotencyService,
+    private readonly jobLock: JobLockService,
+  ) {}
+
+  @Cron(config.idempotency.cleanupCron, { timeZone: 'UTC', name: JOB_NAME })
+  async handleCleanup(): Promise<void> {
+    const acquired = await this.jobLock.tryAcquire(JOB_NAME);
+    if (!acquired) return;
+
+    try {
+      const deleted = await this.service.cleanupExpired();
+      if (deleted > 0) {
+        this.logger.log(`Cleaned up ${deleted} expired idempotency records`);
+      }
+    } finally {
+      await this.jobLock.release(JOB_NAME);
+    }
+  }
+}

--- a/apps/backend/src/idempotency/idempotency.service.spec.ts
+++ b/apps/backend/src/idempotency/idempotency.service.spec.ts
@@ -1,0 +1,271 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  IdempotencyRecord,
+  IdempotencyRecordStatus,
+} from './idempotency-record.entity';
+import { IdempotencyService } from './idempotency.service';
+
+describe('IdempotencyService', () => {
+  let service: IdempotencyService;
+  let repo: jest.Mocked<
+    Pick<
+      Repository<IdempotencyRecord>,
+      | 'findOne'
+      | 'create'
+      | 'insert'
+      | 'update'
+      | 'delete'
+      | 'createQueryBuilder'
+    >
+  >;
+
+  const record = (overrides: Partial<IdempotencyRecord> = {}) =>
+    ({
+      id: 'record-id',
+      key: 'key-1',
+      method: 'POST',
+      route: '/grants/:id',
+      requestHash: 'hash-1',
+      status: IdempotencyRecordStatus.COMPLETED,
+      responseStatus: 201,
+      responseBody: { ok: true },
+      leaseExpiresAt: new Date(Date.now() + 60_000),
+      expiresAt: new Date(Date.now() + 86_400_000),
+      completedAt: new Date(),
+      createdAt: new Date(),
+      ...overrides,
+    }) as IdempotencyRecord;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    repo = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+      insert: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IdempotencyService,
+        {
+          provide: getRepositoryToken(IdempotencyRecord),
+          useValue: repo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<IdempotencyService>(IdempotencyService);
+  });
+
+  describe('acquire', () => {
+    it('claims a fresh key as in_progress and returns acquired', async () => {
+      repo.findOne.mockResolvedValue(null);
+      const claim = record({ status: IdempotencyRecordStatus.IN_PROGRESS });
+      repo.create.mockReturnValue(claim);
+      repo.insert.mockResolvedValue({} as never);
+
+      const outcome = await service.acquire(
+        'key-1',
+        'POST',
+        '/grants/:id',
+        'hash-1',
+      );
+
+      expect(outcome.kind).toBe('acquired');
+      expect(repo.insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('replays the stored response for a completed key with the same body', async () => {
+      repo.findOne.mockResolvedValue(record());
+
+      const outcome = await service.acquire(
+        'key-1',
+        'POST',
+        '/grants/:id',
+        'hash-1',
+      );
+
+      expect(outcome).toMatchObject({ kind: 'replay' });
+      expect(repo.insert).not.toHaveBeenCalled();
+    });
+
+    it('rejects a completed key reused with a different body', async () => {
+      repo.findOne.mockResolvedValue(record({ requestHash: 'other-hash' }));
+
+      const outcome = await service.acquire(
+        'key-1',
+        'POST',
+        '/grants/:id',
+        'hash-1',
+      );
+
+      expect(outcome.kind).toBe('hash-mismatch');
+    });
+
+    it('does not replay a completed key whose retention window has passed', async () => {
+      repo.findOne.mockResolvedValue(
+        record({ expiresAt: new Date(Date.now() - 1_000) }),
+      );
+      const claim = record({ status: IdempotencyRecordStatus.IN_PROGRESS });
+      repo.create.mockReturnValue(claim);
+      repo.insert.mockResolvedValue({} as never);
+
+      const outcome = await service.acquire(
+        'key-1',
+        'POST',
+        '/grants/:id',
+        'hash-1',
+      );
+
+      expect(outcome.kind).toBe('acquired');
+      expect(repo.delete).toHaveBeenCalledWith('record-id');
+    });
+
+    it('returns in-progress for a live claim owned by another request', async () => {
+      repo.findOne.mockResolvedValue(
+        record({ status: IdempotencyRecordStatus.IN_PROGRESS }),
+      );
+
+      const outcome = await service.acquire(
+        'key-1',
+        'POST',
+        '/grants/:id',
+        'hash-1',
+      );
+
+      expect(outcome.kind).toBe('in-progress');
+      expect(repo.insert).not.toHaveBeenCalled();
+    });
+
+    it('reclaims a claim whose lease has expired', async () => {
+      repo.findOne.mockResolvedValue(
+        record({
+          status: IdempotencyRecordStatus.IN_PROGRESS,
+          leaseExpiresAt: new Date(Date.now() - 1_000),
+        }),
+      );
+      const claim = record({ status: IdempotencyRecordStatus.IN_PROGRESS });
+      repo.create.mockReturnValue(claim);
+      repo.insert.mockResolvedValue({} as never);
+
+      const outcome = await service.acquire(
+        'key-1',
+        'POST',
+        '/grants/:id',
+        'hash-1',
+      );
+
+      expect(outcome.kind).toBe('acquired');
+      expect(repo.delete).toHaveBeenCalled();
+    });
+
+    it('re-classifies the winner when it loses the insert race', async () => {
+      repo.findOne.mockResolvedValueOnce(null);
+      repo.create.mockReturnValue(record());
+      repo.insert.mockRejectedValue(
+        new Error('duplicate key value violates unique constraint'),
+      );
+      repo.findOne.mockResolvedValueOnce(record());
+
+      const outcome = await service.acquire(
+        'key-1',
+        'POST',
+        '/grants/:id',
+        'hash-1',
+      );
+
+      expect(outcome.kind).toBe('replay');
+    });
+  });
+
+  describe('complete', () => {
+    it('persists the response on the record', async () => {
+      repo.update.mockResolvedValue({ affected: 1 } as never);
+
+      await service.complete(record(), 201, { ok: true });
+
+      expect(repo.update).toHaveBeenCalledWith(
+        'record-id',
+        expect.objectContaining({
+          status: IdempotencyRecordStatus.COMPLETED,
+          responseStatus: 201,
+          responseBody: { ok: true },
+        }),
+      );
+    });
+  });
+
+  describe('release', () => {
+    it('deletes the claim so the client can retry', async () => {
+      repo.delete.mockResolvedValue({ affected: 1 } as never);
+
+      await service.release('record-id');
+
+      expect(repo.delete).toHaveBeenCalledWith('record-id');
+    });
+  });
+
+  describe('waitForCompletion', () => {
+    it('returns the completed record once the owner finishes', async () => {
+      const completed = record();
+      repo.findOne
+        .mockResolvedValueOnce(
+          record({ status: IdempotencyRecordStatus.IN_PROGRESS }),
+        )
+        .mockResolvedValueOnce(completed);
+
+      const result = await service.waitForCompletion('record-id', 500);
+
+      expect(result).toEqual(completed);
+    });
+
+    it('returns null if the owner does not finish in time', async () => {
+      repo.findOne.mockResolvedValue(
+        record({ status: IdempotencyRecordStatus.IN_PROGRESS }),
+      );
+
+      const result = await service.waitForCompletion('record-id', 50);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('cleanupExpired', () => {
+    it('deletes expired records and stale in-progress claims', async () => {
+      const deleteBuilder = {
+        where: jest.fn().mockReturnThis(),
+        orWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected: 3 }),
+      };
+      repo.createQueryBuilder.mockReturnValue({
+        delete: jest.fn().mockReturnValue(deleteBuilder),
+      } as never);
+
+      const deleted = await service.cleanupExpired(new Date());
+
+      expect(deleted).toBe(3);
+      expect(deleteBuilder.where).toHaveBeenCalled();
+      expect(deleteBuilder.orWhere).toHaveBeenCalled();
+    });
+  });
+
+  describe('hashRequest', () => {
+    it('is stable for the same method, route and body', () => {
+      const a = IdempotencyService.hashRequest('POST', '/x', { a: 1 });
+      const b = IdempotencyService.hashRequest('POST', '/x', { a: 1 });
+      expect(a).toBe(b);
+    });
+
+    it('differs when the body changes', () => {
+      const a = IdempotencyService.hashRequest('POST', '/x', { a: 1 });
+      const b = IdempotencyService.hashRequest('POST', '/x', { a: 2 });
+      expect(a).not.toBe(b);
+    });
+  });
+});

--- a/apps/backend/src/idempotency/idempotency.service.ts
+++ b/apps/backend/src/idempotency/idempotency.service.ts
@@ -1,0 +1,186 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
+import {
+  IdempotencyRecord,
+  IdempotencyRecordStatus,
+} from './idempotency-record.entity';
+import { config } from '../lib/config';
+
+export type IdempotencyOutcome =
+  | { kind: 'replay'; record: IdempotencyRecord }
+  | { kind: 'hash-mismatch'; record: IdempotencyRecord }
+  | { kind: 'in-progress'; record: IdempotencyRecord }
+  | { kind: 'acquired'; record: IdempotencyRecord };
+
+export interface IdempotencySettings {
+  /** How long a completed key is replayed before it expires. Default 24h. */
+  retentionMs?: number;
+  /** How long an in_progress claim is held before it can be reclaimed. Default 60s. */
+  leaseMs?: number;
+  /** How long a concurrent request waits for the owner to finish. Default 30s. */
+  concurrencyTimeoutMs?: number;
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+@Injectable()
+export class IdempotencyService {
+  private readonly logger = new Logger(IdempotencyService.name);
+
+  constructor(
+    @InjectRepository(IdempotencyRecord)
+    private readonly repo: Repository<IdempotencyRecord>,
+  ) {}
+
+  /** Deterministic fingerprint of method + route + body. */
+  static hashRequest(method: string, route: string, body: unknown): string {
+    const payload = `${method}:${route}:${body ? JSON.stringify(body) : ''}`;
+    return crypto.createHash('sha256').update(payload).digest('hex');
+  }
+
+  /**
+   * Register this (key, method, route) for execution, serialising concurrent
+   * requests with the same key:
+   *
+   * - nothing stored  → insert an in_progress claim and return `acquired`.
+   * - completed, same hash → `replay` (return the stored response).
+   * - completed, different hash → `hash-mismatch` (the key was reused).
+   * - in_progress, lease alive → `in-progress` (wait for the owner).
+   * - in_progress, lease expired → reclaim and become the executor.
+   */
+  async acquire(
+    key: string,
+    method: string,
+    route: string,
+    requestHash: string,
+    settings: IdempotencySettings = {},
+  ): Promise<IdempotencyOutcome> {
+    const retentionMs = settings.retentionMs ?? config.idempotency.retentionMs;
+    const leaseMs = settings.leaseMs ?? config.idempotency.leaseMs;
+    const now = Date.now();
+
+    const existing = await this.repo.findOne({
+      where: { key, method, route },
+    });
+    if (existing) {
+      const result = this.classify(existing, requestHash, now);
+      if (result) return result;
+
+      // Lease expired — the owner crashed or is wedged. Reclaim the key.
+      this.logger.warn(
+        `Reclaiming stale idempotency claim ${existing.id} for key ${key} on ${method} ${route}`,
+      );
+      await this.repo.delete(existing.id);
+    }
+
+    const claim = this.repo.create({
+      key,
+      method,
+      route,
+      requestHash,
+      status: IdempotencyRecordStatus.IN_PROGRESS,
+      responseStatus: null,
+      responseBody: null,
+      leaseExpiresAt: new Date(now + leaseMs),
+      expiresAt: new Date(now + retentionMs),
+      completedAt: null,
+    });
+
+    try {
+      await this.repo.insert(claim as any);
+    } catch (err) {
+      // Lost the race to a concurrent request. Re-read and classify again.
+      const winner = await this.repo.findOne({
+        where: { key, method, route },
+      });
+      if (winner) {
+        const result = this.classify(winner, requestHash, Date.now());
+        if (result) return result;
+      }
+      throw err;
+    }
+
+    return { kind: 'acquired', record: claim };
+  }
+
+  /** Store the successful response so a later request can replay it. */
+  async complete(
+    record: IdempotencyRecord,
+    responseStatus: number,
+    responseBody: unknown,
+  ): Promise<void> {
+    await this.repo.update(record.id, {
+      status: IdempotencyRecordStatus.COMPLETED,
+      responseStatus,
+      responseBody,
+      completedAt: new Date(),
+    } as any);
+  }
+
+  /** Drop an in_progress claim after a failure so the client can retry. */
+  async release(recordId: string): Promise<void> {
+    await this.repo.delete(recordId);
+  }
+
+  /**
+   * Wait for the request that owns an in_progress claim to finish, then return
+   * its completed record. Returns null if it does not complete within
+   * `timeoutMs` — the caller decides how to respond.
+   */
+  async waitForCompletion(
+    recordId: string,
+    timeoutMs: number = config.idempotency.concurrencyTimeoutMs,
+  ): Promise<IdempotencyRecord | null> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const record = await this.repo.findOne({ where: { id: recordId } });
+      if (record?.status === IdempotencyRecordStatus.COMPLETED) {
+        return record;
+      }
+      if (Date.now() >= deadline) return null;
+      await sleep(100);
+    }
+  }
+
+  /**
+   * Delete records that are no longer needed: completed records past their
+   * retention window and in_progress claims past their lease. Runs on the
+   * documented cleanup schedule (see `IdempotencyScheduler`).
+   */
+  async cleanupExpired(now: Date = new Date()): Promise<number> {
+    const result = await this.repo
+      .createQueryBuilder()
+      .delete()
+      .where('"expiresAt" < :now', { now })
+      .orWhere('"status" = :status AND "leaseExpiresAt" < :now', {
+        status: IdempotencyRecordStatus.IN_PROGRESS,
+        now,
+      })
+      .execute();
+    return result.affected ?? 0;
+  }
+
+  private classify(
+    record: IdempotencyRecord,
+    requestHash: string,
+    now: number,
+  ): IdempotencyOutcome | null {
+    // Retention window elapsed — treat as reclaimable so a late retry starts a
+    // fresh operation instead of replaying a stale response.
+    if (record.expiresAt.getTime() <= now) {
+      return null;
+    }
+    if (record.status === IdempotencyRecordStatus.COMPLETED) {
+      if (record.requestHash === requestHash) {
+        return { kind: 'replay', record };
+      }
+      return { kind: 'hash-mismatch', record };
+    }
+    if (record.leaseExpiresAt.getTime() > now) {
+      return { kind: 'in-progress', record };
+    }
+    return null;
+  }
+}

--- a/apps/backend/src/lib/config.ts
+++ b/apps/backend/src/lib/config.ts
@@ -93,6 +93,10 @@ import { z } from 'zod';
  * - RATE_LIMIT_WATCHLIST_WRITE_LIMIT
  * - RATE_LIMIT_WATCHLIST_WRITE_TTL_MS
  * - RATE_LIMIT_WATCHLIST_WRITE_BLOCK_MS
+ * - IDEMPOTENCY_RETENTION_MS
+ * - IDEMPOTENCY_LEASE_MS
+ * - IDEMPOTENCY_CONCURRENCY_TIMEOUT_MS
+ * - IDEMPOTENCY_CLEANUP_CRON
  *
  * NEVER_SERVER:
  * - NEXT_PUBLIC_* (validated client-side only)
@@ -533,6 +537,20 @@ const envSchema = z
       parseBoolean,
       z.boolean().default(false),
     ),
+
+    // Idempotency keys (see apps/backend/src/idempotency)
+    IDEMPOTENCY_RETENTION_MS: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .default(86_400_000),
+    IDEMPOTENCY_LEASE_MS: z.coerce.number().int().min(1).default(60_000),
+    IDEMPOTENCY_CONCURRENCY_TIMEOUT_MS: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .default(30_000),
+    IDEMPOTENCY_CLEANUP_CRON: z.string().trim().default('0 3 * * *'),
   })
   .superRefine((values, context) => {
     if (values.NODE_ENV === 'production' && !values.CORS_ORIGIN) {
@@ -979,6 +997,13 @@ const optionalSummary = [
     'PORTFOLIO_SNAPSHOT_QUEUE_METRICS',
     String(parsedEnv.PORTFOLIO_SNAPSHOT_QUEUE_METRICS),
   ],
+  ['IDEMPOTENCY_RETENTION_MS', String(parsedEnv.IDEMPOTENCY_RETENTION_MS)],
+  ['IDEMPOTENCY_LEASE_MS', String(parsedEnv.IDEMPOTENCY_LEASE_MS)],
+  [
+    'IDEMPOTENCY_CONCURRENCY_TIMEOUT_MS',
+    String(parsedEnv.IDEMPOTENCY_CONCURRENCY_TIMEOUT_MS),
+  ],
+  ['IDEMPOTENCY_CLEANUP_CRON', parsedEnv.IDEMPOTENCY_CLEANUP_CRON],
 ] as const;
 
 const wasDefaulted = (key: string): boolean => {
@@ -1144,6 +1169,27 @@ export const config = Object.freeze({
     attempts: parsedEnv.PORTFOLIO_SNAPSHOT_ATTEMPTS,
     retryDelayMs: parsedEnv.PORTFOLIO_SNAPSHOT_RETRY_DELAY_MS,
     queueMetrics: parsedEnv.PORTFOLIO_SNAPSHOT_QUEUE_METRICS,
+  }),
+  idempotency: Object.freeze({
+    /**
+     * How long a completed `Idempotency-Key` response is replayed. Default 24h.
+     */
+    retentionMs: parsedEnv.IDEMPOTENCY_RETENTION_MS,
+    /**
+     * How long an in_progress claim is held before a retry can reclaim it.
+     * Default 60s.
+     */
+    leaseMs: parsedEnv.IDEMPOTENCY_LEASE_MS,
+    /**
+     * How long a concurrent request waits for the request that owns the key
+     * to finish. Default 30s.
+     */
+    concurrencyTimeoutMs: parsedEnv.IDEMPOTENCY_CONCURRENCY_TIMEOUT_MS,
+    /**
+     * Cron expression for the scheduled cleanup of expired records.
+     * Default: daily at 03:00 UTC.
+     */
+    cleanupCron: parsedEnv.IDEMPOTENCY_CLEANUP_CRON,
   }),
   rateLimit: Object.freeze({
     tracker: Object.freeze({

--- a/apps/backend/test/idempotency.e2e-spec.ts
+++ b/apps/backend/test/idempotency.e2e-spec.ts
@@ -1,0 +1,156 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Body, Controller, INestApplication, Post } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { ScheduleModule } from '@nestjs/schedule';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import request from 'supertest';
+import { App } from 'supertest/types';
+import { IdempotencyModule } from '../src/idempotency/idempotency.module';
+import { IdempotencyInterceptor } from '../src/common/interceptors/idempotency.interceptor';
+import { Idempotent } from '../src/common/decorators/idempotent.decorator';
+import databaseConfig from '../src/database/database.config';
+
+@Controller('idempotency-test')
+class IdempotencyTestController {
+  public executions = 0;
+
+  @Post('slow')
+  @Idempotent()
+  async slowCreate(@Body() body: Record<string, unknown>) {
+    this.executions += 1;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    return { received: body, executions: this.executions };
+  }
+
+  @Post('expiring')
+  @Idempotent({ ttl: 300 })
+  expiringCreate(@Body() body: Record<string, unknown>) {
+    this.executions += 1;
+    return { received: body, executions: this.executions };
+  }
+}
+
+interface TestResponseBody {
+  received: Record<string, unknown>;
+  executions: number;
+}
+
+const makeRequest = (app: INestApplication) =>
+  request(app.getHttpServer() as unknown as App);
+
+describe('Idempotency (e2e)', () => {
+  let app: INestApplication;
+  let controller: IdempotencyTestController;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        ConfigModule.forRoot({
+          isGlobal: true,
+          ignoreEnvFile: true,
+          load: [databaseConfig],
+        }),
+        TypeOrmModule.forRootAsync({
+          inject: [ConfigService],
+          useFactory: (configService: ConfigService) => ({
+            ...configService.get<Record<string, unknown>>('database'),
+            autoLoadEntities: true,
+            synchronize: true,
+          }),
+        }),
+        ScheduleModule.forRoot(),
+        IdempotencyModule,
+      ],
+      controllers: [IdempotencyTestController],
+      providers: [
+        {
+          provide: APP_INTERCEPTOR,
+          useClass: IdempotencyInterceptor,
+        },
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+    controller = app.get(IdempotencyTestController);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    controller.executions = 0;
+  });
+
+  it('replays the original response for a repeated key without re-executing', async () => {
+    const first = await makeRequest(app)
+      .post('/idempotency-test/slow')
+      .set('Idempotency-Key', 'replay-key')
+      .send({ amount: 100 });
+
+    expect(first.status).toBe(201);
+    expect((first.body as TestResponseBody).executions).toBe(1);
+
+    const second = await makeRequest(app)
+      .post('/idempotency-test/slow')
+      .set('Idempotency-Key', 'replay-key')
+      .send({ amount: 100 });
+
+    expect(second.status).toBe(201);
+    expect(second.body).toEqual(first.body);
+    expect(controller.executions).toBe(1);
+  });
+
+  it('rejects reusing a key with a different body', async () => {
+    await makeRequest(app)
+      .post('/idempotency-test/slow')
+      .set('Idempotency-Key', 'mismatch-key')
+      .send({ amount: 100 })
+      .expect(201);
+
+    const response = await makeRequest(app)
+      .post('/idempotency-test/slow')
+      .set('Idempotency-Key', 'mismatch-key')
+      .send({ amount: 200 });
+
+    expect(response.status).toBe(422);
+  });
+
+  it('serialises concurrent requests with the same key so only one executes', async () => {
+    const [first, second] = await Promise.all([
+      makeRequest(app)
+        .post('/idempotency-test/slow')
+        .set('Idempotency-Key', 'concurrent-key')
+        .send({ amount: 100 }),
+      makeRequest(app)
+        .post('/idempotency-test/slow')
+        .set('Idempotency-Key', 'concurrent-key')
+        .send({ amount: 100 }),
+    ]);
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    expect(first.body).toEqual(second.body);
+    expect(controller.executions).toBe(1);
+  });
+
+  it('does not replay a key whose retention window has expired', async () => {
+    await makeRequest(app)
+      .post('/idempotency-test/expiring')
+      .set('Idempotency-Key', 'expiring-key')
+      .send({ amount: 100 })
+      .expect(201);
+
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    const response = await makeRequest(app)
+      .post('/idempotency-test/expiring')
+      .set('Idempotency-Key', 'expiring-key')
+      .send({ amount: 100 });
+
+    expect(response.status).toBe(201);
+    expect((response.body as TestResponseBody).executions).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #1199

Adds DB-backed idempotency to write endpoints.

## What changed
- New \IdempotencyInterceptor\ (registered globally) accepts an \Idempotency-Key\ header on write methods, persists the request + response, and replays it for a repeated key within the retention window.
- New \idempotency\ module: entity, service, module, and scheduler.
  - Concurrency: a unique (key, method, route) index plus in-progress claims serialize concurrent requests so only one executes; the others wait and receive the same response.
  - Reclaim: a crashed worker's claim is reclaimed after its lease expires; a completed key whose retention window lapsed is not replayed.
  - Expiry: expired records are purged by a scheduled job (default daily 03:00 UTC, configurable via \IDEMPOTENCY_CLEANUP_CRON\).
- Migration \1831000000000-CreateIdempotencyRecords\.
- Config: \IDEMPOTENCY_RETENTION_MS\ (24h), \IDEMPOTENCY_LEASE_MS\ (60s), \IDEMPOTENCY_CONCURRENCY_TIMEOUT_MS\ (30s), \IDEMPOTENCY_CLEANUP_CRON\.
- Tests:
  - Unit: interceptor (replay, hash-mismatch, in-progress wait, failure release) and service (acquire/reclaim/race/cleanup).
  - Integration (e2e): replay, hash mismatch, concurrent serialization, and expiry.

## Verification
- \
pm run lint\ passes (0 errors).
- \
pm run test\: 73 suites / 597 tests pass.
- \
pm run build\ passes.
- \
pm run test:e2e -- idempotency\ passes against a real Postgres (4/4).