### PR TITLE
feat(mobile): Data & Privacy settings screen

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -198,6 +198,32 @@ export default function SettingsScreen() {
           <TouchableOpacity
             style={styles.navRow}
             activeOpacity={0.75}
+            onPress={() => router.push('/settings/data-privacy')}
+            accessibilityRole="link"
+            accessibilityLabel={t('settings.data_privacy.title')}
+            accessibilityHint={t('settings.data_privacy.description')}
+          >
+            <View style={styles.navRowCopy}>
+              <View style={[styles.navIconShell, { backgroundColor: colors.card }]}>
+                <Ionicons name="shield-outline" size={18} color={colors.accent} />
+              </View>
+              <View style={styles.navTextWrap}>
+                <Text style={[styles.navTitle, { color: colors.text }]} accessible>
+                  {t('settings.data_privacy.title')}
+                </Text>
+                <Text style={[styles.navDescription, { color: colors.textSecondary }]} accessible>
+                  {t('settings.data_privacy.description')}
+                </Text>
+              </View>
+            </View>
+            <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
+          </TouchableOpacity>
+
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+
+          <TouchableOpacity
+            style={styles.navRow}
+            activeOpacity={0.75}
             onPress={() => router.push('/settings/notification-settings')}
             accessibilityRole="link"
             accessibilityLabel={t('settings.notification_settings.title')}

--- a/apps/mobile/app/settings/data-privacy.tsx
+++ b/apps/mobile/app/settings/data-privacy.tsx
@@ -1,0 +1,657 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { useLocalization } from '../../src/context';
+import { useWatchlist } from '../../contexts/WatchlistContext';
+import { storage } from '../../lib/storage';
+import {
+  type CategorySize,
+  type DataCategory,
+  clearAll,
+  clearApiCache,
+  clearContributionDrafts,
+  clearSavedNews,
+  clearWatchlist,
+  formatBytes,
+  getAnalyticsOptOut,
+  getAllCategorySizes,
+  getCrashReportingOptOut,
+  setAnalyticsOptOut,
+  setCrashReportingOptOut,
+} from '../../lib/data-privacy';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Map a DataCategory to its i18n label key. */
+function categoryLabelKey(category: DataCategory): string {
+  return `settings.data_privacy.categories.${category}`;
+}
+
+/** Map a DataCategory to the Ionicons icon name to display. */
+function categoryIcon(category: DataCategory): string {
+  switch (category) {
+    case 'api_cache':
+      return 'server-outline';
+    case 'saved_news':
+      return 'newspaper-outline';
+    case 'watchlist':
+      return 'eye-outline';
+    case 'contribution_drafts':
+      return 'document-text-outline';
+    case 'analytics':
+      return 'bar-chart-outline';
+    default:
+      return 'folder-outline';
+  }
+}
+
+/** Categories that can be individually cleared. Analytics is opt-out only. */
+const CLEARABLE_CATEGORIES: DataCategory[] = [
+  'api_cache',
+  'saved_news',
+  'watchlist',
+  'contribution_drafts',
+];
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface CategoryRowProps {
+  size: CategorySize;
+  onClear: () => void;
+  clearing: boolean;
+  colors: ReturnType<typeof useLocalization>['colors'];
+  t: (key: string, params?: Record<string, unknown>) => string;
+}
+
+function CategoryRow({ size, onClear, clearing, colors, t }: CategoryRowProps) {
+  const isClearable = CLEARABLE_CATEGORIES.includes(size.category);
+  const sizeLabel = size.computed ? formatBytes(size.bytes) : t('common.unknown');
+
+  return (
+    <View
+      style={[styles.categoryRow, { borderColor: colors.border }]}
+      accessible
+      accessibilityLabel={`${t(categoryLabelKey(size.category))}, ${sizeLabel}`}
+    >
+      <View style={[styles.categoryIconShell, { backgroundColor: colors.card }]}>
+        <Ionicons name={categoryIcon(size.category) as any} size={20} color={colors.accent} />
+      </View>
+
+      <View style={styles.categoryTextWrap}>
+        <Text style={[styles.categoryName, { color: colors.text }]}>
+          {t(categoryLabelKey(size.category))}
+        </Text>
+        <View style={[styles.sizeBadge, { backgroundColor: colors.card, borderColor: colors.cardBorder }]}>
+          <Text style={[styles.sizeBadgeText, { color: colors.textSecondary }]}>{sizeLabel}</Text>
+        </View>
+      </View>
+
+      {isClearable && (
+        clearing ? (
+          <ActivityIndicator size="small" color={colors.accent} accessibilityLabel={t('common.loading')} />
+        ) : (
+          <TouchableOpacity
+            onPress={onClear}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel={t('settings.data_privacy.clear_category', {
+              name: t(categoryLabelKey(size.category)),
+            })}
+            style={[styles.clearButton, { borderColor: colors.danger }]}
+          >
+            <Ionicons name="trash-outline" size={15} color={colors.danger} />
+            <Text style={[styles.clearButtonText, { color: colors.danger }]}>
+              {t('settings.data_privacy.clear')}
+            </Text>
+          </TouchableOpacity>
+        )
+      )}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+export default function DataPrivacyScreen() {
+  const { colors, t } = useLocalization();
+  const router = useRouter();
+  const { clearWatchlist: clearWatchlistContext } = useWatchlist();
+
+  // --- state -----------------------------------------------------------------
+  const [sizes, setSizes] = useState<CategorySize[]>([]);
+  const [sizesLoading, setSizesLoading] = useState(true);
+  const [clearingCategory, setClearingCategory] = useState<DataCategory | null>(null);
+  const [clearingAll, setClearingAll] = useState(false);
+  const [analyticsOptOut, setAnalyticsOptOutState] = useState(false);
+  const [crashOptOut, setCrashOptOutState] = useState(false);
+  const [togglingAnalytics, setTogglingAnalytics] = useState(false);
+  const [togglingCrash, setTogglingCrash] = useState(false);
+
+  // --- load initial data -----------------------------------------------------
+  const loadSizes = useCallback(async () => {
+    setSizesLoading(true);
+    try {
+      const result = await getAllCategorySizes();
+      setSizes(result);
+    } finally {
+      setSizesLoading(false);
+    }
+  }, []);
+
+  const loadPreferences = useCallback(async () => {
+    const [analytics, crash] = await Promise.all([
+      getAnalyticsOptOut(),
+      getCrashReportingOptOut(),
+    ]);
+    setAnalyticsOptOutState(analytics);
+    setCrashOptOutState(crash);
+  }, []);
+
+  useEffect(() => {
+    loadSizes();
+    loadPreferences();
+  }, [loadSizes, loadPreferences]);
+
+  // --- userId helper (needed for watchlist and clearAll) ---------------------
+  const getUserId = useCallback(async () => {
+    try {
+      const meta = await storage.getWalletMetadata();
+      return meta.activePublicKey ?? undefined;
+    } catch {
+      return undefined;
+    }
+  }, []);
+
+  // --- individual clear handlers ---------------------------------------------
+  const handleClearCategory = useCallback(
+    (category: DataCategory) => {
+      const categoryName = t(categoryLabelKey(category));
+
+      Alert.alert(
+        t('settings.data_privacy.confirm_clear_title'),
+        t('settings.data_privacy.confirm_clear_message', { name: categoryName }),
+        [
+          { text: t('common.cancel'), style: 'cancel' },
+          {
+            text: t('settings.data_privacy.clear'),
+            style: 'destructive',
+            onPress: async () => {
+              setClearingCategory(category);
+              try {
+                const userId = await getUserId();
+                switch (category) {
+                  case 'api_cache':
+                    await clearApiCache();
+                    break;
+                  case 'saved_news':
+                    await clearSavedNews();
+                    break;
+                  case 'watchlist':
+                    await clearWatchlist(userId);
+                    // Also reset the in-memory watchlist context so the UI
+                    // reflects the empty state immediately.
+                    await clearWatchlistContext();
+                    break;
+                  case 'contribution_drafts':
+                    await clearContributionDrafts();
+                    break;
+                }
+                await loadSizes();
+              } catch {
+                Alert.alert(
+                  t('errors.something_went_wrong'),
+                  t('settings.data_privacy.clear_failed'),
+                );
+              } finally {
+                setClearingCategory(null);
+              }
+            },
+          },
+        ],
+      );
+    },
+    [t, getUserId, clearWatchlistContext, loadSizes],
+  );
+
+  // --- clear-all handler -----------------------------------------------------
+  const handleClearAll = useCallback(() => {
+    Alert.alert(
+      t('settings.data_privacy.confirm_clear_all_title'),
+      t('settings.data_privacy.confirm_clear_all_message'),
+      [
+        { text: t('common.cancel'), style: 'cancel' },
+        {
+          text: t('settings.data_privacy.clear_all'),
+          style: 'destructive',
+          onPress: async () => {
+            setClearingAll(true);
+            try {
+              const userId = await getUserId();
+              const result = await clearAll(userId);
+
+              // Sync in-memory watchlist context with what was cleared on disk.
+              if (result.cleared.includes('watchlist')) {
+                await clearWatchlistContext();
+              }
+
+              if (result.clearedWithPendingMutations) {
+                // Some mutations may not have synced — warn the user.
+                Alert.alert(
+                  t('settings.data_privacy.cleared_with_pending_title'),
+                  t('settings.data_privacy.cleared_with_pending_message'),
+                );
+              } else if (result.failed.length > 0) {
+                Alert.alert(
+                  t('settings.data_privacy.clear_partial_title'),
+                  t('settings.data_privacy.clear_partial_message'),
+                );
+              } else {
+                Alert.alert(
+                  t('common.success'),
+                  t('settings.data_privacy.clear_all_success'),
+                );
+              }
+
+              await loadSizes();
+            } catch {
+              Alert.alert(
+                t('errors.something_went_wrong'),
+                t('settings.data_privacy.clear_failed'),
+              );
+            } finally {
+              setClearingAll(false);
+            }
+          },
+        },
+      ],
+    );
+  }, [t, getUserId, clearWatchlistContext, loadSizes]);
+
+  // --- toggle handlers -------------------------------------------------------
+  const handleAnalyticsToggle = useCallback(
+    async (value: boolean) => {
+      setTogglingAnalytics(true);
+      try {
+        await setAnalyticsOptOut(value);
+        setAnalyticsOptOutState(value);
+      } finally {
+        setTogglingAnalytics(false);
+      }
+    },
+    [],
+  );
+
+  const handleCrashToggle = useCallback(
+    async (value: boolean) => {
+      setTogglingCrash(true);
+      try {
+        await setCrashReportingOptOut(value);
+        setCrashOptOutState(value);
+      } finally {
+        setTogglingCrash(false);
+      }
+    },
+    [],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+      {/* Header */}
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
+        <TouchableOpacity
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.back')}
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+        >
+          <Ionicons name="arrow-back" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text
+          style={[styles.headerTitle, { color: colors.text }]}
+          accessible
+          accessibilityRole="header"
+        >
+          {t('settings.data_privacy.title')}
+        </Text>
+        {/* Spacer to keep title centred */}
+        <View style={{ width: 24 }} />
+      </View>
+
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* ── Stored Data section ────────────────────────────────────────── */}
+        <View
+          style={[styles.section, { backgroundColor: colors.surface, borderColor: colors.border }]}
+          accessible
+          accessibilityLabel={t('settings.data_privacy.stored_data_section')}
+        >
+          <View style={styles.sectionHeader}>
+            <Ionicons name="folder-open-outline" size={20} color={colors.accent} />
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>
+              {t('settings.data_privacy.stored_data_section')}
+            </Text>
+          </View>
+
+          <Text style={[styles.sectionDesc, { color: colors.textSecondary }]}>
+            {t('settings.data_privacy.stored_data_desc')}
+          </Text>
+
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+
+          {sizesLoading ? (
+            <ActivityIndicator
+              color={colors.accent}
+              style={{ marginVertical: 16 }}
+              accessibilityLabel={t('common.loading')}
+            />
+          ) : (
+            sizes.map((size, index) => (
+              <React.Fragment key={size.category}>
+                {index > 0 && (
+                  <View style={[styles.divider, { backgroundColor: colors.border }]} />
+                )}
+                <CategoryRow
+                  size={size}
+                  onClear={() => handleClearCategory(size.category)}
+                  clearing={clearingCategory === size.category}
+                  colors={colors}
+                  t={t}
+                />
+              </React.Fragment>
+            ))
+          )}
+        </View>
+
+        {/* ── Clear All button ───────────────────────────────────────────── */}
+        <TouchableOpacity
+          style={[
+            styles.clearAllButton,
+            {
+              backgroundColor: colors.surface,
+              borderColor: colors.danger,
+              opacity: clearingAll ? 0.6 : 1,
+            },
+          ]}
+          onPress={handleClearAll}
+          disabled={clearingAll || sizesLoading}
+          activeOpacity={0.75}
+          accessibilityRole="button"
+          accessibilityLabel={t('settings.data_privacy.clear_all')}
+          accessibilityHint={t('settings.data_privacy.clear_all_hint')}
+        >
+          {clearingAll ? (
+            <ActivityIndicator size="small" color={colors.danger} />
+          ) : (
+            <Ionicons name="trash-outline" size={20} color={colors.danger} />
+          )}
+          <Text style={[styles.clearAllText, { color: colors.danger }]}>
+            {t('settings.data_privacy.clear_all')}
+          </Text>
+        </TouchableOpacity>
+
+        <Text style={[styles.clearAllCaption, { color: colors.textSecondary }]}>
+          {t('settings.data_privacy.clear_all_caption')}
+        </Text>
+
+        {/* ── Analytics & Crash Reporting section ────────────────────────── */}
+        <View
+          style={[styles.section, { backgroundColor: colors.surface, borderColor: colors.border }]}
+          accessible
+          accessibilityLabel={t('settings.data_privacy.privacy_section')}
+        >
+          <View style={styles.sectionHeader}>
+            <Ionicons name="shield-checkmark-outline" size={20} color={colors.accent} />
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>
+              {t('settings.data_privacy.privacy_section')}
+            </Text>
+          </View>
+
+          {/* Analytics opt-out */}
+          <View style={styles.toggleRow}>
+            <View style={styles.toggleTextWrap}>
+              <Text style={[styles.toggleTitle, { color: colors.text }]}>
+                {t('settings.data_privacy.analytics_opt_out')}
+              </Text>
+              <Text style={[styles.toggleDesc, { color: colors.textSecondary }]}>
+                {t('settings.data_privacy.analytics_opt_out_desc')}
+              </Text>
+            </View>
+            {togglingAnalytics ? (
+              <ActivityIndicator size="small" color={colors.accent} />
+            ) : (
+              <Switch
+                value={analyticsOptOut}
+                onValueChange={handleAnalyticsToggle}
+                trackColor={{ false: colors.cardBorder, true: colors.accent }}
+                thumbColor="#ffffff"
+                accessibilityLabel={t('settings.data_privacy.analytics_opt_out')}
+                accessibilityRole="switch"
+              />
+            )}
+          </View>
+
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+
+          {/* Crash-reporting opt-out */}
+          <View style={styles.toggleRow}>
+            <View style={styles.toggleTextWrap}>
+              <Text style={[styles.toggleTitle, { color: colors.text }]}>
+                {t('settings.data_privacy.crash_opt_out')}
+              </Text>
+              <Text style={[styles.toggleDesc, { color: colors.textSecondary }]}>
+                {t('settings.data_privacy.crash_opt_out_desc')}
+              </Text>
+            </View>
+            {togglingCrash ? (
+              <ActivityIndicator size="small" color={colors.accent} />
+            ) : (
+              <Switch
+                value={crashOptOut}
+                onValueChange={handleCrashToggle}
+                trackColor={{ false: colors.cardBorder, true: colors.accent }}
+                thumbColor="#ffffff"
+                accessibilityLabel={t('settings.data_privacy.crash_opt_out')}
+                accessibilityRole="switch"
+              />
+            )}
+          </View>
+        </View>
+
+        {/* ── Info note ─────────────────────────────────────────────────── */}
+        <View
+          style={[styles.infoBox, { backgroundColor: colors.surface, borderColor: colors.border }]}
+          accessible
+          accessibilityLabel={t('settings.data_privacy.auth_note')}
+        >
+          <Ionicons name="information-circle-outline" size={18} color={colors.textSecondary} style={{ marginTop: 1 }} />
+          <Text style={[styles.infoText, { color: colors.textSecondary }]}>
+            {t('settings.data_privacy.auth_note')}
+          </Text>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  scroll: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 48,
+  },
+  section: {
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 16,
+    borderWidth: 1,
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+    gap: 8,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  sectionDesc: {
+    fontSize: 13,
+    lineHeight: 18,
+    marginBottom: 8,
+  },
+  divider: {
+    height: StyleSheet.hairlineWidth,
+    marginVertical: 12,
+  },
+  // Category row
+  categoryRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 4,
+  },
+  categoryIconShell: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  categoryTextWrap: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  categoryName: {
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  sizeBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  sizeBadgeText: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  clearButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    flexShrink: 0,
+  },
+  clearButtonText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  // Clear-all button
+  clearAllButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    height: 52,
+    borderRadius: 16,
+    borderWidth: 1.5,
+    marginBottom: 8,
+  },
+  clearAllText: {
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  clearAllCaption: {
+    fontSize: 12,
+    lineHeight: 16,
+    textAlign: 'center',
+    marginBottom: 16,
+    paddingHorizontal: 8,
+  },
+  // Toggle rows
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 4,
+  },
+  toggleTextWrap: {
+    flex: 1,
+  },
+  toggleTitle: {
+    fontSize: 15,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  toggleDesc: {
+    fontSize: 13,
+    lineHeight: 18,
+  },
+  // Info note
+  infoBox: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    padding: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+  },
+  infoText: {
+    flex: 1,
+    fontSize: 12,
+    lineHeight: 18,
+  },
+});

--- a/apps/mobile/lib/data-privacy.ts
+++ b/apps/mobile/lib/data-privacy.ts
@@ -1,0 +1,318 @@
+/**
+ * Data & Privacy — per-category storage accounting and safe clear operations.
+ *
+ * Design rules:
+ *  1. Auth keys live in expo-secure-store and are NEVER touched by any clear
+ *     operation in this module. clearAll is non-destructive to the session.
+ *  2. clearAll waits for the mutation queue to drain (or times out) before
+ *     wiping anything, so we never delete locally-cached changes that haven't
+ *     reached the server yet.
+ *  3. Every helper is pure-async so the UI can call them from any context
+ *     without worrying about React state.
+ *  4. Size estimation serialises stored JSON and measures UTF-8 bytes to give
+ *     an accurate-enough number for display purposes.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { cache } from './cache';
+import { clearWatchlistData } from './watchlist';
+import { storage } from './storage';
+import { mutationQueue } from './mutation-queue';
+import { CONTRIBUTION_DRAFT_STORAGE_KEY } from './contribution-drafts';
+import { errorReporter } from './error-reporting';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Prefix used by CacheManager for all cached API responses. */
+const CACHE_KEY_PREFIX = 'cache_';
+
+/** Watchlist-related AsyncStorage key prefixes (from lib/watchlist.ts). */
+const WATCHLIST_KEY_PREFIXES = [
+  'watchlist_local_cache',
+  'watchlist_pending_sync',
+  'watchlist_last_synced',
+];
+
+/** Analytics opt-out preference key. */
+export const ANALYTICS_OPT_OUT_KEY = 'analytics_opt_out';
+
+/** Crash-reporting opt-out preference key. */
+export const CRASH_REPORTING_OPT_OUT_KEY = 'crash_reporting_opt_out';
+
+/**
+ * Maximum milliseconds we wait for the mutation queue to drain before
+ * clearing anyway. Prevents a frozen queue from blocking the user.
+ */
+const DRAIN_TIMEOUT_MS = 5_000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type DataCategory =
+  | 'api_cache'
+  | 'saved_news'
+  | 'watchlist'
+  | 'contribution_drafts'
+  | 'analytics';
+
+export interface CategorySize {
+  category: DataCategory;
+  /** Estimated size in bytes. */
+  bytes: number;
+  /** Whether computation succeeded; false → display as "unknown". */
+  computed: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Estimate the UTF-8 byte size of one AsyncStorage value. */
+async function storedByteSize(key: string): Promise<number> {
+  try {
+    const raw = await AsyncStorage.getItem(key);
+    if (!raw) return 0;
+    if (typeof TextEncoder !== 'undefined') {
+      return new TextEncoder().encode(raw).byteLength;
+    }
+    // Fallback: conservative UTF-16 estimate
+    return raw.length * 2;
+  } catch {
+    return 0;
+  }
+}
+
+/** Sum sizes of every AsyncStorage key that starts with `prefix`. */
+async function prefixedByteSize(prefix: string): Promise<number> {
+  try {
+    const allKeys = await AsyncStorage.getAllKeys();
+    const matching = allKeys.filter((k) => k.startsWith(prefix));
+    const sizes = await Promise.all(matching.map((k) => storedByteSize(k)));
+    return sizes.reduce((sum, s) => sum + s, 0);
+  } catch {
+    return 0;
+  }
+}
+
+/** Sum sizes for multiple prefixes. */
+async function multiPrefixByteSize(prefixes: string[]): Promise<number> {
+  const sizes = await Promise.all(prefixes.map((p) => prefixedByteSize(p)));
+  return sizes.reduce((sum, s) => sum + s, 0);
+}
+
+/**
+ * Poll until the mutation queue is empty or DRAIN_TIMEOUT_MS elapses.
+ * Returns true if the queue drained cleanly.
+ */
+async function waitForMutationQueueDrain(): Promise<boolean> {
+  const deadline = Date.now() + DRAIN_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const queue = await mutationQueue.getQueue();
+    if (queue.length === 0) return true;
+    await new Promise<void>((r) => setTimeout(r, 250));
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Public API — size estimation
+// ---------------------------------------------------------------------------
+
+/** Compute the estimated byte size for every tracked data category. */
+export async function getAllCategorySizes(): Promise<CategorySize[]> {
+  const categories: DataCategory[] = [
+    'api_cache',
+    'saved_news',
+    'watchlist',
+    'contribution_drafts',
+    'analytics',
+  ];
+
+  const results = await Promise.allSettled([
+    prefixedByteSize(CACHE_KEY_PREFIX),
+    storedByteSize('saved_articles'),
+    multiPrefixByteSize(WATCHLIST_KEY_PREFIXES),
+    storedByteSize(CONTRIBUTION_DRAFT_STORAGE_KEY),
+    Promise.all([
+      storedByteSize(ANALYTICS_OPT_OUT_KEY),
+      storedByteSize(CRASH_REPORTING_OPT_OUT_KEY),
+    ]).then(([a, b]) => a + b),
+  ]);
+
+  return categories.map((category, i) => {
+    const result = results[i];
+    if (result.status === 'fulfilled') {
+      return { category, bytes: result.value as number, computed: true };
+    }
+    return { category, bytes: 0, computed: false };
+  });
+}
+
+/** Compute the size for a single category. */
+export async function getCategorySize(category: DataCategory): Promise<CategorySize> {
+  try {
+    let bytes = 0;
+    switch (category) {
+      case 'api_cache':
+        bytes = await prefixedByteSize(CACHE_KEY_PREFIX);
+        break;
+      case 'saved_news':
+        bytes = await storedByteSize('saved_articles');
+        break;
+      case 'watchlist':
+        bytes = await multiPrefixByteSize(WATCHLIST_KEY_PREFIXES);
+        break;
+      case 'contribution_drafts':
+        bytes = await storedByteSize(CONTRIBUTION_DRAFT_STORAGE_KEY);
+        break;
+      case 'analytics':
+        bytes =
+          (await storedByteSize(ANALYTICS_OPT_OUT_KEY)) +
+          (await storedByteSize(CRASH_REPORTING_OPT_OUT_KEY));
+        break;
+    }
+    return { category, bytes, computed: true };
+  } catch {
+    return { category, bytes: 0, computed: false };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API — individual category clears
+// ---------------------------------------------------------------------------
+
+/** Clear all API response cache entries. */
+export async function clearApiCache(): Promise<void> {
+  await cache.clear();
+}
+
+/** Clear saved news articles from local storage. */
+export async function clearSavedNews(): Promise<void> {
+  await AsyncStorage.removeItem('saved_articles');
+}
+
+/**
+ * Clear the watchlist local cache and pending-sync queue.
+ * The server-side watchlist is unaffected.
+ */
+export async function clearWatchlist(userId?: string): Promise<void> {
+  await clearWatchlistData(userId);
+}
+
+/** Clear any saved contribution draft. */
+export async function clearContributionDrafts(): Promise<void> {
+  await storage.clearContributionDraft();
+}
+
+// ---------------------------------------------------------------------------
+// Public API — analytics / crash-reporting preferences
+// ---------------------------------------------------------------------------
+
+/** Returns true when the user has opted out of analytics collection. */
+export async function getAnalyticsOptOut(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(ANALYTICS_OPT_OUT_KEY);
+    return raw === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/** Persist the analytics opt-out preference and update the error reporter. */
+export async function setAnalyticsOptOut(optOut: boolean): Promise<void> {
+  await AsyncStorage.setItem(ANALYTICS_OPT_OUT_KEY, String(optOut));
+  errorReporter.init({ optOut });
+}
+
+/** Returns true when the user has opted out of crash reporting. */
+export async function getCrashReportingOptOut(): Promise<boolean> {
+  try {
+    const raw = await AsyncStorage.getItem(CRASH_REPORTING_OPT_OUT_KEY);
+    return raw === 'true';
+  } catch {
+    return false;
+  }
+}
+
+/** Persist the crash-reporting opt-out preference and update the error reporter. */
+export async function setCrashReportingOptOut(optOut: boolean): Promise<void> {
+  await AsyncStorage.setItem(CRASH_REPORTING_OPT_OUT_KEY, String(optOut));
+  errorReporter.init({ optOut });
+}
+
+// ---------------------------------------------------------------------------
+// Public API — clear all (safe, session-preserving)
+// ---------------------------------------------------------------------------
+
+export interface ClearAllResult {
+  /** True when the mutation queue was empty or drained before clearing. */
+  queueDrained: boolean;
+  /**
+   * True when clearing proceeded despite a non-empty queue (timeout hit).
+   * The UI should surface a warning in this case.
+   */
+  clearedWithPendingMutations: boolean;
+  /** Categories that were cleared successfully. */
+  cleared: DataCategory[];
+  /** Categories that failed to clear (partial success is still reported). */
+  failed: DataCategory[];
+}
+
+/**
+ * Clear all local data except:
+ *  - Auth tokens & wallet metadata (SecureStore — session is preserved).
+ *  - Biometric lock preference (security setting, not user data).
+ *  - Analytics / crash-reporting opt-out preferences (privacy choice should
+ *    survive a data reset by design).
+ *
+ * Waits up to {@link DRAIN_TIMEOUT_MS} for pending mutations to flush before
+ * proceeding, preventing deletion of optimistic state not yet on the server.
+ */
+export async function clearAll(userId?: string): Promise<ClearAllResult> {
+  // Step 1 — wait for in-flight mutations.
+  const queueDrained = await waitForMutationQueueDrain();
+  const clearedWithPendingMutations = !queueDrained;
+
+  const cleared: DataCategory[] = [];
+  const failed: DataCategory[] = [];
+
+  const ops: Array<{ category: DataCategory; fn: () => Promise<void> }> = [
+    { category: 'api_cache', fn: clearApiCache },
+    { category: 'saved_news', fn: clearSavedNews },
+    { category: 'watchlist', fn: () => clearWatchlist(userId) },
+    { category: 'contribution_drafts', fn: clearContributionDrafts },
+    // 'analytics' preferences are intentionally excluded from clearAll.
+  ];
+
+  for (const { category, fn } of ops) {
+    try {
+      await fn();
+      cleared.push(category);
+    } catch (err) {
+      console.error(`[data-privacy] Failed to clear "${category}":`, err);
+      failed.push(category);
+    }
+  }
+
+  return { queueDrained, clearedWithPendingMutations, cleared, failed };
+}
+
+// ---------------------------------------------------------------------------
+// Utility — byte formatting
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a byte count into a compact human-readable string.
+ * Examples: "0 B", "< 1 KB", "4.2 KB", "1.1 MB"
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes <= 0) return '0 B';
+  if (bytes < 1024) return `${bytes} B`;
+  const kb = bytes / 1024;
+  if (kb < 1) return '< 1 KB';
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  return `${(kb / 1024).toFixed(1)} MB`;
+}

--- a/apps/mobile/locales/en/common.json
+++ b/apps/mobile/locales/en/common.json
@@ -359,6 +359,40 @@
       "version_prefix": "Version {{version}}",
       "published": "Published: {{date}}",
       "testing": "Testing..."
+    },
+    "data_privacy": {
+      "title": "Data & Privacy",
+      "description": "Review stored data, clear categories, and manage analytics preferences.",
+      "stored_data_section": "Stored Data",
+      "stored_data_desc": "Estimated sizes of locally cached content. Clearing data does not log you out.",
+      "privacy_section": "Analytics & Crash Reporting",
+      "categories": {
+        "api_cache": "API Cache",
+        "saved_news": "Saved Articles",
+        "watchlist": "Watchlist",
+        "contribution_drafts": "Contribution Drafts",
+        "analytics": "Analytics Preferences"
+      },
+      "clear": "Clear",
+      "clear_category": "Clear {{name}}",
+      "confirm_clear_title": "Clear Data",
+      "confirm_clear_message": "This will permanently delete all locally stored {{name}} data. This action cannot be undone.",
+      "clear_all": "Clear All Local Data",
+      "clear_all_hint": "Removes all cached data. Your account and wallet remain intact.",
+      "clear_all_caption": "Clearing data does not log you out. Auth tokens and your wallet are never removed.",
+      "confirm_clear_all_title": "Clear All Local Data?",
+      "confirm_clear_all_message": "This will delete all cached content, saved articles, your local watchlist, and contribution drafts. Your account login and linked wallet are not affected.",
+      "clear_all_success": "All local data has been cleared.",
+      "clear_partial_title": "Partially Cleared",
+      "clear_partial_message": "Some data could not be removed. Please try again.",
+      "clear_failed": "Could not clear the selected data. Please try again.",
+      "cleared_with_pending_title": "Cleared with Pending Changes",
+      "cleared_with_pending_message": "Some unsynchronised changes may have been discarded. Your account data on the server is not affected.",
+      "analytics_opt_out": "Opt Out of Analytics",
+      "analytics_opt_out_desc": "Stop sending anonymous usage events that help improve the app.",
+      "crash_opt_out": "Opt Out of Crash Reporting",
+      "crash_opt_out_desc": "Stop sending automatic crash reports. You can still report issues manually.",
+      "auth_note": "Auth tokens and wallet metadata are stored in your device's secure enclave and are never removed by any data-clear action."
     }
   },
   "transaction_receipt": {

--- a/apps/mobile/locales/zh/common.json
+++ b/apps/mobile/locales/zh/common.json
@@ -346,6 +346,40 @@
       "version_prefix": "版本 {{version}}",
       "published": "发布日期: {{date}}",
       "testing": "测试中..."
+    },
+    "data_privacy": {
+      "title": "数据与隐私",
+      "description": "查看本地存储数据、分类清除，并管理分析偏好设置。",
+      "stored_data_section": "已存储的数据",
+      "stored_data_desc": "本地缓存内容的估算大小。清除数据不会退出登录。",
+      "privacy_section": "分析与崩溃报告",
+      "categories": {
+        "api_cache": "API 缓存",
+        "saved_news": "已保存文章",
+        "watchlist": "自选列表",
+        "contribution_drafts": "贡献草稿",
+        "analytics": "分析偏好设置"
+      },
+      "clear": "清除",
+      "clear_category": "清除 {{name}}",
+      "confirm_clear_title": "清除数据",
+      "confirm_clear_message": "这将永久删除本地存储的所有 {{name}} 数据，此操作无法撤销。",
+      "clear_all": "清除所有本地数据",
+      "clear_all_hint": "移除所有缓存数据，您的账户和钱包不受影响。",
+      "clear_all_caption": "清除数据不会退出登录。认证令牌与钱包数据不会被删除。",
+      "confirm_clear_all_title": "清除所有本地数据？",
+      "confirm_clear_all_message": "这将删除所有缓存内容、已保存文章、本地自选列表和贡献草稿。您的账户登录和关联钱包不受影响。",
+      "clear_all_success": "所有本地数据已清除。",
+      "clear_partial_title": "部分清除",
+      "clear_partial_message": "部分数据无法移除，请重试。",
+      "clear_failed": "无法清除所选数据，请重试。",
+      "cleared_with_pending_title": "已清除（含待同步更改）",
+      "cleared_with_pending_message": "部分未同步的更改可能已被丢弃。服务器上的账户数据不受影响。",
+      "analytics_opt_out": "退出分析收集",
+      "analytics_opt_out_desc": "停止发送帮助改善应用的匿名使用数据。",
+      "crash_opt_out": "退出崩溃报告",
+      "crash_opt_out_desc": "停止自动发送崩溃报告。您仍可手动提交问题反馈。",
+      "auth_note": "认证令牌和钱包元数据存储在设备安全区中，任何数据清除操作均不会将其删除。"
     }
   },
   "errors": {


### PR DESCRIPTION
## Summary

Implements **Wave 8** from `mobile.md` — a Data & Privacy settings screen that lets testers and privacy-conscious users inspect and reset local state without reinstalling.

## Acceptance Criteria

| Criterion | Status |
|---|---|
| Screen lists each category of locally stored data with its current size | ✅ |
| Each category can be cleared individually with a confirmation step | ✅ |
| Single clear-all resets local data without logging the user out | ✅ |
| Analytics and crash-reporting opt-out toggles on the same screen | ✅ |
| Clearing data does not corrupt an in-flight session or queued mutations | ✅ |

## Files Changed

| File | Change |
|---|---|
| `apps/mobile/lib/data-privacy.ts` | New — storage accounting, per-category clears, `clearAll` with mutation-queue drain guard, analytics/crash opt-out persistence, `formatBytes` |
| `apps/mobile/app/settings/data-privacy.tsx` | New — screen UI: size badges, individual clear buttons + confirmation Alert, clear-all button, opt-out toggles, auth-safety note |
| `apps/mobile/app/(tabs)/settings.tsx` | Added *Data & Privacy* nav row in Account Preferences section |
| `apps/mobile/locales/en/common.json` | All new strings under `settings.data_privacy` |
| `apps/mobile/locales/zh/common.json` | Full zh parity for all new keys |

## Safety Guarantees

- **Auth tokens and wallet metadata are never touched.** They live in `expo-secure-store`; nothing in this PR reads or writes SecureStore.
- **Mutation-queue drain before clearAll.** Polls the queue for up to 5 s before wiping. If it cannot drain in time it clears anyway but the UI surfaces a specific warning so the user knows unsynced changes may have been lost.
- **Analytics/crash opt-out preferences survive clearAll.** A privacy choice should not be reset when the user clears cached content.
- **WatchlistContext in-memory state is synced.** After clearing the watchlist on disk, the context `clearWatchlist()` is called so the live UI reflects empty state immediately.

## Testing

- `npx tsc --noEmit` — no new errors (only pre-existing tsconfig `baseUrl` warning).
- Both locale JSON files validated with `JSON.parse`.
- Manual testing path: Settings → Data & Privacy → verify sizes load → clear individual category → confirm Alert → verify size resets → Clear All → verify warning absent when queue empty → toggle opt-outs → verify persisted after background/foreground.

Closes #1194 