### PR TITLE
fix(backend): unify data-processing service URL configuration (#1197)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -113,8 +113,10 @@ JWT_EXPIRES_IN=7d
 DOMAIN=lumenpulse.io
 
 # Python/data-processing integrations
+# Port 8000 is the default FastAPI server port (apps/data-processing/src/api/server.py).
+# In development/test environments this defaults to http://localhost:8000.
+# In non-development environments (staging, production), PYTHON_API_URL must be explicitly configured.
 PYTHON_API_URL=http://localhost:8000
-PYTHON_SERVICE_URL=http://localhost:8000
 PYTHON_API_KEY=python-api-key-here
 COINDESK_API_KEY=coindesk-api-key-here
 

--- a/apps/backend/src/lib/config.spec.ts
+++ b/apps/backend/src/lib/config.spec.ts
@@ -22,6 +22,7 @@ const MANAGED_KEYS = [
   'ENVIRONMENT',
   'CACHE_TTL_MS',
   'CORS_ORIGIN',
+  'PYTHON_API_URL',
 ] as const;
 
 const resetManagedEnv = (values: Record<string, string | undefined>) => {
@@ -233,6 +234,7 @@ describe('environment-specific loading', () => {
       NODE_ENV: 'production',
       ENVIRONMENT: 'production',
       CORS_ORIGIN: 'https://app.lumenpulse.io',
+      PYTHON_API_URL: 'https://data-processing.lumenpulse.io',
     });
 
     process.chdir(tempDir);
@@ -258,5 +260,87 @@ describe('environment-specific loading', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       'WARNING: NODE_ENV/ENVIRONMENT not set. Defaulting to development.',
     );
+  });
+});
+
+describe('PYTHON_API_URL environment validation', () => {
+  const originalCwd = process.cwd();
+  let infoSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => undefined);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    process.chdir(originalCwd);
+  });
+
+  afterEach(() => {
+    infoSpy.mockRestore();
+    warnSpy.mockRestore();
+    process.chdir(originalCwd);
+  });
+
+  it('defaults to http://localhost:8000 in development when omitted', async () => {
+    resetManagedEnv({
+      ...REQUIRED_ENV,
+      NODE_ENV: 'development',
+      ENVIRONMENT: 'development',
+      PYTHON_API_URL: undefined,
+    });
+
+    const { config } = await importFreshConfigModule();
+    expect(config.python.apiUrl).toBe('http://localhost:8000');
+  });
+
+  it('defaults to http://localhost:8000 in test environment when omitted', async () => {
+    resetManagedEnv({
+      ...REQUIRED_ENV,
+      NODE_ENV: 'test',
+      ENVIRONMENT: 'test',
+      PYTHON_API_URL: undefined,
+    });
+
+    const { config } = await importFreshConfigModule();
+    expect(config.python.apiUrl).toBe('http://localhost:8000');
+  });
+
+  it('throws in production when PYTHON_API_URL is missing', async () => {
+    resetManagedEnv({
+      ...REQUIRED_ENV,
+      NODE_ENV: 'production',
+      ENVIRONMENT: 'production',
+      CORS_ORIGIN: 'https://app.lumenpulse.io',
+      PYTHON_API_URL: undefined,
+    });
+
+    await expect(importFreshConfigModule()).rejects.toThrow(
+      /PYTHON_API_URL must be set in non-development environments/i,
+    );
+  });
+
+  it('throws in staging when PYTHON_API_URL is missing', async () => {
+    resetManagedEnv({
+      ...REQUIRED_ENV,
+      NODE_ENV: 'staging',
+      ENVIRONMENT: 'staging',
+      PYTHON_API_URL: undefined,
+    });
+
+    await expect(importFreshConfigModule()).rejects.toThrow(
+      /PYTHON_API_URL must be set in non-development environments/i,
+    );
+  });
+
+  it('accepts custom PYTHON_API_URL in production when provided', async () => {
+    resetManagedEnv({
+      ...REQUIRED_ENV,
+      NODE_ENV: 'production',
+      ENVIRONMENT: 'production',
+      CORS_ORIGIN: 'https://app.lumenpulse.io',
+      PYTHON_API_URL: 'https://data-processing.lumenpulse.io',
+    });
+
+    const { config } = await importFreshConfigModule();
+    expect(config.python.apiUrl).toBe('https://data-processing.lumenpulse.io');
   });
 });

--- a/apps/backend/src/lib/config.ts
+++ b/apps/backend/src/lib/config.ts
@@ -29,7 +29,6 @@ import { z } from 'zod';
  * - CACHE_TTL_MS
  * - COINDESK_API_KEY
  * - PYTHON_API_URL
- * - PYTHON_SERVICE_URL
  * - PYTHON_API_KEY
  * - DOMAIN
  * - JWT_EXPIRES_IN
@@ -460,8 +459,7 @@ const envSchema = z
     STELLAR_CONTRACT_TREASURY: z.string().trim().optional(),
     STELLAR_CONTRACT_VESTING_WALLET: z.string().trim().optional(),
 
-    PYTHON_API_URL: z.string().trim().default('http://localhost:8000'),
-    PYTHON_SERVICE_URL: z.string().trim().optional(),
+    PYTHON_API_URL: z.string().trim().optional(),
     PYTHON_API_KEY: z.string().trim().optional(),
 
     COINDESK_API_KEY: z.string().trim().optional(),
@@ -565,6 +563,18 @@ const envSchema = z
         path: ['CORS_ORIGIN'],
       });
     }
+
+    if (
+      values.NODE_ENV !== 'development' &&
+      values.NODE_ENV !== 'test' &&
+      !values.PYTHON_API_URL
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'PYTHON_API_URL must be set in non-development environments.',
+        path: ['PYTHON_API_URL'],
+      });
+    }
   });
 
 const rawEnvironment = {
@@ -592,6 +602,9 @@ if (!parseResult.success) {
 }
 
 const parsedEnv = parseResult.data;
+const pythonApiUrl = parsedEnv.PYTHON_API_URL || 'http://localhost:8000';
+process.env.PYTHON_API_URL = pythonApiUrl;
+
 const rateLimitDefaults =
   RATE_LIMIT_DEFAULTS[getRateLimitEnvironment(parsedEnv.NODE_ENV)];
 
@@ -920,11 +933,7 @@ const optionalSummary = [
     'STELLAR_CONTRACT_VESTING_WALLET',
     parsedEnv.STELLAR_CONTRACT_VESTING_WALLET ?? '(not set)',
   ],
-  ['PYTHON_API_URL', parsedEnv.PYTHON_API_URL],
-  [
-    'PYTHON_SERVICE_URL',
-    parsedEnv.PYTHON_SERVICE_URL ?? '(defaults to PYTHON_API_URL)',
-  ],
+  ['PYTHON_API_URL', pythonApiUrl],
   ['PYTHON_API_KEY', parsedEnv.PYTHON_API_KEY ? '[REDACTED]' : '(not set)'],
   ['COINDESK_API_KEY', parsedEnv.COINDESK_API_KEY ? '[REDACTED]' : '(not set)'],
   ['JWT_EXPIRES_IN', parsedEnv.JWT_EXPIRES_IN],
@@ -1119,8 +1128,7 @@ export const config = Object.freeze({
     domain: parsedEnv.DOMAIN,
   }),
   python: Object.freeze({
-    apiUrl: parsedEnv.PYTHON_API_URL,
-    serviceUrl: parsedEnv.PYTHON_SERVICE_URL || parsedEnv.PYTHON_API_URL,
+    apiUrl: pythonApiUrl,
     apiKey: parsedEnv.PYTHON_API_KEY,
   }),
   apiKeys: Object.freeze({

--- a/apps/backend/src/model-retraining/model-retraining.service.spec.ts
+++ b/apps/backend/src/model-retraining/model-retraining.service.spec.ts
@@ -1,0 +1,96 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { of, throwError } from 'rxjs';
+import { AxiosError } from 'axios';
+import {
+  ModelRetrainingService,
+  RetrainResult,
+  ModelStatusResult,
+} from './model-retraining.service';
+
+describe('ModelRetrainingService', () => {
+  let service: ModelRetrainingService;
+  let httpService: jest.Mocked<Pick<HttpService, 'post' | 'get'>>;
+  let configService: jest.Mocked<Pick<ConfigService, 'get'>>;
+
+  beforeEach(async () => {
+    httpService = {
+      post: jest.fn(),
+      get: jest.fn(),
+    } as unknown as jest.Mocked<Pick<HttpService, 'post' | 'get'>>;
+
+    configService = {
+      get: jest.fn((key: string) => {
+        if (key === 'PYTHON_API_URL') return 'http://localhost:8000';
+        if (key === 'PYTHON_API_KEY') return 'test-key';
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<Pick<ConfigService, 'get'>>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ModelRetrainingService,
+        { provide: HttpService, useValue: httpService },
+        { provide: ConfigService, useValue: configService },
+      ],
+    }).compile();
+
+    service = module.get<ModelRetrainingService>(ModelRetrainingService);
+  });
+
+  describe('triggerRetraining', () => {
+    it('calls python /retrain with correct URL and headers', async () => {
+      const mockResult: RetrainResult = {
+        status: 'completed',
+        duration_seconds: 12.5,
+        models: { sentiment: 'v1.1' },
+      };
+
+      (httpService.post as jest.Mock).mockReturnValue(of({ data: mockResult }));
+
+      const result = await service.triggerRetraining(true);
+
+      expect(result).toEqual(mockResult);
+      expect(httpService.post).toHaveBeenCalledWith(
+        'http://localhost:8000/retrain',
+        { force: true },
+        {
+          headers: { 'X-API-Key': 'test-key' },
+          timeout: 300_000,
+        },
+      );
+    });
+
+    it('propagates error when request fails', async () => {
+      const error = new AxiosError('Network Error');
+      (httpService.post as jest.Mock).mockReturnValue(throwError(() => error));
+
+      await expect(service.triggerRetraining()).rejects.toThrow(
+        'Network Error',
+      );
+    });
+  });
+
+  describe('getModelStatus', () => {
+    it('calls python /model/status with correct URL and headers', async () => {
+      const mockStatus: ModelStatusResult = {
+        last_run: { status: 'success' },
+        registry: { active_version: 'v1.0' },
+      };
+
+      (httpService.get as jest.Mock).mockReturnValue(of({ data: mockStatus }));
+
+      const result = await service.getModelStatus();
+
+      expect(result).toEqual(mockStatus);
+      expect(httpService.get).toHaveBeenCalledWith(
+        'http://localhost:8000/model/status',
+        {
+          headers: { 'X-API-Key': 'test-key' },
+          timeout: 10_000,
+        },
+      );
+    });
+  });
+});

--- a/apps/backend/src/model-retraining/model-retraining.service.ts
+++ b/apps/backend/src/model-retraining/model-retraining.service.ts
@@ -3,6 +3,7 @@ import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
 import { firstValueFrom } from 'rxjs';
 import { AxiosError } from 'axios';
+import { config } from '../lib/config';
 
 export interface RetrainResult {
   status: string;
@@ -29,11 +30,12 @@ export class ModelRetrainingService {
     private readonly httpService: HttpService,
     private readonly configService: ConfigService,
   ) {
-    this.pythonApiUrl = this.configService.get<string>(
-      'PYTHON_API_URL',
-      'http://localhost:8000',
-    );
-    this.apiKey = this.configService.get<string>('PYTHON_API_KEY', '');
+    this.pythonApiUrl =
+      this.configService.get<string>('PYTHON_API_URL') || config.python.apiUrl;
+    this.apiKey =
+      this.configService.get<string>('PYTHON_API_KEY') ||
+      config.python.apiKey ||
+      '';
   }
 
   private get headers() {

--- a/apps/backend/src/news/news-sentiment.services.ts
+++ b/apps/backend/src/news/news-sentiment.services.ts
@@ -7,6 +7,7 @@ import { NewsService } from './news.service';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { JobLockService } from '../scheduler/job-lock.service';
 import { JobHistoryService } from '../scheduler/job-history.service';
+import { config } from '../lib/config';
 
 const SENTIMENT_JOB_NAME = 'news-sentiment-update';
 
@@ -28,7 +29,9 @@ export class NewsSentimentService {
 
   async analyzeSentiment(text: string): Promise<number | null> {
     try {
-      const baseUrl = this.configService.get<string>('PYTHON_SERVICE_URL');
+      const baseUrl =
+        this.configService.get<string>('PYTHON_API_URL') ||
+        config.python.apiUrl;
       const response = await firstValueFrom<
         AxiosResponse<SentimentApiResponse>
       >(

--- a/apps/backend/src/read-model-rebuild/read-model-rebuild.service.spec.ts
+++ b/apps/backend/src/read-model-rebuild/read-model-rebuild.service.spec.ts
@@ -1,0 +1,132 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { of } from 'rxjs';
+import { ReadModelRebuildService } from './read-model-rebuild.service';
+import {
+  ReadModelRebuildJob,
+  RebuildStatus,
+  RebuildDataset,
+} from './entities/read-model-rebuild-job.entity';
+import { JobLockService } from '../scheduler/job-lock.service';
+import { JobHistoryService } from '../scheduler/job-history.service';
+import { AdminAuditService } from '../admin-audit/admin-audit.service';
+
+describe('ReadModelRebuildService', () => {
+  let service: ReadModelRebuildService;
+  let httpService: jest.Mocked<Pick<HttpService, 'post'>>;
+  let configService: jest.Mocked<Pick<ConfigService, 'get'>>;
+  let jobRepo: {
+    save: jest.Mock;
+    findOne: jest.Mock;
+    find: jest.Mock;
+    delete: jest.Mock;
+    create: jest.Mock;
+  };
+  let jobLockService: {
+    tryAcquire: jest.Mock;
+    release: jest.Mock;
+  };
+  let jobHistoryService: {
+    start: jest.Mock;
+    complete: jest.Mock;
+    fail: jest.Mock;
+  };
+  let adminAuditService: {
+    create: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    httpService = {
+      post: jest.fn(),
+    } as unknown as jest.Mocked<Pick<HttpService, 'post'>>;
+
+    configService = {
+      get: jest.fn((key: string) => {
+        if (key === 'PYTHON_API_URL') return 'http://localhost:8000';
+        if (key === 'PYTHON_API_KEY') return 'test-key';
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<Pick<ConfigService, 'get'>>;
+
+    jobRepo = {
+      save: jest
+        .fn()
+        .mockImplementation((job: ReadModelRebuildJob) => Promise.resolve(job)),
+      findOne: jest.fn(),
+      find: jest.fn(),
+      delete: jest.fn(),
+      create: jest
+        .fn()
+        .mockImplementation(
+          (job: Partial<ReadModelRebuildJob>): ReadModelRebuildJob =>
+            job as ReadModelRebuildJob,
+        ),
+    };
+
+    jobLockService = {
+      tryAcquire: jest.fn().mockResolvedValue(true),
+      release: jest.fn().mockResolvedValue(undefined),
+    };
+
+    jobHistoryService = {
+      start: jest.fn().mockResolvedValue({ id: 'hist-1' }),
+      complete: jest.fn().mockResolvedValue(undefined),
+      fail: jest.fn().mockResolvedValue(undefined),
+    };
+
+    adminAuditService = {
+      create: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ReadModelRebuildService,
+        {
+          provide: getRepositoryToken(ReadModelRebuildJob),
+          useValue: jobRepo,
+        },
+        { provide: HttpService, useValue: httpService },
+        { provide: ConfigService, useValue: configService },
+        { provide: JobLockService, useValue: jobLockService },
+        { provide: JobHistoryService, useValue: jobHistoryService },
+        { provide: AdminAuditService, useValue: adminAuditService },
+      ],
+    }).compile();
+
+    service = module.get<ReadModelRebuildService>(ReadModelRebuildService);
+  });
+
+  it('uses configured PYTHON_API_URL and PYTHON_API_KEY for rebuild requests', async () => {
+    const job = new ReadModelRebuildJob();
+    job.id = 'job-123';
+    job.dataset = RebuildDataset.KPI_SNAPSHOTS;
+    job.status = RebuildStatus.PENDING;
+
+    (httpService.post as jest.Mock).mockReturnValue(
+      of({
+        data: {
+          totalItems: 10,
+          processedItems: 10,
+          failedItems: 0,
+        },
+      }),
+    );
+
+    await (service as any).executeRebuild(job, 'user-1');
+
+    expect(httpService.post).toHaveBeenCalledWith(
+      'http://localhost:8000/api/rebuild/kpi-snapshots',
+      { dataset: RebuildDataset.KPI_SNAPSHOTS, force: true },
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-API-Key': 'test-key',
+          'X-Correlation-ID': 'rebuild-job-123',
+        }),
+      }),
+    );
+    expect(job.status).toBe(RebuildStatus.COMPLETED);
+    expect(job.processedItems).toBe(10);
+  });
+});

--- a/apps/backend/src/read-model-rebuild/read-model-rebuild.service.ts
+++ b/apps/backend/src/read-model-rebuild/read-model-rebuild.service.ts
@@ -23,6 +23,8 @@ import {
 import { JobLockService } from '../scheduler/job-lock.service';
 import { JobHistoryService } from '../scheduler/job-history.service';
 import { AdminAuditService } from '../admin-audit/admin-audit.service';
+import { ConfigService } from '@nestjs/config';
+import { config } from '../lib/config';
 
 interface RebuildResultResponse {
   totalItems?: number;
@@ -57,6 +59,8 @@ function getErrorDetails(error: unknown): ErrorDetails {
 export class ReadModelRebuildService {
   private readonly logger = new Logger(ReadModelRebuildService.name);
   private readonly REBUILD_VERSION = '1.0.0';
+  private readonly pythonApiUrl: string;
+  private readonly pythonApiKey: string;
 
   // Mapping of datasets to their data-processing endpoints
   private readonly datasetEndpoints: Record<RebuildDataset, string> = {
@@ -74,7 +78,15 @@ export class ReadModelRebuildService {
     private readonly jobLockService: JobLockService,
     private readonly jobHistoryService: JobHistoryService,
     private readonly adminAuditService: AdminAuditService,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.pythonApiUrl =
+      this.configService.get<string>('PYTHON_API_URL') || config.python.apiUrl;
+    this.pythonApiKey =
+      this.configService.get<string>('PYTHON_API_KEY') ||
+      config.python.apiKey ||
+      '';
+  }
 
   /**
    * Trigger a rebuild for a specific dataset or contract domain
@@ -233,9 +245,7 @@ export class ReadModelRebuildService {
       }
 
       // Call data-processing service
-      const dataProcessingUrl =
-        process.env.DATA_PROCESSING_URL || 'http://localhost:8001';
-      const url = `${dataProcessingUrl}${endpoint}`;
+      const url = `${this.pythonApiUrl}${endpoint}`;
 
       // Update progress
       job.progressDetails = {
@@ -250,7 +260,7 @@ export class ReadModelRebuildService {
       const response = await firstValueFrom(
         this.httpService.post<RebuildResultResponse>(url, payload, {
           headers: {
-            'X-API-Key': process.env.DATA_PROCESSING_API_KEY || '',
+            ...(this.pythonApiKey ? { 'X-API-Key': this.pythonApiKey } : {}),
             'X-Correlation-ID': `rebuild-${job.id}`,
           },
           timeout: 300000, // 5 minutes

--- a/apps/backend/src/sentiment/sentiment.service.ts
+++ b/apps/backend/src/sentiment/sentiment.service.ts
@@ -3,6 +3,7 @@ import { HttpService } from '@nestjs/axios';
 import { firstValueFrom } from 'rxjs';
 import { ConfigService } from '@nestjs/config';
 import { AxiosError } from 'axios';
+import { config } from '../lib/config';
 
 export interface SentimentRequest {
   text: string;
@@ -70,11 +71,9 @@ export class SentimentService {
     private readonly httpService: HttpService,
     private readonly configService: ConfigService,
   ) {
-    // Get Python API URL from environment or use default
-    this.pythonApiUrl = this.configService.get<string>(
-      'PYTHON_API_URL',
-      'http://localhost:8000',
-    );
+    // Get Python API URL from environment or configuration
+    this.pythonApiUrl =
+      this.configService.get<string>('PYTHON_API_URL') || config.python.apiUrl;
     this.logger.log(`Python API URL: ${this.pythonApiUrl}`);
   }
 

--- a/document/DATA_PROCESSING_CONFIG_MIGRATION.md
+++ b/document/DATA_PROCESSING_CONFIG_MIGRATION.md
@@ -1,0 +1,47 @@
+# Data-Processing Service Configuration Migration Guide
+
+## Overview
+As of Issue #1197, backend configuration for the Python data-processing service has been unified across the entire codebase.
+
+Previously, different modules addressed the service using disjointed environment variables and inconsistent defaults:
+- `PYTHON_API_URL` (defaulted to `http://localhost:8000`)
+- `PYTHON_SERVICE_URL` (optional, fell back to `PYTHON_API_URL`)
+- `DATA_PROCESSING_URL` (defaulted to `http://localhost:8001`)
+- `DATA_PROCESSING_API_KEY` (unvalidated raw env read)
+
+This caused silent integration failures and configuration drift in environments where different ports or hostnames were configured.
+
+---
+
+## Canonical Configuration Variables
+
+The backend now uses a single, validated set of variables:
+
+| Variable | Description | Development Default | Staging / Production |
+| :--- | :--- | :--- | :--- |
+| `PYTHON_API_URL` | Base URL for the Python data-processing FastAPI service | `http://localhost:8000` | **Required** (Startup will fail if missing) |
+| `PYTHON_API_KEY` | Optional API key for authenticating requests via `X-API-Key` | `None` / `local-dev-key` | Optional / As configured |
+
+### Default Port Confirmation
+The default port is confirmed as **`8000`**, matching the FastAPI server definition in `apps/data-processing/src/api/server.py` (`uvicorn.run(..., port=8000)`).
+
+---
+
+## Removed Variables (Migration Actions)
+
+If your existing staging or production deployment configurations use any of the removed variables below, please update them:
+
+| Removed Variable | Replacement | Action |
+| :--- | :--- | :--- |
+| `DATA_PROCESSING_URL` | `PYTHON_API_URL` | Rename in environment / deployment manifests / secrets managers. |
+| `PYTHON_SERVICE_URL` | `PYTHON_API_URL` | Rename in environment / deployment manifests / secrets managers. |
+| `DATA_PROCESSING_API_KEY` | `PYTHON_API_KEY` | Rename in environment / deployment manifests / secrets managers. |
+
+---
+
+## Fail-Fast Boot Behavior
+
+In non-development environments (`NODE_ENV=production` or `NODE_ENV=staging`):
+- If `PYTHON_API_URL` is omitted or empty, backend startup will immediately fail with the error:
+  `Configuration validation failed. Fix the following variables: PYTHON_API_URL: PYTHON_API_URL must be set in non-development environments.`
+- In local development (`NODE_ENV=development`) or test environments (`NODE_ENV=test`), `PYTHON_API_URL` automatically defaults to `http://localhost:8000`.

--- a/document/LOCAL_SETUP.md
+++ b/document/LOCAL_SETUP.md
@@ -184,7 +184,6 @@ REDIS_URL=redis://localhost:6379
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 PYTHON_API_URL=http://localhost:8000
-PYTHON_SERVICE_URL=http://localhost:8000
 PYTHON_API_KEY=local-dev-key
 USE_MOCK_TRANSACTIONS=true
 CORS_ORIGIN=http://localhost:3000,http://localhost:3001,http://localhost:8081


### PR DESCRIPTION
## Overview
Unifies the data-processing service URL configuration across the backend into a single validated key (`PYTHON_API_URL`), removing redundant variables (`PYTHON_SERVICE_URL`, `DATA_PROCESSING_URL`), removing hardcoded fallback URLs in services, enforcing fail-fast startup in non-development environments, and providing a migration guide.

## Related Issue
Closes #1197

## Changes
### Backend Configuration & Services
* **[MODIFY]** `apps/backend/src/lib/config.ts`
  * Removed redundant `PYTHON_SERVICE_URL` variable.
  * Added non-development validation to ensure `PYTHON_API_URL` is configured in production and staging.
  * Defaulted `PYTHON_API_URL` to `http://localhost:8000` in development and test environments.
  * Synchronized `process.env.PYTHON_API_URL` and exposed `config.python.apiUrl` / `config.python.apiKey`.
* **[MODIFY]** `apps/backend/src/read-model-rebuild/read-model-rebuild.service.ts`
  * Injected `ConfigService` and replaced `process.env.DATA_PROCESSING_URL` and `DATA_PROCESSING_API_KEY` with `PYTHON_API_URL` and `PYTHON_API_KEY`.
* **[MODIFY]** `apps/backend/src/model-retraining/model-retraining.service.ts`
  * Removed hardcoded `'http://localhost:8000'` fallback and consolidated on `PYTHON_API_URL` / `PYTHON_API_KEY`.
* **[MODIFY]** `apps/backend/src/sentiment/sentiment.service.ts`
  * Removed hardcoded fallback URL and consolidated on `PYTHON_API_URL`.
* **[MODIFY]** `apps/backend/src/news/news-sentiment.services.ts`
  * Replaced `PYTHON_SERVICE_URL` with `PYTHON_API_URL`.

### Documentation & Environment Templates
* **[MODIFY]** `apps/backend/.env.example`
  * Documented `PYTHON_API_URL=http://localhost:8000` and removed `PYTHON_SERVICE_URL`.
* **[MODIFY]** `document/LOCAL_SETUP.md`
  * Removed `PYTHON_SERVICE_URL` from local setup documentation.
* **[ADD]** `document/DATA_PROCESSING_CONFIG_MIGRATION.md`
  * Added migration notes detailing the consolidated variable `PYTHON_API_URL`, default port 8000 confirmation, fail-fast behavior, and removed variables (`DATA_PROCESSING_URL`, `PYTHON_SERVICE_URL`, `DATA_PROCESSING_API_KEY`).

### Tests
* **[MODIFY]** `apps/backend/src/lib/config.spec.ts`
  * Added unit tests verifying development/test default behavior and fail-fast startup errors in staging/production when `PYTHON_API_URL` is omitted.
* **[ADD]** `apps/backend/src/model-retraining/model-retraining.service.spec.ts`
  * Added unit tests verifying `ModelRetrainingService` integration with configured URL and API key.
* **[ADD]** `apps/backend/src/read-model-rebuild/read-model-rebuild.service.spec.ts`
  * Added unit tests verifying `ReadModelRebuildService` uses `PYTHON_API_URL` and `PYTHON_API_KEY`.

## Verification Results
```text
Test Suites: 1 skipped, 76 passed, 76 of 77 total
Tests:       19 skipped, 626 passed, 645 total
Snapshots:   2 passed, 2 total
Time:        4.876 s
```

| Acceptance Criteria | Status |
| :--- | :--- |
| Single validated configuration key (`PYTHON_API_URL`) addresses data-processing service | ✅ Verified |
| Redundant variables (`PYTHON_SERVICE_URL`, `DATA_PROCESSING_URL`) and hardcoded URLs removed | ✅ Verified |
| Correct default port (8000) confirmed against `server.py` and documented | ✅ Verified |
| Startup fails with clear message when missing in non-development environments | ✅ Verified |
| Migration note records removed variables | ✅ Verified |