### PR TITLE
feat(security): add multi-key API support with scoped permissions

### DIFF
--- a/apps/data-processing/src/security.py
+++ b/apps/data-processing/src/security.py
@@ -5,6 +5,8 @@ Includes admin token verification for KPI recompute endpoints.
 
 import os
 import re
+import json
+import hmac
 from typing import Optional, Callable, Dict, Any
 from functools import wraps
 from fastapi import Request, HTTPException, status, Header
@@ -27,7 +29,25 @@ class SecurityConfig:
     """Security configuration manager."""
     
     def __init__(self):
-        self.api_key = os.getenv("API_KEY", "")
+        # Load API keys configuration (JSON list)
+        # Expected format: [{"id": "key1", "value": "abcd", "scopes": ["default"]}, ...]
+        api_keys_json = os.getenv("API_KEYS", "[]")
+        try:
+            api_keys_list = json.loads(api_keys_json)
+        except json.JSONDecodeError:
+            raise ValueError("API_KEYS environment variable must be valid JSON")
+        # Map key value to (id, scopes) for lookup
+        self.api_keys: Dict[str, Dict[str, Any]] = {}
+        for entry in api_keys_list:
+            # Validate entry fields
+            if not all(k in entry for k in ("id", "value", "scopes")):
+                raise ValueError("Each API_KEYS entry must contain 'id', 'value', and 'scopes'")
+            self.api_keys[entry["value"]] = {"id": entry["id"], "scopes": entry["scopes"]}
+        # Backward compatibility: if no API_KEYS provided, fall back to single API_KEY
+        if not self.api_keys:
+            single_key = os.getenv("API_KEY", "")
+            if single_key:
+                self.api_keys[single_key] = {"id": "default", "scopes": ["default"]}
         self.rate_limit_enabled = os.getenv("RATE_LIMIT_ENABLED", "true").lower() == "true"
         self.rate_limit_default = os.getenv("RATE_LIMIT_DEFAULT", "100/minute")
         self.rate_limit_strict = os.getenv("RATE_LIMIT_STRICT", "10/minute")
@@ -75,28 +95,40 @@ class SecurityConfig:
         Raises:
             HTTPException: If API key is missing or invalid
         """
-        if not self.api_key:
+        # Ensure API keys are configured
+        if not self.api_keys:
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="API is not configured: API_KEY environment variable is missing.",
+                detail="API is not configured: no API_KEYS or API_KEY provided.",
             )
 
         api_key_header = request.headers.get("X-API-Key")
-        
+
         if not api_key_header:
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Missing API key. Please provide X-API-Key header.",
                 headers={"WWW-Authenticate": "ApiKey"},
             )
-        
-        if api_key_header != self.api_key:
+
+        # Constant‑time comparison against stored keys
+        matched = None
+        for stored_key, info in self.api_keys.items():
+            if hmac.compare_digest(api_key_header, stored_key):
+                matched = info
+                break
+        if not matched:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Invalid API key",
                 headers={"WWW-Authenticate": "ApiKey"},
             )
-        
+
+        # Log usage by identifier (never log the raw key)
+        logger.info(f"API key {matched['id']} used for {request.url.path}")
+        # Attach key info to request state for downstream checks
+        request.state.api_key_id = matched['id']
+        request.state.api_key_scopes = matched.get('scopes', [])
         return True
     
     def verify_admin_token(self, authorization: Optional[str] = None) -> bool:
@@ -253,6 +285,14 @@ def require_admin_token(func: Callable) -> Callable:
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Admin access required. Please provide valid admin token.",
                 headers={"WWW-Authenticate": "Bearer"},
+            )
+        # Additionally, ensure the API key used has admin scope
+        if "admin" not in getattr(request.state, "api_key_scopes", []):
+            logger.warning(f"Admin route accessed without admin-scoped API key: {request.url.path}")
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="API key does not have admin scope.",
+                headers={"WWW-Authenticate": "ApiKey"},
             )
         
         return await func(request, *args, **kwargs)

--- a/apps/data-processing/src/security.py
+++ b/apps/data-processing/src/security.py
@@ -43,11 +43,23 @@ class SecurityConfig:
             if not all(k in entry for k in ("id", "value", "scopes")):
                 raise ValueError("Each API_KEYS entry must contain 'id', 'value', and 'scopes'")
             self.api_keys[entry["value"]] = {"id": entry["id"], "scopes": entry["scopes"]}
-        # Backward compatibility: if no API_KEYS provided, fall back to single API_KEY
+        # Backward compatibility: expose a single api_key attribute for older code/tests
+        # Initialize attribute so monkeypatch.setattr(...) won't raise AttributeError
+        self.api_key: str = ""
+
+        # If API_KEYS JSON produced no entries, fall back to single API_KEY env var
         if not self.api_keys:
             single_key = os.getenv("API_KEY", "")
             if single_key:
+                # keep the unified api_keys mapping for runtime checks...
                 self.api_keys[single_key] = {"id": "default", "scopes": ["default"]}
+                # ...and also expose the legacy attribute for tests and old callers
+                self.api_key = single_key
+        else:
+            # If exactly one API key is configured, expose it on the legacy attribute as well
+            if len(self.api_keys) == 1:
+                # store the first key string (the actual key value)
+                self.api_key = next(iter(self.api_keys))
         self.rate_limit_enabled = os.getenv("RATE_LIMIT_ENABLED", "true").lower() == "true"
         self.rate_limit_default = os.getenv("RATE_LIMIT_DEFAULT", "100/minute")
         self.rate_limit_strict = os.getenv("RATE_LIMIT_STRICT", "10/minute")
@@ -96,7 +108,7 @@ class SecurityConfig:
             HTTPException: If API key is missing or invalid
         """
         # Ensure API keys are configured
-        if not self.api_keys:
+        if not self.api_keys and not getattr(self, "api_key", ""):
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="API is not configured: no API_KEYS or API_KEY provided.",
@@ -117,6 +129,14 @@ class SecurityConfig:
             if hmac.compare_digest(api_key_header, stored_key):
                 matched = info
                 break
+
+        # Backward-compatibility: some tests/legacy code patch `security_config.api_key` directly.
+        # If no mapping matched, compare against legacy single api_key attribute if present.
+        if not matched:
+            legacy_key = getattr(self, "api_key", "")
+            if legacy_key and hmac.compare_digest(api_key_header, legacy_key):
+                matched = {"id": "default", "scopes": ["default"]}
+
         if not matched:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,


### PR DESCRIPTION
Closes #1246 

## Summary

Implemented **multi‑key API support** with scoped permissions:

* **Multiple keys** can now be configured via an `API_KEYS` JSON environment variable (fallback to the original `API_KEY` for compatibility).
* Each key carries an **identifier** and a list of **scopes** (e.g., `default`, `admin`).
* Validation uses **constant‑time comparison** (`hmac.compare_digest`) to mitigate timing attacks.
* Successful authentication is **logged by identifier** only – the raw key value is never written to logs.
* The **admin decorator** now checks that the API key used for admin routes includes the `admin` scope, in addition to the existing admin token/JWT verification.
* Updated imports to include `json` and `hmac`; added necessary request‑state fields (`api_key_id`, `api_key_scopes`).

These changes enable safe key rotation without downtime and enforce stricter access control for admin endpoints.

## Linked Issue

Closes #1246 

## Type of Change

- [x] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] chore

## Validation

- [ ] Lint passed for affected area(s)
- [ ] Tests passed for affected area(s)
- [ ] Manual verification completed (if applicable)

## Documentation

- [ ] Documentation updated (or N/A with explanation)
- [ ] Screenshots/videos attached for UI changes

## Checklist

- [x] Branch name uses `feat/`, `fix/`, or `docs/`
- [ ] Commit messages follow Conventional Commits
- [x] PR scope matches linked issue acceptance criteria