### PR TITLE
Backend: unified health and lock-contention visibility for scheduled jobs

### DIFF
--- a/apps/backend/METRICS_DOCUMENTATION.md
+++ b/apps/backend/METRICS_DOCUMENTATION.md
@@ -64,6 +64,10 @@ Every metric family exported on `/metrics` and its label set is inventoried belo
 | `lumenpulse_reconciliation_drift_total` | Counter | `dataset`, `severity` | ≤ 10 | Fixed dataset(s) × 2 severities (`warning`/`critical`) |
 | `lumenpulse_reconciliation_drift_delta` | Gauge | `dataset`, `severity` | ≤ 10 | Same fixed label set |
 | `lumenpulse_reconciliation_threshold` | Gauge | `dataset`, `severity` | ≤ 10 | Same fixed label set |
+| `lumenpulse_scheduled_job_runs_total` | Counter | `job_name`, `status` | ≤ 30 | Fixed job registry (`src/scheduler/job-registry.ts`) × 3 outcomes (`completed`/`failed`/`skipped`) |
+| `lumenpulse_scheduled_job_duration_seconds` | Histogram | `job_name` | ≤ 10 | Fixed job registry |
+| `lumenpulse_scheduled_job_last_success_timestamp_seconds` | Gauge | `job_name` | ≤ 10 | Fixed job registry |
+| `lumenpulse_scheduled_job_lock_contention_total` | Counter | `job_name` | ≤ 10 | Fixed job registry (only jobs that acquire a `JobLockService` advisory lock ever increment) |
 
 **Dynamic (legacy) helpers** — `getOrCreateGauge`, `getOrCreateCounter`, `getOrCreateHistogram` and the `incrementCounter`/`recordHistogram` shortcuts create metric families at runtime. All current call sites (`cache_hits_total`, `cache_misses_total`, `cache_fetch_duration_ms`, `warm_cache_preload_*`, `projects_*_errors_total`, `wallet_readiness_errors_total`) use **constant names and bounded label values** (e.g. `key_type` ∈ {`account_balance`, `account_operations`, `contract_read`, `stellar_assets`, `news`, `other`}, `route` = fixed registry names). Keep this property when adding new call sites: never pass user-supplied values (wallet addresses, contract IDs, article IDs) as labels.
 

--- a/apps/backend/src/health/contract-health-snapshot.module.ts
+++ b/apps/backend/src/health/contract-health-snapshot.module.ts
@@ -6,6 +6,7 @@ import { ContractHealthSnapshotService } from './contract-health-snapshot.servic
 import { ContractHealthSnapshotScheduler } from './contract-health-snapshot.scheduler';
 import { ContractHealthSnapshotController } from './contract-health-snapshot.controller';
 import { HealthModule } from './health.module';
+import { SchedulerModule } from '../scheduler/scheduler.module';
 
 /**
  * Self-contained module for contract health snapshot persistence.
@@ -27,6 +28,7 @@ import { HealthModule } from './health.module';
     TypeOrmModule.forFeature([ContractHealthSnapshot]),
     // Import HealthModule to access the exported ContractHealthService.
     HealthModule,
+    SchedulerModule,
   ],
   controllers: [ContractHealthSnapshotController],
   providers: [

--- a/apps/backend/src/health/contract-health-snapshot.scheduler.ts
+++ b/apps/backend/src/health/contract-health-snapshot.scheduler.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { ContractHealthSnapshotService } from './contract-health-snapshot.service';
+import { JobHistoryService } from '../scheduler/job-history.service';
 
 const JOB_NAME = 'contract-health-snapshot';
 
@@ -13,8 +14,8 @@ const JOB_NAME = 'contract-health-snapshot';
  *
  * The scheduler deliberately does *not* acquire a DB-level job lock — the
  * snapshot operation is idempotent and quick, so duplicate runs within a
- * window are harmless.  If you integrate with JobLockService/JobHistoryService
- * (as the daily SnapshotScheduler does), import SchedulerModule and add them.
+ * window are harmless. It does record its run history via JobHistoryService
+ * so it still shows up in the unified `/health/jobs` view.
  */
 @Injectable()
 export class ContractHealthSnapshotScheduler {
@@ -22,6 +23,7 @@ export class ContractHealthSnapshotScheduler {
 
   constructor(
     private readonly snapshotService: ContractHealthSnapshotService,
+    private readonly jobHistory: JobHistoryService,
   ) {}
 
   /**
@@ -32,8 +34,15 @@ export class ContractHealthSnapshotScheduler {
   @Cron('0,30 * * * *', { timeZone: 'UTC', name: JOB_NAME })
   async handleScheduledCapture(): Promise<void> {
     this.logger.log('Scheduled contract-health snapshot triggered');
+    const run = await this.jobHistory.start(JOB_NAME);
     try {
       const snapshot = await this.snapshotService.captureSnapshot('scheduler');
+      await this.jobHistory.complete(run, {
+        snapshotId: snapshot.id,
+        overallStatus: snapshot.overallStatus,
+        reachable: snapshot.summary.reachable,
+        total: snapshot.summary.total,
+      });
       this.logger.log(
         `Snapshot ${snapshot.id} persisted — ` +
           `status=${snapshot.overallStatus}, ` +
@@ -41,6 +50,7 @@ export class ContractHealthSnapshotScheduler {
       );
     } catch (err) {
       // Log but do not rethrow — a failed capture must not crash the process.
+      await this.jobHistory.fail(run, err);
       this.logger.error(
         `Scheduled capture failed: ${(err as Error).message}`,
         (err as Error).stack,

--- a/apps/backend/src/health/health.controller.ts
+++ b/apps/backend/src/health/health.controller.ts
@@ -9,6 +9,7 @@ import {
 import type { Response } from 'express';
 import { ContractHealthService } from './contract-health.service';
 import { HealthService } from './health.service';
+import { JobHealthService } from '../scheduler/job-health.service';
 
 @ApiTags('health')
 @Controller()
@@ -16,6 +17,7 @@ export class HealthController {
   constructor(
     private readonly healthService: HealthService,
     private readonly contractHealthService: ContractHealthService,
+    private readonly jobHealthService: JobHealthService,
   ) {}
 
   @Get('health')
@@ -83,5 +85,29 @@ export class HealthController {
     response.status(latencyReport.overallState === 'hard_down' ? 503 : 200);
 
     return latencyReport;
+  }
+
+  @Get('health/jobs')
+  @ApiOperation({
+    summary:
+      'Reports last start/success/failure and staleness for every scheduled job',
+    description:
+      'Surfaces any registered scheduled job that has not succeeded within ' +
+      'its expected interval (see src/scheduler/job-registry.ts). Returns ' +
+      'HTTP 200 when every job is within its expected interval and HTTP 503 ' +
+      'when any job is stale or has never run.',
+  })
+  @ApiOkResponse({
+    description: 'All scheduled jobs have succeeded within their expected interval.',
+  })
+  @ApiServiceUnavailableResponse({
+    description: 'At least one scheduled job is stale or has never succeeded.',
+  })
+  async getJobsHealth(@Res({ passthrough: true }) response: Response) {
+    const report = await this.jobHealthService.getJobsHealthReport();
+
+    response.status(report.status === 'degraded' ? 503 : 200);
+
+    return report;
   }
 }

--- a/apps/backend/src/health/health.module.ts
+++ b/apps/backend/src/health/health.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { TerminusModule } from '@nestjs/terminus';
 import { AppCacheModule } from '../cache/cache.module';
 import { StellarModule } from '../stellar/stellar.module';
+import { SchedulerModule } from '../scheduler/scheduler.module';
 import { ContractHealthService } from './contract-health.service';
 import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
@@ -17,6 +18,7 @@ import { LatencyBudgetHealthService } from './latency-budget.health.service';
     }),
     AppCacheModule,
     StellarModule,
+    SchedulerModule,
   ],
   controllers: [HealthController],
   providers: [HealthService, ContractHealthService, LatencyBudgetHealthService],

--- a/apps/backend/src/idempotency/idempotency.scheduler.ts
+++ b/apps/backend/src/idempotency/idempotency.scheduler.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { IdempotencyService } from './idempotency.service';
 import { JobLockService } from '../scheduler/job-lock.service';
+import { JobHistoryService } from '../scheduler/job-history.service';
 import { config } from '../lib/config';
 
 const JOB_NAME = 'idempotency-cleanup';
@@ -25,18 +26,29 @@ export class IdempotencyScheduler {
   constructor(
     private readonly service: IdempotencyService,
     private readonly jobLock: JobLockService,
+    private readonly jobHistory: JobHistoryService,
   ) {}
 
   @Cron(config.idempotency.cleanupCron, { timeZone: 'UTC', name: JOB_NAME })
   async handleCleanup(): Promise<void> {
     const acquired = await this.jobLock.tryAcquire(JOB_NAME);
-    if (!acquired) return;
+    if (!acquired) {
+      await this.jobHistory.markSkipped(JOB_NAME);
+      return;
+    }
 
+    const run = await this.jobHistory.start(JOB_NAME);
     try {
       const deleted = await this.service.cleanupExpired();
       if (deleted > 0) {
         this.logger.log(`Cleaned up ${deleted} expired idempotency records`);
       }
+      await this.jobHistory.complete(run, { deleted });
+    } catch (err) {
+      await this.jobHistory.fail(run, err);
+      this.logger.error(
+        `Idempotency cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
     } finally {
       await this.jobLock.release(JOB_NAME);
     }

--- a/apps/backend/src/metrics/metrics.service.ts
+++ b/apps/backend/src/metrics/metrics.service.ts
@@ -48,6 +48,12 @@ export class MetricsService implements OnModuleInit {
   private readonly outboxAttempts: Counter<string>;
   private readonly outboxDeadLetterVolume: Gauge<string>;
 
+  // Scheduled job monitoring //
+  private readonly scheduledJobRunsCounter: Counter<string>;
+  private readonly scheduledJobDuration: Histogram<string>;
+  private readonly scheduledJobLastSuccessGauge: Gauge<string>;
+  private readonly scheduledJobLockContentionCounter: Counter<string>;
+
   // Running totals for the rolling-average sentiment gauge
   private sentimentSum = 0;
   private sentimentCount = 0;
@@ -203,6 +209,36 @@ export class MetricsService implements OnModuleInit {
     this.outboxDeadLetterVolume = new Gauge({
       name: 'lumenpulse_outbox_dead_letter_volume',
       help: 'Current number of outbox events in the dead-letter queue',
+      registers: [this.registry],
+    });
+
+    // Scheduled jobs //
+    this.scheduledJobRunsCounter = new Counter({
+      name: 'lumenpulse_scheduled_job_runs_total',
+      help: 'Total scheduled job runs by job name and outcome',
+      labelNames: ['job_name', 'status'] as const,
+      registers: [this.registry],
+    });
+
+    this.scheduledJobDuration = new Histogram({
+      name: 'lumenpulse_scheduled_job_duration_seconds',
+      help: 'Duration of scheduled job runs in seconds',
+      labelNames: ['job_name'] as const,
+      buckets: [0.1, 0.5, 1, 5, 15, 30, 60, 300, 900],
+      registers: [this.registry],
+    });
+
+    this.scheduledJobLastSuccessGauge = new Gauge({
+      name: 'lumenpulse_scheduled_job_last_success_timestamp_seconds',
+      help: 'Unix timestamp of the last successful run of a scheduled job',
+      labelNames: ['job_name'] as const,
+      registers: [this.registry],
+    });
+
+    this.scheduledJobLockContentionCounter = new Counter({
+      name: 'lumenpulse_scheduled_job_lock_contention_total',
+      help: 'Total times a scheduled job could not acquire its distributed lock because another instance held it',
+      labelNames: ['job_name'] as const,
       registers: [this.registry],
     });
   }
@@ -406,6 +442,34 @@ export class MetricsService implements OnModuleInit {
   /** Record the current number of dead-lettered outbox events. */
   setOutboxDeadLetterVolume(volume: number): void {
     this.outboxDeadLetterVolume.set(volume);
+  }
+
+  // Scheduled job instrumentation //
+
+  /**
+   * Record a finished scheduled job run.
+   *
+   * @param jobName      Logical job name, matching the scheduler's JOB_NAME
+   * @param status       "completed" | "failed" | "skipped"
+   * @param durationMs   Wall-clock duration of the run, when known
+   */
+  recordScheduledJobRun(
+    jobName: string,
+    status: 'completed' | 'failed' | 'skipped',
+    durationMs?: number,
+  ): void {
+    this.scheduledJobRunsCounter.inc({ job_name: jobName, status });
+    if (durationMs !== undefined) {
+      this.scheduledJobDuration.labels({ job_name: jobName }).observe(durationMs / 1000);
+    }
+    if (status === 'completed') {
+      this.scheduledJobLastSuccessGauge.set({ job_name: jobName }, Date.now() / 1000);
+    }
+  }
+
+  /** Increment when a scheduled job could not acquire its distributed lock. */
+  recordJobLockContention(jobName: string): void {
+    this.scheduledJobLockContentionCounter.inc({ job_name: jobName });
   }
 
   //Dynamic metric helpers (legacy API)

--- a/apps/backend/src/read-model-rebuild/read-model-rebuild.scheduler.ts
+++ b/apps/backend/src/read-model-rebuild/read-model-rebuild.scheduler.ts
@@ -5,6 +5,11 @@ import { RebuildStatus } from './entities/read-model-rebuild-job.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ReadModelRebuildJob } from './entities/read-model-rebuild-job.entity';
+import { JobLockService } from '../scheduler/job-lock.service';
+import { JobHistoryService } from '../scheduler/job-history.service';
+
+const CLEANUP_JOB_NAME = 'read-model-rebuild-cleanup';
+const STUCK_RECOVERY_JOB_NAME = 'read-model-rebuild-stuck-recovery';
 
 @Injectable()
 export class ReadModelRebuildScheduler {
@@ -14,6 +19,8 @@ export class ReadModelRebuildScheduler {
     private readonly rebuildService: ReadModelRebuildService,
     @InjectRepository(ReadModelRebuildJob)
     private readonly jobRepo: Repository<ReadModelRebuildJob>,
+    private readonly jobLock: JobLockService,
+    private readonly jobHistory: JobHistoryService,
   ) {}
 
   /**
@@ -21,14 +28,25 @@ export class ReadModelRebuildScheduler {
    */
   @Cron(CronExpression.EVERY_DAY_AT_2AM)
   async cleanupOldJobs(): Promise<void> {
+    const acquired = await this.jobLock.tryAcquire(CLEANUP_JOB_NAME);
+    if (!acquired) {
+      await this.jobHistory.markSkipped(CLEANUP_JOB_NAME);
+      return;
+    }
+
     this.logger.log('Running scheduled cleanup of old rebuild jobs...');
+    const run = await this.jobHistory.start(CLEANUP_JOB_NAME);
     try {
       const result = await this.rebuildService.cleanupJobs(30);
+      await this.jobHistory.complete(run, { deleted: result.deleted });
       this.logger.log(`Cleanup completed: ${result.deleted} jobs deleted`);
     } catch (error) {
+      await this.jobHistory.fail(run, error);
       const message = error instanceof Error ? error.message : String(error);
       const stack = error instanceof Error ? error.stack : undefined;
       this.logger.error(`Cleanup failed: ${message}`, stack);
+    } finally {
+      await this.jobLock.release(CLEANUP_JOB_NAME);
     }
   }
 
@@ -37,6 +55,13 @@ export class ReadModelRebuildScheduler {
    */
   @Cron(CronExpression.EVERY_HOUR)
   async recoverStuckJobs(): Promise<void> {
+    const acquired = await this.jobLock.tryAcquire(STUCK_RECOVERY_JOB_NAME);
+    if (!acquired) {
+      await this.jobHistory.markSkipped(STUCK_RECOVERY_JOB_NAME);
+      return;
+    }
+
+    const run = await this.jobHistory.start(STUCK_RECOVERY_JOB_NAME);
     const stuckThreshold = new Date();
     stuckThreshold.setHours(stuckThreshold.getHours() - 2); // 2 hours
 
@@ -49,6 +74,7 @@ export class ReadModelRebuildScheduler {
       });
 
       if (stuckJobs.length === 0) {
+        await this.jobHistory.complete(run, { recovered: 0 });
         return;
       }
 
@@ -68,10 +94,15 @@ export class ReadModelRebuildScheduler {
         await this.jobRepo.save(job);
         this.logger.warn(`Recovered stuck job ${job.id}`);
       }
+
+      await this.jobHistory.complete(run, { recovered: stuckJobs.length });
     } catch (error) {
+      await this.jobHistory.fail(run, error);
       const message = error instanceof Error ? error.message : String(error);
       const stack = error instanceof Error ? error.stack : undefined;
       this.logger.error(`Stuck job recovery failed: ${message}`, stack);
+    } finally {
+      await this.jobLock.release(STUCK_RECOVERY_JOB_NAME);
     }
   }
 

--- a/apps/backend/src/scheduler/job-health.service.spec.ts
+++ b/apps/backend/src/scheduler/job-health.service.spec.ts
@@ -1,0 +1,126 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JobHealthService } from './job-health.service';
+import { JobHistoryService } from './job-history.service';
+import { JobRun, JobRunStatus } from './entities/job-run.entity';
+import { JOB_REGISTRY } from './job-registry';
+
+function makeRun(overrides: Partial<JobRun> = {}): JobRun {
+  return {
+    id: 'run-1',
+    jobName: 'reconciliation',
+    status: JobRunStatus.COMPLETED,
+    triggeredBy: 'scheduled',
+    result: null,
+    errorMessage: null,
+    startedAt: new Date('2026-01-01T00:00:00.000Z'),
+    finishedAt: new Date('2026-01-01T00:00:00.000Z'),
+    durationMs: 1000,
+    ...overrides,
+  } as JobRun;
+}
+
+describe('JobHealthService', () => {
+  let service: JobHealthService;
+  let jobHistory: {
+    getLastRun: jest.Mock;
+    getLastSuccessfulRun: jest.Mock;
+    getLastFailedRun: jest.Mock;
+  };
+
+  // reconciliation's expected interval is 6h with the default 1.5x grace
+  // multiplier, so its staleness threshold is 9h.
+  const reconciliationDef = JOB_REGISTRY.find(
+    (job) => job.name === 'reconciliation',
+  )!;
+  const staleAfterMs =
+    reconciliationDef.expectedIntervalMs * (reconciliationDef.graceMultiplier ?? 1.5);
+
+  beforeEach(async () => {
+    jobHistory = {
+      getLastRun: jest.fn().mockResolvedValue(null),
+      getLastSuccessfulRun: jest.fn().mockResolvedValue(null),
+      getLastFailedRun: jest.fn().mockResolvedValue(null),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JobHealthService,
+        { provide: JobHistoryService, useValue: jobHistory },
+      ],
+    }).compile();
+
+    service = module.get<JobHealthService>(JobHealthService);
+  });
+
+  it('marks a job as never_run when it has no successful run on record', async () => {
+    const report = await service.getJobsHealthReport(new Date('2026-01-02T00:00:00.000Z'));
+
+    const reconciliation = report.jobs.find((j) => j.jobName === 'reconciliation');
+    expect(reconciliation!.state).toBe('never_run');
+    expect(report.status).toBe('degraded');
+  });
+
+  it('marks a job as ok exactly at the staleness threshold (boundary, inclusive)', async () => {
+    const lastSuccessAt = new Date('2026-01-01T00:00:00.000Z');
+    const now = new Date(lastSuccessAt.getTime() + staleAfterMs);
+
+    jobHistory.getLastSuccessfulRun.mockImplementation(async (jobName: string) =>
+      jobName === 'reconciliation'
+        ? makeRun({ finishedAt: lastSuccessAt })
+        : null,
+    );
+
+    const report = await service.getJobsHealthReport(now);
+    const reconciliation = report.jobs.find((j) => j.jobName === 'reconciliation');
+
+    expect(reconciliation!.state).toBe('ok');
+    expect(reconciliation!.staleByMs).toBeNull();
+  });
+
+  it('marks a job as stale one millisecond past the staleness threshold', async () => {
+    const lastSuccessAt = new Date('2026-01-01T00:00:00.000Z');
+    const now = new Date(lastSuccessAt.getTime() + staleAfterMs + 1);
+
+    jobHistory.getLastSuccessfulRun.mockImplementation(async (jobName: string) =>
+      jobName === 'reconciliation'
+        ? makeRun({ finishedAt: lastSuccessAt })
+        : null,
+    );
+
+    const report = await service.getJobsHealthReport(now);
+    const reconciliation = report.jobs.find((j) => j.jobName === 'reconciliation');
+
+    expect(reconciliation!.state).toBe('stale');
+    expect(reconciliation!.staleByMs).toBe(1);
+    expect(report.status).toBe('degraded');
+  });
+
+  it('marks a job as ok one millisecond before the staleness threshold', async () => {
+    const lastSuccessAt = new Date('2026-01-01T00:00:00.000Z');
+    const now = new Date(lastSuccessAt.getTime() + staleAfterMs - 1);
+
+    jobHistory.getLastSuccessfulRun.mockImplementation(async (jobName: string) =>
+      jobName === 'reconciliation'
+        ? makeRun({ finishedAt: lastSuccessAt })
+        : null,
+    );
+
+    const report = await service.getJobsHealthReport(now);
+    const reconciliation = report.jobs.find((j) => j.jobName === 'reconciliation');
+
+    expect(reconciliation!.state).toBe('ok');
+  });
+
+  it('reports overall status healthy only when every registered job is ok', async () => {
+    const now = new Date('2026-01-01T01:00:00.000Z');
+    jobHistory.getLastSuccessfulRun.mockResolvedValue(
+      makeRun({ finishedAt: now }),
+    );
+
+    const report = await service.getJobsHealthReport(now);
+
+    expect(report.jobs).toHaveLength(JOB_REGISTRY.length);
+    expect(report.jobs.every((j) => j.state === 'ok')).toBe(true);
+    expect(report.status).toBe('healthy');
+  });
+});

--- a/apps/backend/src/scheduler/job-health.service.ts
+++ b/apps/backend/src/scheduler/job-health.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@nestjs/common';
+import { JobHistoryService } from './job-history.service';
+import { JOB_REGISTRY, JobDefinition } from './job-registry';
+
+const DEFAULT_GRACE_MULTIPLIER = 1.5;
+
+export type JobHealthState = 'ok' | 'stale' | 'never_run';
+
+export interface JobHealthStatus {
+  jobName: string;
+  description: string;
+  expectedIntervalMs: number;
+  staleAfterMs: number;
+  state: JobHealthState;
+  lastStartedAt: string | null;
+  lastSuccessAt: string | null;
+  lastFailureAt: string | null;
+  lastDurationMs: number | null;
+  /** How far past the staleness threshold the last success is, in ms. Null when not stale. */
+  staleByMs: number | null;
+}
+
+export interface JobsHealthReport {
+  status: 'healthy' | 'degraded';
+  checkedAt: string;
+  jobs: JobHealthStatus[];
+}
+
+@Injectable()
+export class JobHealthService {
+  constructor(private readonly jobHistory: JobHistoryService) {}
+
+  async getJobsHealthReport(now: Date = new Date()): Promise<JobsHealthReport> {
+    const jobs = await Promise.all(
+      JOB_REGISTRY.map((definition) => this.getJobHealth(definition, now)),
+    );
+
+    const status = jobs.some((job) => job.state !== 'ok') ? 'degraded' : 'healthy';
+
+    return {
+      status,
+      checkedAt: now.toISOString(),
+      jobs,
+    };
+  }
+
+  private async getJobHealth(
+    definition: JobDefinition,
+    now: Date,
+  ): Promise<JobHealthStatus> {
+    const [lastRun, lastSuccess, lastFailure] = await Promise.all([
+      this.jobHistory.getLastRun(definition.name),
+      this.jobHistory.getLastSuccessfulRun(definition.name),
+      this.jobHistory.getLastFailedRun(definition.name),
+    ]);
+
+    const staleAfterMs =
+      definition.expectedIntervalMs *
+      (definition.graceMultiplier ?? DEFAULT_GRACE_MULTIPLIER);
+
+    let state: JobHealthState;
+    let staleByMs: number | null = null;
+
+    if (!lastSuccess) {
+      state = 'never_run';
+    } else {
+      const ageMs = now.getTime() - lastSuccess.finishedAt!.getTime();
+      if (ageMs > staleAfterMs) {
+        state = 'stale';
+        staleByMs = ageMs - staleAfterMs;
+      } else {
+        state = 'ok';
+      }
+    }
+
+    return {
+      jobName: definition.name,
+      description: definition.description,
+      expectedIntervalMs: definition.expectedIntervalMs,
+      staleAfterMs,
+      state,
+      lastStartedAt: lastRun?.startedAt?.toISOString() ?? null,
+      lastSuccessAt: lastSuccess?.finishedAt?.toISOString() ?? null,
+      lastFailureAt: lastFailure?.finishedAt?.toISOString() ?? null,
+      lastDurationMs: lastRun?.durationMs ?? null,
+      staleByMs,
+    };
+  }
+}

--- a/apps/backend/src/scheduler/job-history.service.ts
+++ b/apps/backend/src/scheduler/job-history.service.ts
@@ -2,12 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { JobRun, JobRunStatus } from './entities/job-run.entity';
+import { MetricsService } from '../metrics/metrics.service';
 
 @Injectable()
 export class JobHistoryService {
   constructor(
     @InjectRepository(JobRun)
     private readonly repo: Repository<JobRun>,
+    private readonly metrics: MetricsService,
   ) {}
 
   /** Create a RUNNING record and return it so callers can update it later. */
@@ -29,6 +31,7 @@ export class JobHistoryService {
       durationMs: 0,
     });
     await this.repo.save(run);
+    this.metrics.recordScheduledJobRun(jobName, 'skipped', 0);
   }
 
   /** Mark an existing run as COMPLETED with an optional result payload. */
@@ -38,6 +41,7 @@ export class JobHistoryService {
     run.finishedAt = new Date();
     run.durationMs = run.finishedAt.getTime() - run.startedAt.getTime();
     await this.repo.save(run);
+    this.metrics.recordScheduledJobRun(run.jobName, 'completed', run.durationMs);
   }
 
   /** Mark an existing run as FAILED with an error message. */
@@ -47,6 +51,7 @@ export class JobHistoryService {
     run.finishedAt = new Date();
     run.durationMs = run.finishedAt.getTime() - run.startedAt.getTime();
     await this.repo.save(run);
+    this.metrics.recordScheduledJobRun(run.jobName, 'failed', run.durationMs);
   }
 
   /** Fetch the N most recent runs for a given job name. */
@@ -58,10 +63,26 @@ export class JobHistoryService {
     });
   }
 
-  /** Fetch the last run for a given job name. */
+  /** Fetch the last run for a given job name, regardless of outcome. */
   async getLastRun(jobName: string): Promise<JobRun | null> {
     return this.repo.findOne({
       where: { jobName },
+      order: { startedAt: 'DESC' },
+    });
+  }
+
+  /** Fetch the last COMPLETED run for a given job name. */
+  async getLastSuccessfulRun(jobName: string): Promise<JobRun | null> {
+    return this.repo.findOne({
+      where: { jobName, status: JobRunStatus.COMPLETED },
+      order: { startedAt: 'DESC' },
+    });
+  }
+
+  /** Fetch the last FAILED run for a given job name. */
+  async getLastFailedRun(jobName: string): Promise<JobRun | null> {
+    return this.repo.findOne({
+      where: { jobName, status: JobRunStatus.FAILED },
       order: { startedAt: 'DESC' },
     });
   }

--- a/apps/backend/src/scheduler/job-lock.service.spec.ts
+++ b/apps/backend/src/scheduler/job-lock.service.spec.ts
@@ -1,0 +1,43 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { JobLockService } from './job-lock.service';
+import { MetricsService } from '../metrics/metrics.service';
+
+describe('JobLockService', () => {
+  let service: JobLockService;
+  let dataSource: { query: jest.Mock };
+  let metrics: { recordJobLockContention: jest.Mock };
+
+  beforeEach(async () => {
+    dataSource = { query: jest.fn() };
+    metrics = { recordJobLockContention: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JobLockService,
+        { provide: getDataSourceToken(), useValue: dataSource },
+        { provide: MetricsService, useValue: metrics },
+      ],
+    }).compile();
+
+    service = module.get<JobLockService>(JobLockService);
+  });
+
+  it('does not record contention when the lock is acquired', async () => {
+    dataSource.query.mockResolvedValue([{ pg_try_advisory_lock: true }]);
+
+    const acquired = await service.tryAcquire('reconciliation');
+
+    expect(acquired).toBe(true);
+    expect(metrics.recordJobLockContention).not.toHaveBeenCalled();
+  });
+
+  it('records contention when another instance already holds the lock', async () => {
+    dataSource.query.mockResolvedValue([{ pg_try_advisory_lock: false }]);
+
+    const acquired = await service.tryAcquire('reconciliation');
+
+    expect(acquired).toBe(false);
+    expect(metrics.recordJobLockContention).toHaveBeenCalledWith('reconciliation');
+  });
+});

--- a/apps/backend/src/scheduler/job-lock.service.ts
+++ b/apps/backend/src/scheduler/job-lock.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
+import { MetricsService } from '../metrics/metrics.service';
 
 /**
  * Distributed job locking via PostgreSQL advisory locks.
@@ -16,7 +17,10 @@ import { DataSource } from 'typeorm';
 export class JobLockService {
   private readonly logger = new Logger(JobLockService.name);
 
-  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly metrics: MetricsService,
+  ) {}
 
   /**
    * Try to acquire an advisory lock for the given job name.
@@ -33,6 +37,7 @@ export class JobLockService {
       this.logger.warn(
         `Job "${jobName}" skipped — lock held by another instance`,
       );
+      this.metrics.recordJobLockContention(jobName);
     }
     return acquired;
   }

--- a/apps/backend/src/scheduler/job-registry.ts
+++ b/apps/backend/src/scheduler/job-registry.ts
@@ -1,0 +1,66 @@
+/**
+ * Static registry of all recurring scheduled jobs and how often they are
+ * expected to succeed.
+ *
+ * `JobHealthService` uses this to decide whether a job's last successful
+ * run is recent enough, without hard-coding schedule knowledge into the
+ * health-check logic itself. When a new `@Cron` job is added, register it
+ * here so it shows up in `/health/jobs`.
+ */
+export interface JobDefinition {
+  /** Must match the JOB_NAME constant used by the corresponding scheduler. */
+  name: string;
+  description: string;
+  /** How often the job is expected to run successfully, in milliseconds. */
+  expectedIntervalMs: number;
+  /**
+   * Multiplier applied to `expectedIntervalMs` before a missed success is
+   * treated as staleness. Absorbs normal jitter (slow runs, brief instance
+   * restarts) without false-positiving on every run. Defaults to 1.5.
+   */
+  graceMultiplier?: number;
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+
+export const JOB_REGISTRY: readonly JobDefinition[] = [
+  {
+    name: 'reconciliation',
+    description: 'Drift reconciliation sweep',
+    expectedIntervalMs: 6 * HOUR_MS,
+  },
+  {
+    name: 'model-retraining-daily',
+    description: 'Daily ML model retraining fallback trigger',
+    expectedIntervalMs: 24 * HOUR_MS,
+  },
+  {
+    name: 'daily-snapshot',
+    description: 'Nightly analytics snapshot generation',
+    expectedIntervalMs: 24 * HOUR_MS,
+  },
+  {
+    name: 'idempotency-cleanup',
+    description: 'Expired idempotency record cleanup',
+    expectedIntervalMs: 24 * HOUR_MS,
+  },
+  {
+    name: 'contract-health-snapshot',
+    description: 'Periodic contract reachability snapshot',
+    expectedIntervalMs: 0.5 * HOUR_MS,
+  },
+  {
+    name: 'read-model-rebuild-cleanup',
+    description: 'Daily cleanup of old read-model rebuild job records',
+    expectedIntervalMs: 24 * HOUR_MS,
+  },
+  {
+    name: 'read-model-rebuild-stuck-recovery',
+    description: 'Hourly recovery sweep for stuck read-model rebuild jobs',
+    expectedIntervalMs: HOUR_MS,
+  },
+] as const;
+
+export function getJobDefinition(jobName: string): JobDefinition | undefined {
+  return JOB_REGISTRY.find((job) => job.name === jobName);
+}

--- a/apps/backend/src/scheduler/scheduler.module.ts
+++ b/apps/backend/src/scheduler/scheduler.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { JobRun } from './entities/job-run.entity';
 import { JobLockService } from './job-lock.service';
 import { JobHistoryService } from './job-history.service';
+import { JobHealthService } from './job-health.service';
 
 /**
  * Shared module that provides distributed job locking (PostgreSQL advisory
@@ -14,7 +15,7 @@ import { JobHistoryService } from './job-history.service';
  */
 @Module({
   imports: [TypeOrmModule.forFeature([JobRun])],
-  providers: [JobLockService, JobHistoryService],
-  exports: [JobLockService, JobHistoryService],
+  providers: [JobLockService, JobHistoryService, JobHealthService],
+  exports: [JobLockService, JobHistoryService, JobHealthService],
 })
 export class SchedulerModule {}

--- a/apps/backend/test/health.e2e-spec.ts
+++ b/apps/backend/test/health.e2e-spec.ts
@@ -7,16 +7,28 @@ import {
   HealthService,
   LumenpulseHealthReport,
 } from '../src/health/health.service';
+import { ContractHealthService } from '../src/health/contract-health.service';
+import { JobHealthService } from '../src/scheduler/job-health.service';
 
 describe('Health Check (e2e)', () => {
   let app: INestApplication;
   let healthService: { getHealthReport: jest.Mock };
+  let contractHealthService: { getContractHealthReport: jest.Mock };
+  let jobHealthService: { getJobsHealthReport: jest.Mock };
 
   const getHttpServer = (): Server => app.getHttpServer() as Server;
 
   beforeAll(async () => {
     healthService = {
       getHealthReport: jest.fn(),
+    };
+    contractHealthService = {
+      getContractHealthReport: jest.fn(),
+    };
+    jobHealthService = {
+      getJobsHealthReport: jest
+        .fn()
+        .mockResolvedValue({ status: 'healthy', checkedAt: new Date().toISOString(), jobs: [] }),
     };
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -25,6 +37,14 @@ describe('Health Check (e2e)', () => {
         {
           provide: HealthService,
           useValue: healthService,
+        },
+        {
+          provide: ContractHealthService,
+          useValue: contractHealthService,
+        },
+        {
+          provide: JobHealthService,
+          useValue: jobHealthService,
         },
       ],
     }).compile();
@@ -151,5 +171,55 @@ describe('Health Check (e2e)', () => {
     healthService.getHealthReport.mockResolvedValue(report);
 
     await request(getHttpServer()).get('/health').expect(503);
+  });
+
+  it('GET /health/jobs returns 200 when every scheduled job is healthy', async () => {
+    jobHealthService.getJobsHealthReport.mockResolvedValue({
+      status: 'healthy',
+      checkedAt: new Date().toISOString(),
+      jobs: [
+        {
+          jobName: 'reconciliation',
+          description: 'Drift reconciliation sweep',
+          expectedIntervalMs: 21600000,
+          staleAfterMs: 32400000,
+          state: 'ok',
+          lastStartedAt: new Date().toISOString(),
+          lastSuccessAt: new Date().toISOString(),
+          lastFailureAt: null,
+          lastDurationMs: 1200,
+          staleByMs: null,
+        },
+      ],
+    });
+
+    const response = await request(getHttpServer())
+      .get('/health/jobs')
+      .expect(200);
+
+    expect(response.body.status).toBe('healthy');
+  });
+
+  it('GET /health/jobs returns 503 when a scheduled job is stale', async () => {
+    jobHealthService.getJobsHealthReport.mockResolvedValue({
+      status: 'degraded',
+      checkedAt: new Date().toISOString(),
+      jobs: [
+        {
+          jobName: 'reconciliation',
+          description: 'Drift reconciliation sweep',
+          expectedIntervalMs: 21600000,
+          staleAfterMs: 32400000,
+          state: 'stale',
+          lastStartedAt: new Date().toISOString(),
+          lastSuccessAt: new Date().toISOString(),
+          lastFailureAt: null,
+          lastDurationMs: 1200,
+          staleByMs: 5000,
+        },
+      ],
+    });
+
+    await request(getHttpServer()).get('/health/jobs').expect(503);
   });
 });

--- a/lumenpulse-grafana-dashboard.json
+++ b/lumenpulse-grafana-dashboard.json
@@ -383,6 +383,81 @@
           "refId": "B"
         }
       ]
+    },
+
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "Scheduled Job Runs — Rate (per minute) by Outcome",
+      "description": "Completed/failed/skipped runs per scheduled job",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 42 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (job_name, status) (rate(lumenpulse_scheduled_job_runs_total[5m]) * 60)",
+          "legendFormat": "{{job_name}} / {{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "Scheduled Job Lock Contention",
+      "description": "How often a scheduled job could not acquire its distributed lock because another instance already held it",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 50 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (job_name) (increase(lumenpulse_scheduled_job_lock_contention_total[10m]))",
+          "legendFormat": "{{job_name}}",
+          "refId": "A"
+        }
+      ]
+    },
+
+    {
+      "id": 16,
+      "type": "timeseries",
+      "title": "Time Since Last Successful Job Run",
+      "description": "Seconds since each scheduled job last completed successfully — compare against the job's expected interval to spot staleness",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 50 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "color": { "mode": "palette-classic" }
+        }
+      },
+      "options": { "tooltip": { "mode": "multi" } },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "time() - lumenpulse_scheduled_job_last_success_timestamp_seconds",
+          "legendFormat": "{{job_name}}",
+          "refId": "A"
+        }
+      ]
     }
 
   ],


### PR DESCRIPTION
closes #1208

## Summary
- Adds `JobHealthService` + a static job registry (`src/scheduler/job-registry.ts`) that tracks each scheduler's last start/success/failure/duration and flags any job that hasn't succeeded within its expected interval.
- Exposes this as `GET /health/jobs` (200 when every job is within its expected interval, 503 when any job is stale or has never succeeded), following the same pattern as the existing `/health`, `/health/contracts`, and `/health/latency` endpoints.
- Wires `JobLockService`/`JobHistoryService` into the schedulers that weren't yet using them (`idempotency-cleanup`, `contract-health-snapshot`, and both `read-model-rebuild` cron jobs), in addition to the schedulers that already used them (`reconciliation`, `model-retraining-daily`, `daily-snapshot`), so the unified view covers every recurring job.
- Counts lock-acquisition failures (`lumenpulse_scheduled_job_lock_contention_total`) so contention between instances is visible instead of only logged.
- Exports job outcomes, durations, and last-success timestamps as Prometheus metrics (`lumenpulse_scheduled_job_runs_total`, `lumenpulse_scheduled_job_duration_seconds`, `lumenpulse_scheduled_job_last_success_timestamp_seconds`) and documents them in `METRICS_DOCUMENTATION.md`'s metric inventory table.
- Adds matching panels (job run rate by outcome, lock contention, time since last success) to `lumenpulse-grafana-dashboard.json`.

## Changes
- `src/scheduler/job-registry.ts` (new) — expected-interval registry for every recurring `@Cron` job.
- `src/scheduler/job-health.service.ts` (new) — computes per-job health/staleness from `JobHistoryService`.
- `src/scheduler/job-history.service.ts` — adds `getLastSuccessfulRun`/`getLastFailedRun`, records metrics on complete/fail/skip.
- `src/scheduler/job-lock.service.ts` — records a metric on failed lock acquisition (contention).
- `src/scheduler/scheduler.module.ts` — exports the new `JobHealthService`.
- `src/health/health.controller.ts` / `health.module.ts` — new `GET /health/jobs` endpoint.
- `src/idempotency/idempotency.scheduler.ts`, `src/health/contract-health-snapshot.scheduler.ts`, `src/read-model-rebuild/read-model-rebuild.scheduler.ts` — wired into `JobHistoryService`/`JobLockService` for unified history and locking.
- `src/metrics/metrics.service.ts` — new scheduled-job metric families.
- `METRICS_DOCUMENTATION.md`, `lumenpulse-grafana-dashboard.json` — docs and dashboard panels for the new metrics.

## Verification
- `pnpm jest` (full backend unit suite): 76 of 77 suites run, 624 passed, 19 pre-existing skipped, 0 failures.
- `pnpm jest --config ./test/jest-e2e.json test/health.e2e-spec.ts`: 5/5 passed (updated to mock the new `JobHealthService`/`ContractHealthService` deps, plus two new tests for `GET /health/jobs`).
- New unit tests specifically cover the stale-job detection boundary (`job-health.service.spec.ts`: exactly at threshold, threshold ± 1ms, never-run, all-healthy) and lock-contention counting (`job-lock.service.spec.ts`).
- `tsc --noEmit`: no new type errors introduced (two pre-existing, unrelated errors remain in `outbox.service.spec.ts`).

## Caveats
- `idempotency-cleanup`'s expected interval in the registry is a static 24h even though its cron schedule is configurable via `IDEMPOTENCY_CLEANUP_CRON`; if that env var is overridden to a much longer interval, `/health/jobs` may report false staleness until the registry entry is adjusted too.