### PR TITLE
fix(webhook): add replay protection with timestamp tolerance and nonce dedup

### DIFF
--- a/apps/backend/src/webhook/webhook-verification.guard.spec.ts
+++ b/apps/backend/src/webhook/webhook-verification.guard.spec.ts
@@ -1,0 +1,533 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { Reflector } from '@nestjs/core';
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import * as crypto from 'crypto';
+import {
+  WebhookVerificationGuard,
+  WEBHOOK_PROVIDER_KEY,
+} from './webhook-verification.guard';
+import { WebhookVerificationService } from './webhook-verification.service';
+import { MetricsService } from '../metrics/metrics.service';
+
+describe('WebhookVerificationGuard', () => {
+  let guard: WebhookVerificationGuard;
+
+  const testSecret = 'test-webhook-secret-12345';
+  const testProvider = 'test-provider';
+
+  const mockVerificationService = {
+    verifySignature: jest.fn(),
+    getProviderInfo: jest.fn(),
+    getRegisteredProviders: jest.fn(),
+    registerProvider: jest.fn(),
+    onModuleInit: jest.fn(),
+  };
+
+  const mockMetricsService = {
+    incrementCounter: jest.fn(),
+  };
+
+  const mockReflector = {
+    get: jest.fn(),
+  };
+
+  const mockConfigService = {
+    get: jest.fn((key: string) => {
+      if (key === 'WEBHOOK_TIMESTAMP_TOLERANCE_MS') return '300000';
+      return null;
+    }),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookVerificationGuard,
+        {
+          provide: WebhookVerificationService,
+          useValue: mockVerificationService,
+        },
+        { provide: Reflector, useValue: mockReflector },
+        { provide: ConfigService, useValue: mockConfigService },
+        { provide: MetricsService, useValue: mockMetricsService },
+      ],
+    }).compile();
+
+    guard = module.get<WebhookVerificationGuard>(WebhookVerificationGuard);
+  });
+
+  afterEach(() => {
+    // Clean up the interval timer
+    (guard as any).cleanupTimer?.unref?.();
+    clearInterval((guard as any).cleanupTimer);
+  });
+
+  // ── Helpers ──────────────────────────────────────────────────────────
+
+  function generateValidSignature(
+    body: Buffer,
+    _timestamp: string,
+    _nonce: string,
+    secret: string = testSecret,
+  ): string {
+    // The guard computes HMAC over the raw body (not a constructed payload)
+    return crypto.createHmac('sha256', secret).update(body).digest('hex');
+  }
+
+  function createMockContext(
+    overrides: {
+      rawBody?: Buffer | 'MISSING';
+      signature?: string;
+      timestamp?: string;
+      nonce?: string;
+      providerName?: string;
+      routePath?: string;
+    } = {},
+  ): ExecutionContext {
+    const defaultBody = Buffer.from(
+      '{"type":"anomaly","metric_name":"volume"}',
+    );
+
+    const headers: Record<string, string> = {};
+    if (overrides.signature !== undefined) {
+      headers['x-webhook-signature'] = overrides.signature;
+    }
+    if (overrides.timestamp !== undefined) {
+      headers['x-webhook-timestamp'] = overrides.timestamp;
+    }
+    if (overrides.nonce !== undefined) {
+      headers['x-webhook-nonce'] = overrides.nonce;
+    }
+    if (overrides.providerName !== undefined) {
+      headers['x-webhook-provider'] = overrides.providerName;
+    }
+
+    // Build request, conditionally omitting rawBody to simulate missing body
+    const mockRequest: Record<string, unknown> = {
+      headers,
+      query: {},
+      method: 'POST',
+      path: overrides.routePath ?? '/webhooks/data-processing',
+      route: { path: overrides.routePath ?? '/webhooks/data-processing' },
+    };
+    if (overrides.rawBody !== 'MISSING') {
+      mockRequest.rawBody = overrides.rawBody ?? defaultBody;
+    }
+
+    return {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+      getHandler: () => null,
+      getClass: () => null,
+    } as unknown as ExecutionContext;
+  }
+
+  function setupProviderInfo() {
+    mockVerificationService.getProviderInfo.mockReturnValue({
+      name: testProvider,
+      algorithm: 'hmac-sha256',
+      enabled: true,
+      signatureHeader: 'X-Webhook-Signature',
+      timestampHeader: 'X-Webhook-Timestamp',
+    });
+  }
+
+  function setupReflector(providerName: string | null) {
+    mockReflector.get.mockImplementation((key: string) => {
+      if (key === WEBHOOK_PROVIDER_KEY) return providerName;
+      return undefined;
+    });
+  }
+
+  // ── Tests ────────────────────────────────────────────────────────────
+
+  it('should be defined', () => {
+    expect(guard).toBeDefined();
+  });
+
+  describe('valid request', () => {
+    it('should accept a request with valid signature, timestamp, and nonce', async () => {
+      setupProviderInfo();
+      setupReflector(testProvider);
+
+      const body = Buffer.from('{"type":"anomaly","metric_name":"volume"}');
+      const timestamp = String(Date.now());
+      const nonce = crypto.randomUUID();
+
+      mockVerificationService.verifySignature.mockReturnValue({
+        valid: true,
+        algorithm: 'hmac-sha256',
+        provider: testProvider,
+      });
+
+      const context = createMockContext({
+        rawBody: body,
+        signature: `sha256=${generateValidSignature(body, timestamp, nonce)}`,
+        timestamp,
+        nonce,
+      });
+
+      const result = await guard.canActivate(context);
+      expect(result).toBe(true);
+      expect(mockVerificationService.verifySignature).toHaveBeenCalledWith(
+        testProvider,
+        body,
+        expect.stringContaining('sha256='),
+        timestamp,
+      );
+    });
+  });
+
+  describe('missing provider', () => {
+    it('should reject when no provider is specified', async () => {
+      setupReflector(null);
+
+      const context = createMockContext({
+        signature: 'sha256=fake',
+        timestamp: String(Date.now()),
+        nonce: crypto.randomUUID(),
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(mockMetricsService.incrementCounter).toHaveBeenCalledWith(
+        'webhook_rejections_total',
+        expect.objectContaining({ reason: 'missing_provider' }),
+      );
+    });
+  });
+
+  describe('missing raw body', () => {
+    it('should reject when rawBody is not available', async () => {
+      setupReflector(testProvider);
+
+      const context = createMockContext({
+        rawBody: 'MISSING',
+        signature: 'sha256=fake',
+        timestamp: String(Date.now()),
+        nonce: crypto.randomUUID(),
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(mockMetricsService.incrementCounter).toHaveBeenCalledWith(
+        'webhook_rejections_total',
+        expect.objectContaining({ reason: 'missing_body' }),
+      );
+    });
+  });
+
+  describe('missing signature', () => {
+    it('should reject when signature header is missing', async () => {
+      setupReflector(testProvider);
+
+      const context = createMockContext({
+        signature: undefined,
+        timestamp: String(Date.now()),
+        nonce: crypto.randomUUID(),
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(mockMetricsService.incrementCounter).toHaveBeenCalledWith(
+        'webhook_rejections_total',
+        expect.objectContaining({ reason: 'missing_signature' }),
+      );
+    });
+  });
+
+  describe('missing timestamp', () => {
+    it('should reject when timestamp header is missing', async () => {
+      setupReflector(testProvider);
+
+      const context = createMockContext({
+        signature: 'sha256=fake',
+        timestamp: undefined,
+        nonce: crypto.randomUUID(),
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(mockMetricsService.incrementCounter).toHaveBeenCalledWith(
+        'webhook_rejections_total',
+        expect.objectContaining({ reason: 'missing_timestamp' }),
+      );
+    });
+  });
+
+  describe('invalid timestamp', () => {
+    it('should reject non-numeric timestamp', async () => {
+      setupReflector(testProvider);
+
+      const context = createMockContext({
+        signature: 'sha256=fake',
+        timestamp: 'not-a-number',
+        nonce: crypto.randomUUID(),
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(mockMetricsService.incrementCounter).toHaveBeenCalledWith(
+        'webhook_rejections_total',
+        expect.objectContaining({ reason: 'invalid_timestamp' }),
+      );
+    });
+  });
+
+  describe('future timestamp', () => {
+    it('should reject timestamp in the future', async () => {
+      setupReflector(testProvider);
+
+      const futureTimestamp = String(Date.now() + 600_000);
+      const nonce = crypto.randomUUID();
+
+      const body = Buffer.from('{"type":"anomaly"}');
+      const signature = `sha256=${generateValidSignature(body, futureTimestamp, nonce)}`;
+
+      const context = createMockContext({
+        rawBody: body,
+        signature,
+        timestamp: futureTimestamp,
+        nonce,
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(mockMetricsService.incrementCounter).toHaveBeenCalledWith(
+        'webhook_rejections_total',
+        expect.objectContaining({ reason: 'future_timestamp' }),
+      );
+    });
+  });
+
+  describe('expired timestamp', () => {
+    it('should reject timestamp older than tolerance window', async () => {
+      setupReflector(testProvider);
+
+      // 10 minutes ago, tolerance is 5 minutes
+      const expiredTimestamp = String(Date.now() - 600_000);
+      const nonce = crypto.randomUUID();
+
+      const body = Buffer.from('{"type":"anomaly"}');
+      const signature = `sha256=${generateValidSignature(body, expiredTimestamp, nonce)}`;
+
+      const context = createMockContext({
+        rawBody: body,
+        signature,
+        timestamp: expiredTimestamp,
+        nonce,
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(mockMetricsService.incrementCounter).toHaveBeenCalledWith(
+        'webhook_rejections_total',
+        expect.objectContaining({ reason: 'expired_timestamp' }),
+      );
+    });
+  });
+
+  describe('missing nonce', () => {
+    it('should reject when nonce header is missing', async () => {
+      setupReflector(testProvider);
+
+      const timestamp = String(Date.now());
+      const body = Buffer.from('{"type":"anomaly"}');
+      const signature = `sha256=${generateValidSignature(body, timestamp, '')}`;
+
+      const context = createMockContext({
+        rawBody: body,
+        signature,
+        timestamp,
+        nonce: undefined,
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(mockMetricsService.incrementCounter).toHaveBeenCalledWith(
+        'webhook_rejections_total',
+        expect.objectContaining({ reason: 'missing_nonce' }),
+      );
+    });
+  });
+
+  describe('replayed nonce', () => {
+    it('should reject duplicate nonce (replay attack)', async () => {
+      setupProviderInfo();
+      setupReflector(testProvider);
+
+      const body = Buffer.from('{"type":"anomaly","metric_name":"volume"}');
+      const timestamp = String(Date.now());
+      const nonce = crypto.randomUUID();
+
+      mockVerificationService.verifySignature.mockReturnValue({
+        valid: true,
+        algorithm: 'hmac-sha256',
+        provider: testProvider,
+      });
+
+      // First delivery — should succeed
+      const firstContext = createMockContext({
+        rawBody: body,
+        signature: `sha256=${generateValidSignature(body, timestamp, nonce)}`,
+        timestamp,
+        nonce,
+      });
+      const firstResult = await guard.canActivate(firstContext);
+      expect(firstResult).toBe(true);
+
+      // Second delivery with the same nonce — should be rejected
+      const secondContext = createMockContext({
+        rawBody: body,
+        signature: `sha256=${generateValidSignature(body, timestamp, nonce)}`,
+        timestamp,
+        nonce,
+      });
+
+      await expect(guard.canActivate(secondContext)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(mockMetricsService.incrementCounter).toHaveBeenCalledWith(
+        'webhook_rejections_total',
+        expect.objectContaining({ reason: 'replayed_nonce' }),
+      );
+    });
+  });
+
+  describe('tampered body', () => {
+    it('should reject when signature does not match the body', async () => {
+      setupProviderInfo();
+      setupReflector(testProvider);
+
+      const originalBody = Buffer.from(
+        '{"type":"anomaly","metric_name":"volume"}',
+      );
+      const timestamp = String(Date.now());
+      const nonce = crypto.randomUUID();
+
+      // Sign the original body
+      const signature = `sha256=${generateValidSignature(originalBody, timestamp, nonce)}`;
+
+      // Tamper with the body
+      const tamperedBody = Buffer.from(
+        '{"type":"sentiment_spike","metric_name":"volume"}',
+      );
+
+      mockVerificationService.verifySignature.mockReturnValue({
+        valid: false,
+        error: 'HMAC-SHA256 signature mismatch',
+        provider: testProvider,
+      });
+
+      const context = createMockContext({
+        rawBody: tamperedBody,
+        signature,
+        timestamp,
+        nonce,
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(mockMetricsService.incrementCounter).toHaveBeenCalledWith(
+        'webhook_rejections_total',
+        expect.objectContaining({ reason: 'signature_mismatch' }),
+      );
+    });
+  });
+
+  describe('wrong secret', () => {
+    it('should reject when signed with a different secret', async () => {
+      setupProviderInfo();
+      setupReflector(testProvider);
+
+      const body = Buffer.from('{"type":"anomaly","metric_name":"volume"}');
+      const timestamp = String(Date.now());
+      const nonce = crypto.randomUUID();
+
+      // Sign with the wrong secret
+      const wrongSignature = `sha256=${generateValidSignature(body, timestamp, nonce, 'wrong-secret')}`;
+
+      mockVerificationService.verifySignature.mockReturnValue({
+        valid: false,
+        error: 'HMAC-SHA256 signature mismatch',
+        provider: testProvider,
+      });
+
+      const context = createMockContext({
+        rawBody: body,
+        signature: wrongSignature,
+        timestamp,
+        nonce,
+      });
+
+      await expect(guard.canActivate(context)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+  });
+
+  describe('rejection metrics', () => {
+    it('should call incrementCounter for every rejection', async () => {
+      setupReflector(testProvider);
+
+      const context = createMockContext({
+        signature: undefined,
+        timestamp: String(Date.now()),
+        nonce: crypto.randomUUID(),
+      });
+
+      await guard.canActivate(context).catch(() => {});
+
+      expect(mockMetricsService.incrementCounter).toHaveBeenCalledTimes(1);
+      expect(mockMetricsService.incrementCounter).toHaveBeenCalledWith(
+        'webhook_rejections_total',
+        expect.objectContaining({
+          reason: 'missing_signature',
+          route: '/webhooks/data-processing',
+          method: 'POST',
+        }),
+      );
+    });
+  });
+
+  describe('provider fallback via header', () => {
+    it('should read provider name from x-webhook-provider header when not set via decorator', async () => {
+      setupProviderInfo();
+
+      mockReflector.get.mockReturnValue(undefined);
+
+      const body = Buffer.from('{"type":"anomaly"}');
+      const timestamp = String(Date.now());
+      const nonce = crypto.randomUUID();
+
+      mockVerificationService.verifySignature.mockReturnValue({
+        valid: true,
+        algorithm: 'hmac-sha256',
+        provider: testProvider,
+      });
+
+      const context = createMockContext({
+        rawBody: body,
+        signature: `sha256=${generateValidSignature(body, timestamp, nonce)}`,
+        timestamp,
+        nonce,
+        providerName: testProvider,
+      });
+
+      const result = await guard.canActivate(context);
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/apps/backend/src/webhook/webhook-verification.guard.ts
+++ b/apps/backend/src/webhook/webhook-verification.guard.ts
@@ -5,14 +5,22 @@ import {
   UnauthorizedException,
   Logger,
 } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Reflector } from '@nestjs/core';
-import { Request, Response } from 'express';
+import { Request } from 'express';
 import { WebhookVerificationService } from './webhook-verification.service';
+import { MetricsService } from '../metrics/metrics.service';
 
 /**
  * Metadata key for webhook provider name
  */
 export const WEBHOOK_PROVIDER_KEY = 'webhook:provider';
+
+/** Default timestamp tolerance window (5 minutes) */
+const DEFAULT_TIMESTAMP_TOLERANCE_MS = 300_000;
+
+/** How often to purge expired nonces from the in-memory store */
+const NONCE_CLEANUP_INTERVAL_MS = 60_000;
 
 /**
  * Decorator to specify which webhook provider to use for verification
@@ -38,18 +46,51 @@ export const WebhookProvider = (provider: string) => {
 };
 
 /**
- * Guard that verifies webhook signatures using the specified provider
- * Apply @WebhookProvider('provider-name') to routes that need verification
+ * Guard that verifies webhook signatures, enforces a timestamp tolerance
+ * window, and rejects replayed deliveries via a seen-nonce store.
+ *
+ * Required headers:
+ *   X-Webhook-Signature  — HMAC/RSA/Ed25519 signature
+ *   X-Webhook-Timestamp  — Unix epoch milliseconds
+ *   X-Webhook-Nonce      — Unique per-delivery identifier (UUID recommended)
+ *
+ * Apply @WebhookProvider('provider-name') to routes that need verification.
  */
 @Injectable()
 export class WebhookVerificationGuard implements CanActivate {
   private readonly logger = new Logger(WebhookVerificationGuard.name);
 
+  /** nonce → expiry timestamp (ms) */
+  private readonly seenNonces = new Map<string, number>();
+
+  private readonly timestampToleranceMs: number;
+  private readonly cleanupTimer: ReturnType<typeof setInterval>;
+
   constructor(
     private readonly verificationService: WebhookVerificationService,
     private readonly reflector: Reflector,
-  ) {}
+    private readonly configService: ConfigService,
+    private readonly metricsService: MetricsService,
+  ) {
+    const rawTolerance = this.configService.get<string>(
+      'WEBHOOK_TIMESTAMP_TOLERANCE_MS',
+    );
+    this.timestampToleranceMs = rawTolerance
+      ? Number(rawTolerance)
+      : DEFAULT_TIMESTAMP_TOLERANCE_MS;
 
+    // Periodic cleanup so the nonce store doesn't grow unbounded
+    this.cleanupTimer = setInterval(
+      () => this.purgeExpiredNonces(),
+      NONCE_CLEANUP_INTERVAL_MS,
+    );
+    // Allow the process to exit without waiting for the timer
+    if (this.cleanupTimer.unref) {
+      this.cleanupTimer.unref();
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
 
@@ -76,19 +117,23 @@ export class WebhookVerificationGuard implements CanActivate {
     }
 
     if (!providerName) {
-      this.logger.warn('No webhook provider specified');
+      this.reject(request, 'missing_provider', 'No webhook provider specified');
       throw new UnauthorizedException('Webhook provider not specified');
     }
 
-    // Get raw body
+    // ── Raw body ────────────────────────────────────────────────────
     const reqWithRawBody = request as Request & { rawBody?: Buffer };
     const rawBody = reqWithRawBody.rawBody;
     if (!rawBody || !(rawBody instanceof Buffer)) {
-      this.logger.warn('Raw body not available for verification');
+      this.reject(
+        request,
+        'missing_body',
+        'Raw body not available for verification',
+      );
       throw new UnauthorizedException('Request body not available');
     }
 
-    // Get provider config to determine header names
+    // ── Provider config & header names ──────────────────────────────
     const providerInfo = this.verificationService.getProviderInfo(providerName);
     const signatureHeaderName =
       providerInfo?.signatureHeader?.toLowerCase() || 'x-webhook-signature';
@@ -96,16 +141,85 @@ export class WebhookVerificationGuard implements CanActivate {
       providerInfo?.timestampHeader?.toLowerCase() || 'x-webhook-timestamp';
 
     const signatureHeader = request.headers[signatureHeaderName] as
-      string | undefined;
+      | string
+      | undefined;
     const timestampHeader = request.headers[timestampHeaderName] as
-      string | undefined;
+      | string
+      | undefined;
+    const nonceHeader = request.headers['x-webhook-nonce'] as
+      | string
+      | undefined;
 
     if (!signatureHeader) {
-      this.logger.warn('Missing signature header');
+      this.reject(request, 'missing_signature', 'Missing signature header');
       throw new UnauthorizedException('Missing signature header');
     }
 
-    // Verify signature
+    // ── Timestamp tolerance ─────────────────────────────────────────
+    if (!timestampHeader) {
+      this.reject(
+        request,
+        'missing_timestamp',
+        'Missing timestamp header — replay protection requires X-Webhook-Timestamp',
+      );
+      throw new UnauthorizedException('Missing timestamp header');
+    }
+
+    const timestamp = Number(timestampHeader);
+    if (!Number.isInteger(timestamp) || timestamp <= 0) {
+      this.reject(
+        request,
+        'invalid_timestamp',
+        'Invalid timestamp format — expected unix epoch ms',
+      );
+      throw new UnauthorizedException('Invalid timestamp format');
+    }
+
+    const now = Date.now();
+    const age = now - timestamp;
+
+    if (age < 0) {
+      this.reject(
+        request,
+        'future_timestamp',
+        `Timestamp is in the future (drift: ${Math.abs(age)}ms)`,
+      );
+      throw new UnauthorizedException('Timestamp is in the future');
+    }
+
+    if (age > this.timestampToleranceMs) {
+      this.reject(
+        request,
+        'expired_timestamp',
+        `Timestamp expired (age: ${age}ms, tolerance: ${this.timestampToleranceMs}ms)`,
+      );
+      throw new UnauthorizedException('Timestamp expired');
+    }
+
+    // ── Nonce dedup ─────────────────────────────────────────────────
+    if (!nonceHeader) {
+      this.reject(
+        request,
+        'missing_nonce',
+        'Missing nonce header — replay protection requires X-Webhook-Nonce',
+      );
+      throw new UnauthorizedException('Missing nonce header');
+    }
+
+    const nonceExpiry = this.seenNonces.get(nonceHeader);
+    if (nonceExpiry !== undefined) {
+      this.reject(
+        request,
+        'replayed_nonce',
+        'Duplicate nonce detected — delivery already processed',
+      );
+      throw new UnauthorizedException('Duplicate webhook delivery (replay)');
+    }
+
+    // Mark nonce as seen; expires together with the tolerance window
+    this.seenNonces.set(nonceHeader, now + this.timestampToleranceMs);
+
+    // ── Signature verification ──────────────────────────────────────
     const result = this.verificationService.verifySignature(
       providerName,
       rawBody,
@@ -125,8 +239,10 @@ export class WebhookVerificationGuard implements CanActivate {
     };
 
     if (!result.valid) {
-      this.logger.warn(
-        `Webhook verification failed for provider ${providerName}: ${result.error}`,
+      this.reject(
+        request,
+        'signature_mismatch',
+        `Signature verification failed for provider ${providerName}: ${result.error}`,
       );
       throw new UnauthorizedException(
         result.error || 'Webhook signature verification failed',
@@ -137,6 +253,44 @@ export class WebhookVerificationGuard implements CanActivate {
       `Webhook verified successfully from provider ${providerName} using ${result.algorithm}`,
     );
 
-    return await Promise.resolve(true);
+    return true;
+  }
+
+  /**
+   * Log the rejection reason and increment the webhook_rejections_total
+   * Prometheus counter so it is visible on the /metrics scrape endpoint.
+   */
+  private reject(request: Request, reason: string, message: string): void {
+    const route =
+      ((request.route as Record<string, unknown>)?.path as string) ??
+      request.path ??
+      'unknown';
+    const method = request.method ?? 'POST';
+
+    this.logger.warn({ reason, route, method }, `Webhook rejected: ${message}`);
+
+    this.metricsService.incrementCounter('webhook_rejections_total', {
+      reason,
+      route,
+      method,
+    });
+  }
+
+  /**
+   * Remove nonces whose TTL has expired so the in-memory store stays
+   * bounded. Runs periodically via the cleanup timer.
+   */
+  private purgeExpiredNonces(): void {
+    const now = Date.now();
+    let purged = 0;
+    for (const [nonce, expiry] of this.seenNonces) {
+      if (expiry <= now) {
+        this.seenNonces.delete(nonce);
+        purged++;
+      }
+    }
+    if (purged > 0) {
+      this.logger.debug(`Purged ${purged} expired nonces from replay store`);
+    }
   }
 }

--- a/apps/backend/src/webhook/webhook.module.ts
+++ b/apps/backend/src/webhook/webhook.module.ts
@@ -5,9 +5,10 @@ import { WebhookVerificationService } from './webhook-verification.service';
 import { WebhookVerificationGuard } from './webhook-verification.guard';
 import { WebhookAdminController } from './webhook-admin.controller';
 import { NotificationModule } from '../notification/notification.module';
+import { MetricsModule } from '../metrics/metrics.module';
 
 @Module({
-  imports: [NotificationModule],
+  imports: [NotificationModule, MetricsModule],
   controllers: [WebhookController, WebhookAdminController],
   providers: [
     WebhookService,


### PR DESCRIPTION
## What this fixes

Closes #1211 — the `WebhookVerificationGuard` only verified HMAC signatures,
leaving the endpoint vulnerable to **replay attacks**. An attacker who captured
a valid signed webhook could replay it indefinitely, with no timestamp
enforcement and no nonce deduplication. Rejected deliveries were also not
logged with structured reasons or counted as Prometheus metrics.

## Root cause

The guard performed signature verification but omitted two critical defences
that the acceptance criteria of #1211 require:

1. **No timestamp tolerance window** — the `X-Webhook-Timestamp` header was
   read but never validated, so an old (or future) request was accepted as
   long as the HMAC matched.
2. **No nonce deduplication** — there was no seen-nonce store, so replayed
   deliveries with the same payload were processed repeatedly.
3. **No rejection metrics** — failed verifications were logged via
   `Logger.warn` but never surfaced as a Prometheus counter, making it
   impossible to alert on spikes in rejected webhooks.

## The fix and why

### Changes (3 files, ~700 lines including tests)

| File | What changed |
|------|-------------|
| `webhook-verification.guard.ts` | Added three hard gates before signature check: (1) require `X-Webhook-Timestamp` and reject if age > tolerance or in the future; (2) require `X-Webhook-Nonce` and reject duplicates via an in-memory `Map<string, number>` with TTL-based expiry; (3) every rejection now calls a `reject()` helper that logs a structured `{reason, route, method}` object and increments `webhook_rejections_total`. |
| `webhook.module.ts` | Imported `MetricsModule` so the guard can inject `MetricsService`. |
| `webhook-verification.guard.spec.ts` | **New file** — 15 unit tests covering: valid request, missing provider/body/signature/timestamp/nonce, invalid timestamp, future timestamp, expired timestamp, replayed nonce, tampered body, wrong secret, metrics emission, and provider fallback via header. |

### Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `WEBHOOK_TIMESTAMP_TOLERANCE_MS` | `300000` (5 min) | Maximum age (ms) of the `X-Webhook-Timestamp` header before the guard rejects the request. |

### Design decisions

- **In-memory nonce store** — chosen over Redis/DB because webhook volume is
  moderate and the nonce window is short (5 min). The store is bounded by a
  60-second cleanup interval and entries auto-expire with the tolerance window.
  If horizontal scaling is needed later, the `seenNonces` Map can be swapped
  for a Redis-backed `SET` with TTL.
- **`@typescript-eslint/require-await` suppressed** — the `canActivate` method
  returns `Promise<boolean>` for NestJS compatibility but currently performs
  only synchronous work. If async provider lookups are added later the
  suppression can be removed.
- **MetricsService already `@Global()`** — no additional module wiring was
  needed beyond importing `MetricsModule` into `WebhookModule`.

## How it was tested

1. **Unit tests (15)** — all passing against the new guard spec:
   ```
   PASS  src/webhook/webhook-verification.guard.spec.ts
   Tests: 15 passed, 15 total
   ```
2. **Existing webhook tests (24 total)** — `webhook-verification.service.spec.ts`
   still passes unchanged.
3. **Lint** — `eslint` passes with zero errors on all three changed files.
4. **Typecheck** — `tsc --noEmit` reports zero new errors (pre-existing
   unrelated error in `outbox.service.spec.ts`).

## Follow-up worth filing separately

- **Redis-backed nonce store** for horizontal scaling — current in-memory
  approach is correct for single-instance but won't deduplicate across pods.
- **Configurable nonce header name** per provider (like `signatureHeader` /
  `timestampHeader`) so external providers can use their own conventions.
- **Rate-limit webhook endpoints** separately from the global throttle —
  webhook senders typically need higher sustained rates than browser clients.