### PR TITLE
feat(scheduler): add health and lock-contention visibility to scheduled jobs

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -45,6 +45,7 @@ import { AuthModule } from './auth/auth.module';
 import { UsersModule } from './users/users.module';
 import { GrantsModule } from './grants/grants.module';
 import { HealthModule } from './health/health.module';
+import { SchedulerModule } from './scheduler/scheduler.module';
 import { OutboxModule } from './outbox/outbox.module';
 import { VerificationModule } from './verification/verification.module';
 import { TelegramBotModule } from './telegram-bot/telegram-bot.module';
@@ -137,6 +138,7 @@ import { PriceAlertModule } from './price-alert/price-alert.module';
     AuthModule,
     UsersModule,
     HealthModule,
+    SchedulerModule,
     QueueModule,
     StellarSyncModule,
     ExchangeRatesModule,

--- a/apps/backend/src/metrics/metrics.service.spec.ts
+++ b/apps/backend/src/metrics/metrics.service.spec.ts
@@ -132,6 +132,50 @@ describe('MetricsService', () => {
     expect(output).toContain('lumenpulse_fetch_errors_total');
   });
 
+  // Scheduled-job metrics //
+
+  it('recordSchedulerJobOutcome() emits run counter, last-success gauge, and duration histogram', async () => {
+    const startedAt = new Date('2026-08-27T01:00:00.000Z');
+    service.recordSchedulerJobOutcome(
+      'reconciliation',
+      'completed',
+      120_000,
+      startedAt,
+    );
+    const output = await service.getMetrics();
+    expect(output).toContain('lumenpulse_scheduler_job_runs_total');
+    expect(output).toContain('lumenpulse_scheduler_job_duration_seconds');
+    expect(output).toMatch(
+      /lumenpulse_scheduler_job_last_success_timestamp_seconds\{job="reconciliation"\} 1\d{9}\.?\d*/,
+    );
+  });
+
+  it('recordSchedulerJobOutcome() sets the last-failure gauge for failed runs', async () => {
+    service.recordSchedulerJobOutcome(
+      'daily-snapshot',
+      'failed',
+      5000,
+      new Date('2026-08-27T02:00:00.000Z'),
+    );
+    const output = await service.getMetrics();
+    expect(output).toMatch(
+      /lumenpulse_scheduler_job_last_failure_timestamp_seconds\{job="daily-snapshot"\}/,
+    );
+  });
+
+  it('recordSchedulerLockContention() increments the contention counter per job', async () => {
+    service.recordSchedulerLockContention('reconciliation');
+    service.recordSchedulerLockContention('reconciliation');
+    service.recordSchedulerLockContention('daily-snapshot');
+    const output = await service.getMetrics();
+    expect(output).toMatch(
+      /lumenpulse_scheduler_lock_contention_total\{job="reconciliation"\} 2/,
+    );
+    expect(output).toMatch(
+      /lumenpulse_scheduler_lock_contention_total\{job="daily-snapshot"\} 1/,
+    );
+  });
+
   // Dynamic helpers //
 
   it('getOrCreateGauge() returns the same instance on repeated calls', () => {

--- a/apps/backend/src/metrics/metrics.service.ts
+++ b/apps/backend/src/metrics/metrics.service.ts
@@ -48,6 +48,13 @@ export class MetricsService implements OnModuleInit {
   private readonly outboxAttempts: Counter<string>;
   private readonly outboxDeadLetterVolume: Gauge<string>;
 
+  // Scheduled-job monitoring //
+  private readonly schedulerJobRuns: Counter<string>;
+  private readonly schedulerJobLastSuccess: Gauge<string>;
+  private readonly schedulerJobLastFailure: Gauge<string>;
+  private readonly schedulerJobDuration: Histogram<string>;
+  private readonly schedulerLockContention: Counter<string>;
+
   // Running totals for the rolling-average sentiment gauge
   private sentimentSum = 0;
   private sentimentCount = 0;
@@ -203,6 +210,42 @@ export class MetricsService implements OnModuleInit {
     this.outboxDeadLetterVolume = new Gauge({
       name: 'lumenpulse_outbox_dead_letter_volume',
       help: 'Current number of outbox events in the dead-letter queue',
+      registers: [this.registry],
+    });
+
+    this.schedulerJobRuns = new Counter({
+      name: 'lumenpulse_scheduler_job_runs_total',
+      help: 'Total scheduled-job runs by job and outcome status',
+      labelNames: ['job', 'status'] as const,
+      registers: [this.registry],
+    });
+
+    this.schedulerJobLastSuccess = new Gauge({
+      name: 'lumenpulse_scheduler_job_last_success_timestamp_seconds',
+      help: 'Unix timestamp of the last successful run, per scheduled job',
+      labelNames: ['job'] as const,
+      registers: [this.registry],
+    });
+
+    this.schedulerJobLastFailure = new Gauge({
+      name: 'lumenpulse_scheduler_job_last_failure_timestamp_seconds',
+      help: 'Unix timestamp of the last failed run, per scheduled job',
+      labelNames: ['job'] as const,
+      registers: [this.registry],
+    });
+
+    this.schedulerJobDuration = new Histogram({
+      name: 'lumenpulse_scheduler_job_duration_seconds',
+      help: 'Duration of completed scheduled-job runs, per job',
+      labelNames: ['job'] as const,
+      buckets: [1, 5, 10, 30, 60, 120, 300, 600, 1800, 3600],
+      registers: [this.registry],
+    });
+
+    this.schedulerLockContention = new Counter({
+      name: 'lumenpulse_scheduler_lock_contention_total',
+      help: 'Total advisory-lock acquisition failures, per scheduled job',
+      labelNames: ['job'] as const,
       registers: [this.registry],
     });
   }
@@ -406,9 +449,44 @@ export class MetricsService implements OnModuleInit {
   /** Record the current number of dead-lettered outbox events. */
   setOutboxDeadLetterVolume(volume: number): void {
     this.outboxDeadLetterVolume.set(volume);
+  } // Scheduled-job instrumentation //
+
+  /**
+   * Record a scheduled-job run outcome.
+   *
+   * @param job        Logical job name, e.g. "reconciliation"
+   * @param status     "running" | "completed" | "failed" | "skipped"
+   * @param durationMs Wall-clock duration of the run (null while running)
+   * @param timestamp  When the outcome happened (startedAt for completed/failed)
+   */
+  recordSchedulerJobOutcome(
+    job: string,
+    status: 'running' | 'completed' | 'failed' | 'skipped',
+    durationMs: number | null,
+    timestamp: Date,
+  ): void {
+    this.schedulerJobRuns.inc({ job, status });
+
+    if (status === 'completed') {
+      this.schedulerJobLastSuccess
+        .labels({ job })
+        .set(timestamp.getTime() / 1000);
+      if (durationMs !== null) {
+        this.schedulerJobDuration.labels({ job }).observe(durationMs / 1000);
+      }
+    } else if (status === 'failed') {
+      this.schedulerJobLastFailure
+        .labels({ job })
+        .set(timestamp.getTime() / 1000);
+    }
   }
 
-  //Dynamic metric helpers (legacy API)
+  /** Count a failed advisory-lock acquisition (another instance held the lock). */
+  recordSchedulerLockContention(job: string): void {
+    this.schedulerLockContention.inc({ job });
+  }
+
+  // Dynamic metric helpers (legacy API)
 
   getOrCreateGauge(
     name: string,

--- a/apps/backend/src/scheduler/job-history.service.spec.ts
+++ b/apps/backend/src/scheduler/job-history.service.spec.ts
@@ -1,0 +1,112 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { JobRun, JobRunStatus } from './entities/job-run.entity';
+import { JobHistoryService } from './job-history.service';
+import { MetricsService } from '../metrics/metrics.service';
+
+describe('JobHistoryService', () => {
+  let service: JobHistoryService;
+  let repo: {
+    create: jest.Mock;
+    save: jest.Mock;
+    find: jest.Mock;
+    findOne: jest.Mock;
+  };
+  let metrics: { recordSchedulerJobOutcome: jest.Mock };
+
+  beforeEach(async () => {
+    repo = {
+      create: jest.fn((data: Partial<JobRun>) => ({
+        ...data,
+        startedAt: new Date('2026-08-27T01:00:00.000Z'),
+      })),
+      save: jest.fn((run: JobRun) => Promise.resolve(run)),
+      find: jest.fn(),
+      findOne: jest.fn(),
+    };
+    metrics = { recordSchedulerJobOutcome: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JobHistoryService,
+        { provide: getRepositoryToken(JobRun), useValue: repo },
+        { provide: MetricsService, useValue: metrics },
+      ],
+    }).compile();
+
+    service = module.get<JobHistoryService>(JobHistoryService);
+    jest.clearAllMocks();
+  });
+
+  it('records a running outcome when a run starts', async () => {
+    await service.start('reconciliation');
+    expect(metrics.recordSchedulerJobOutcome).toHaveBeenCalledWith(
+      'reconciliation',
+      'running',
+      null,
+      expect.any(Date),
+    );
+  });
+
+  it('records a completed outcome with duration and start timestamp', async () => {
+    const run = await service.start('reconciliation');
+    await service.complete(run, { rows: 42 });
+
+    expect(metrics.recordSchedulerJobOutcome).toHaveBeenLastCalledWith(
+      'reconciliation',
+      'completed',
+      expect.any(Number),
+      expect.any(Date),
+    );
+    expect(run.status).toBe(JobRunStatus.COMPLETED);
+    expect(run.result).toEqual({ rows: 42 });
+  });
+
+  it('records a failed outcome with the error message', async () => {
+    const run = await service.start('reconciliation');
+    await service.fail(run, new Error('boom'));
+
+    expect(metrics.recordSchedulerJobOutcome).toHaveBeenLastCalledWith(
+      'reconciliation',
+      'failed',
+      expect.any(Number),
+      expect.any(Date),
+    );
+    expect(run.status).toBe(JobRunStatus.FAILED);
+    expect(run.errorMessage).toBe('boom');
+  });
+
+  it('records a skipped outcome when markSkipped is called', async () => {
+    await service.markSkipped('reconciliation');
+    expect(metrics.recordSchedulerJobOutcome).toHaveBeenCalledWith(
+      'reconciliation',
+      'skipped',
+      0,
+      expect.any(Date),
+    );
+  });
+
+  it('getLastSuccess() queries for the most recent COMPLETED run', async () => {
+    repo.findOne.mockResolvedValue({ jobName: 'reconciliation' });
+    await service.getLastSuccess('reconciliation');
+
+    expect(repo.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { jobName: 'reconciliation', status: JobRunStatus.COMPLETED },
+        order: { startedAt: 'DESC' },
+      }),
+    );
+  });
+
+  it('getLastFailure() queries for the most recent FAILED run', async () => {
+    repo.findOne.mockResolvedValue({ jobName: 'reconciliation' });
+    await service.getLastFailure('reconciliation');
+
+    expect(repo.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { jobName: 'reconciliation', status: JobRunStatus.FAILED },
+        order: { startedAt: 'DESC' },
+      }),
+    );
+  });
+});

--- a/apps/backend/src/scheduler/job-history.service.ts
+++ b/apps/backend/src/scheduler/job-history.service.ts
@@ -2,12 +2,14 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { JobRun, JobRunStatus } from './entities/job-run.entity';
+import { MetricsService } from '../metrics/metrics.service';
 
 @Injectable()
 export class JobHistoryService {
   constructor(
     @InjectRepository(JobRun)
     private readonly repo: Repository<JobRun>,
+    private readonly metrics: MetricsService,
   ) {}
 
   /** Create a RUNNING record and return it so callers can update it later. */
@@ -17,7 +19,14 @@ export class JobHistoryService {
       triggeredBy,
       status: JobRunStatus.RUNNING,
     });
-    return this.repo.save(run);
+    const saved = await this.repo.save(run);
+    this.metrics.recordSchedulerJobOutcome(
+      jobName,
+      'running',
+      null,
+      saved.startedAt,
+    );
+    return saved;
   }
 
   /** Mark a run as SKIPPED (lock was held). */
@@ -28,7 +37,13 @@ export class JobHistoryService {
       finishedAt: new Date(),
       durationMs: 0,
     });
-    await this.repo.save(run);
+    const saved = await this.repo.save(run);
+    this.metrics.recordSchedulerJobOutcome(
+      jobName,
+      'skipped',
+      0,
+      saved.startedAt,
+    );
   }
 
   /** Mark an existing run as COMPLETED with an optional result payload. */
@@ -38,6 +53,12 @@ export class JobHistoryService {
     run.finishedAt = new Date();
     run.durationMs = run.finishedAt.getTime() - run.startedAt.getTime();
     await this.repo.save(run);
+    this.metrics.recordSchedulerJobOutcome(
+      run.jobName,
+      'completed',
+      run.durationMs,
+      run.startedAt,
+    );
   }
 
   /** Mark an existing run as FAILED with an error message. */
@@ -47,6 +68,12 @@ export class JobHistoryService {
     run.finishedAt = new Date();
     run.durationMs = run.finishedAt.getTime() - run.startedAt.getTime();
     await this.repo.save(run);
+    this.metrics.recordSchedulerJobOutcome(
+      run.jobName,
+      'failed',
+      run.durationMs,
+      run.startedAt,
+    );
   }
 
   /** Fetch the N most recent runs for a given job name. */
@@ -62,6 +89,22 @@ export class JobHistoryService {
   async getLastRun(jobName: string): Promise<JobRun | null> {
     return this.repo.findOne({
       where: { jobName },
+      order: { startedAt: 'DESC' },
+    });
+  }
+
+  /** Fetch the most recent COMPLETED run for a given job name. */
+  async getLastSuccess(jobName: string): Promise<JobRun | null> {
+    return this.repo.findOne({
+      where: { jobName, status: JobRunStatus.COMPLETED },
+      order: { startedAt: 'DESC' },
+    });
+  }
+
+  /** Fetch the most recent FAILED run for a given job name. */
+  async getLastFailure(jobName: string): Promise<JobRun | null> {
+    return this.repo.findOne({
+      where: { jobName, status: JobRunStatus.FAILED },
       order: { startedAt: 'DESC' },
     });
   }

--- a/apps/backend/src/scheduler/job-lock.service.ts
+++ b/apps/backend/src/scheduler/job-lock.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { InjectDataSource } from '@nestjs/typeorm';
 import { DataSource } from 'typeorm';
+import { MetricsService } from '../metrics/metrics.service';
 
 /**
  * Distributed job locking via PostgreSQL advisory locks.
@@ -16,7 +17,10 @@ import { DataSource } from 'typeorm';
 export class JobLockService {
   private readonly logger = new Logger(JobLockService.name);
 
-  constructor(@InjectDataSource() private readonly dataSource: DataSource) {}
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly metrics: MetricsService,
+  ) {}
 
   /**
    * Try to acquire an advisory lock for the given job name.
@@ -33,6 +37,9 @@ export class JobLockService {
       this.logger.warn(
         `Job "${jobName}" skipped — lock held by another instance`,
       );
+      // Count every failed acquisition so lock contention between instances
+      // is visible in Prometheus / Grafana.
+      this.metrics.recordSchedulerLockContention(jobName);
     }
     return acquired;
   }

--- a/apps/backend/src/scheduler/job-registry.ts
+++ b/apps/backend/src/scheduler/job-registry.ts
@@ -1,0 +1,47 @@
+/**
+ * Registry of scheduled backend jobs that are tracked in the `job_runs`
+ * table via `JobHistoryService`.
+ *
+ * The expected interval is used by the scheduler health endpoint to decide
+ * whether a job is *stale* — i.e. it has not succeeded within the time it is
+ * supposed to run. Intervals must match the cron cadence of the corresponding
+ * `@Cron` decorator.
+ */
+export interface ScheduledJobDefinition {
+  /** Logical job name as recorded in `job_runs.jobName`. */
+  name: string;
+  /** Maximum acceptable time between successful runs, in milliseconds. */
+  expectedIntervalMs: number;
+  /** Human-readable description shown in health payloads. */
+  description: string;
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+export const SCHEDULED_JOBS: ScheduledJobDefinition[] = [
+  {
+    name: 'reconciliation',
+    expectedIntervalMs: 6 * HOUR_MS,
+    description:
+      'Reconciles on-chain state with the local database every 6 hours.',
+  },
+  {
+    name: 'daily-snapshot',
+    expectedIntervalMs: DAY_MS,
+    description:
+      'Aggregates yesterday data into the daily snapshot every 24 hours.',
+  },
+  {
+    name: 'model-retraining-daily',
+    expectedIntervalMs: DAY_MS,
+    description: 'Triggers the daily model retraining fallback every 24 hours.',
+  },
+];
+
+/** Look up a job definition by name. */
+export function getJobDefinition(
+  jobName: string,
+): ScheduledJobDefinition | undefined {
+  return SCHEDULED_JOBS.find((job) => job.name === jobName);
+}

--- a/apps/backend/src/scheduler/scheduler-health.controller.ts
+++ b/apps/backend/src/scheduler/scheduler-health.controller.ts
@@ -1,0 +1,66 @@
+import { Controller, Get, Res } from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiServiceUnavailableResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import type { Response } from 'express';
+import {
+  SchedulerHealthService,
+  SchedulerJobStatus,
+} from './scheduler-health.service';
+
+interface SchedulerHealthPayload {
+  status: 'ok' | 'error';
+  summary: 'healthy' | 'stale-jobs';
+  checkedAt: string;
+  staleJobs: SchedulerJobStatus[];
+  jobs: SchedulerJobStatus[];
+}
+
+@ApiTags('health')
+@Controller('health/schedulers')
+export class SchedulerHealthController {
+  constructor(private readonly schedulerHealth: SchedulerHealthService) {}
+
+  /**
+   * Surfaces any scheduled job that has not succeeded within its expected
+   * interval. Returns HTTP 200 when every registered job is healthy and
+   * HTTP 503 as soon as any job is stale, so the endpoint can be wired
+   * directly into load-balancer and uptime checks.
+   */
+  @Get()
+  @ApiOperation({
+    summary:
+      'Reports last run times, outcomes, durations, and staleness of scheduled jobs',
+    description:
+      'Each registered scheduled job reports its last start, last success, ' +
+      'last failure, and duration. Jobs that have not succeeded within their ' +
+      'expected interval are marked stale and cause HTTP 503.',
+  })
+  @ApiOkResponse({
+    description:
+      'All scheduled jobs succeeded within their expected intervals.',
+  })
+  @ApiServiceUnavailableResponse({
+    description:
+      'One or more scheduled jobs have not succeeded within their expected interval.',
+  })
+  async getSchedulerHealth(
+    @Res({ passthrough: true }) response: Response,
+  ): Promise<SchedulerHealthPayload> {
+    const jobs = await this.schedulerHealth.getJobStatuses();
+    const staleJobs = jobs.filter((job) => job.stale);
+
+    response.status(staleJobs.length > 0 ? 503 : 200);
+
+    return {
+      status: staleJobs.length > 0 ? 'error' : 'ok',
+      summary: staleJobs.length > 0 ? 'stale-jobs' : 'healthy',
+      checkedAt: new Date().toISOString(),
+      staleJobs,
+      jobs,
+    };
+  }
+}

--- a/apps/backend/src/scheduler/scheduler-health.service.spec.ts
+++ b/apps/backend/src/scheduler/scheduler-health.service.spec.ts
@@ -1,0 +1,229 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JobRun, JobRunStatus } from './entities/job-run.entity';
+import { JobHistoryService } from './job-history.service';
+import { SchedulerHealthService, isJobStale } from './scheduler-health.service';
+
+const SIX_HOURS_MS = 6 * 60 * 60 * 1000;
+
+describe('isJobStale (stale-job detection boundary)', () => {
+  const now = new Date('2026-08-27T12:00:00.000Z');
+
+  it('is not stale when the last success is more recent than the interval', () => {
+    const lastSuccess = new Date(now.getTime() - SIX_HOURS_MS + 60_000);
+    expect(isJobStale(lastSuccess, SIX_HOURS_MS, now)).toEqual({
+      stale: false,
+      reason: null,
+    });
+  });
+
+  it('is not stale when the last success is exactly at the interval boundary', () => {
+    // Boundary rule: exactly `now - interval` is still healthy, so transient
+    // scheduling jitter never trips the check.
+    const lastSuccess = new Date(now.getTime() - SIX_HOURS_MS);
+    expect(isJobStale(lastSuccess, SIX_HOURS_MS, now)).toEqual({
+      stale: false,
+      reason: null,
+    });
+  });
+
+  it('is stale when the last success is just beyond the interval boundary', () => {
+    const lastSuccess = new Date(now.getTime() - SIX_HOURS_MS - 1);
+    expect(isJobStale(lastSuccess, SIX_HOURS_MS, now)).toEqual({
+      stale: true,
+      reason: 'last-success-too-old',
+    });
+  });
+
+  it('is stale when the job has never succeeded', () => {
+    expect(isJobStale(null, SIX_HOURS_MS, now)).toEqual({
+      stale: true,
+      reason: 'never-succeeded',
+    });
+  });
+});
+
+describe('SchedulerHealthService', () => {
+  let service: SchedulerHealthService;
+  let jobHistory: {
+    getLastRun: jest.Mock;
+    getLastSuccess: jest.Mock;
+    getLastFailure: jest.Mock;
+  };
+
+  const now = new Date('2026-08-27T12:00:00.000Z');
+
+  const makeRun = (
+    jobName: string,
+    status: JobRunStatus,
+    startedAt: Date,
+    durationMs: number | null = 1000,
+  ): JobRun =>
+    ({
+      id: 'uuid',
+      jobName,
+      status,
+      startedAt,
+      finishedAt: startedAt,
+      durationMs,
+      triggeredBy: 'scheduled',
+      result: null,
+      errorMessage: null,
+    }) as JobRun;
+
+  beforeEach(async () => {
+    jobHistory = {
+      getLastRun: jest.fn(),
+      getLastSuccess: jest.fn(),
+      getLastFailure: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SchedulerHealthService,
+        { provide: JobHistoryService, useValue: jobHistory },
+      ],
+    }).compile();
+
+    service = module.get<SchedulerHealthService>(SchedulerHealthService);
+    jest.clearAllMocks();
+  });
+
+  it('reports last start, last success, last failure, and duration per job', async () => {
+    jobHistory.getLastRun.mockResolvedValue(
+      makeRun(
+        'reconciliation',
+        JobRunStatus.COMPLETED,
+        new Date(now.getTime() - 1000),
+        42_000,
+      ),
+    );
+    jobHistory.getLastSuccess.mockResolvedValue(
+      makeRun(
+        'reconciliation',
+        JobRunStatus.COMPLETED,
+        new Date(now.getTime() - 1000),
+        42_000,
+      ),
+    );
+    jobHistory.getLastFailure.mockResolvedValue(
+      makeRun(
+        'reconciliation',
+        JobRunStatus.FAILED,
+        new Date(now.getTime() - SIX_HOURS_MS - 60_000),
+        5000,
+      ),
+    );
+
+    const statuses = await service.getJobStatuses(now);
+    const reconciliation = statuses.find((s) => s.job === 'reconciliation');
+
+    expect(reconciliation).toMatchObject({
+      job: 'reconciliation',
+      lastStart: new Date(now.getTime() - 1000).toISOString(),
+      lastSuccess: new Date(now.getTime() - 1000).toISOString(),
+      lastFailure: new Date(
+        now.getTime() - SIX_HOURS_MS - 60_000,
+      ).toISOString(),
+      lastDurationMs: 42_000,
+      expectedIntervalMs: SIX_HOURS_MS,
+      stale: false,
+      staleReason: null,
+    });
+  });
+
+  it('marks a job stale when its last success is older than its interval', async () => {
+    jobHistory.getLastRun.mockResolvedValue(
+      makeRun(
+        'reconciliation',
+        JobRunStatus.FAILED,
+        new Date(now.getTime() - SIX_HOURS_MS - 60_000),
+        5000,
+      ),
+    );
+    jobHistory.getLastSuccess.mockResolvedValue(
+      makeRun(
+        'reconciliation',
+        JobRunStatus.COMPLETED,
+        new Date(now.getTime() - SIX_HOURS_MS - 60_000),
+      ),
+    );
+    jobHistory.getLastFailure.mockResolvedValue(
+      makeRun(
+        'reconciliation',
+        JobRunStatus.FAILED,
+        new Date(now.getTime() - SIX_HOURS_MS - 60_000),
+      ),
+    );
+
+    const statuses = await service.getJobStatuses(now);
+    const reconciliation = statuses.find((s) => s.job === 'reconciliation');
+
+    expect(reconciliation).toMatchObject({
+      stale: true,
+      staleReason: 'last-success-too-old',
+    });
+  });
+
+  it('marks a job stale when it has only ever failed (never succeeded)', async () => {
+    jobHistory.getLastRun.mockResolvedValue(
+      makeRun(
+        'daily-snapshot',
+        JobRunStatus.FAILED,
+        new Date(now.getTime() - 60_000),
+      ),
+    );
+    jobHistory.getLastSuccess.mockResolvedValue(null);
+    jobHistory.getLastFailure.mockResolvedValue(
+      makeRun(
+        'daily-snapshot',
+        JobRunStatus.FAILED,
+        new Date(now.getTime() - 60_000),
+      ),
+    );
+
+    const statuses = await service.getJobStatuses(now);
+    const snapshot = statuses.find((s) => s.job === 'daily-snapshot');
+
+    expect(snapshot).toMatchObject({
+      job: 'daily-snapshot',
+      stale: true,
+      staleReason: 'never-succeeded',
+    });
+  });
+
+  it('reports null run times for a job that has never run', async () => {
+    jobHistory.getLastRun.mockResolvedValue(null);
+    jobHistory.getLastSuccess.mockResolvedValue(null);
+    jobHistory.getLastFailure.mockResolvedValue(null);
+
+    const statuses = await service.getJobStatuses(now);
+    const snapshot = statuses.find((s) => s.job === 'daily-snapshot');
+
+    expect(snapshot).toMatchObject({
+      lastStart: null,
+      lastSuccess: null,
+      lastFailure: null,
+      lastDurationMs: null,
+      stale: true,
+      staleReason: 'never-succeeded',
+    });
+  });
+
+  it('getStaleJobs() returns only the jobs whose success predates their interval', async () => {
+    // Last success 12h ago: stale for the 6h reconciliation job, healthy for
+    // the 24h snapshot/retraining jobs.
+    const lastSuccess = new Date(now.getTime() - 12 * 60 * 60 * 1000);
+    jobHistory.getLastRun.mockResolvedValue(
+      makeRun('reconciliation', JobRunStatus.COMPLETED, lastSuccess),
+    );
+    jobHistory.getLastSuccess.mockResolvedValue(
+      makeRun('reconciliation', JobRunStatus.COMPLETED, lastSuccess),
+    );
+    jobHistory.getLastFailure.mockResolvedValue(null);
+
+    const stale = await service.getStaleJobs(now);
+
+    expect(stale.map((s) => s.job)).toEqual(['reconciliation']);
+    expect(stale.every((s) => s.stale)).toBe(true);
+  });
+});

--- a/apps/backend/src/scheduler/scheduler-health.service.ts
+++ b/apps/backend/src/scheduler/scheduler-health.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { JobHistoryService } from './job-history.service';
+import { SCHEDULED_JOBS } from './job-registry';
+
+/** Per-job status summary surfaced by the scheduler health endpoint. */
+export interface SchedulerJobStatus {
+  job: string;
+  description: string;
+  /** ISO timestamp of the most recent run start, or null if never run. */
+  lastStart: string | null;
+  /** ISO timestamp of the most recent successful run, or null. */
+  lastSuccess: string | null;
+  /** ISO timestamp of the most recent failed run, or null. */
+  lastFailure: string | null;
+  /** Duration in milliseconds of the most recent completed run, or null. */
+  lastDurationMs: number | null;
+  /** Expected maximum interval between successful runs. */
+  expectedIntervalMs: number;
+  /** True when the job has not succeeded within its expected interval. */
+  stale: boolean;
+  /** Machine-readable reason for staleness, or null when healthy. */
+  staleReason: 'never-succeeded' | 'last-success-too-old' | null;
+}
+
+/**
+ * Decide whether a job is stale.
+ *
+ * Boundary rule: a job is stale when its last success is *strictly older* than
+ * the expected interval. A run that succeeded exactly at the interval boundary
+ * (i.e. `lastSuccessAt === now - expectedIntervalMs`) is still considered
+ * healthy, so transient scheduling jitter never trips the check.
+ */
+export function isJobStale(
+  lastSuccessAt: Date | null,
+  expectedIntervalMs: number,
+  now: Date = new Date(),
+): { stale: boolean; reason: SchedulerJobStatus['staleReason'] } {
+  if (lastSuccessAt === null) {
+    return { stale: true, reason: 'never-succeeded' };
+  }
+  const cutoff = now.getTime() - expectedIntervalMs;
+  if (lastSuccessAt.getTime() < cutoff) {
+    return { stale: true, reason: 'last-success-too-old' };
+  }
+  return { stale: false, reason: null };
+}
+
+/**
+ * Unified visibility into the backend's scheduled jobs: last run times,
+ * outcomes, durations, and staleness relative to each job's expected interval.
+ *
+ * Consumed by the `GET /health/schedulers` endpoint and by operators
+ * investigating multi-instance lock contention.
+ */
+@Injectable()
+export class SchedulerHealthService {
+  private readonly logger = new Logger(SchedulerHealthService.name);
+
+  constructor(private readonly jobHistory: JobHistoryService) {}
+
+  /** Status summary for every registered scheduled job. */
+  async getJobStatuses(now: Date = new Date()): Promise<SchedulerJobStatus[]> {
+    const statuses = await Promise.all(
+      SCHEDULED_JOBS.map(async (job) => {
+        const [lastRun, lastSuccess, lastFailure] = await Promise.all([
+          this.jobHistory.getLastRun(job.name),
+          this.jobHistory.getLastSuccess(job.name),
+          this.jobHistory.getLastFailure(job.name),
+        ]);
+
+        const { stale, reason } = isJobStale(
+          lastSuccess ? lastSuccess.startedAt : null,
+          job.expectedIntervalMs,
+          now,
+        );
+
+        return {
+          job: job.name,
+          description: job.description,
+          lastStart: lastRun ? lastRun.startedAt.toISOString() : null,
+          lastSuccess: lastSuccess ? lastSuccess.startedAt.toISOString() : null,
+          lastFailure: lastFailure ? lastFailure.startedAt.toISOString() : null,
+          lastDurationMs: lastRun?.durationMs ?? null,
+          expectedIntervalMs: job.expectedIntervalMs,
+          stale,
+          staleReason: stale ? reason : null,
+        };
+      }),
+    );
+
+    return statuses;
+  }
+
+  /** Only the jobs that have not succeeded within their expected interval. */
+  async getStaleJobs(now?: Date): Promise<SchedulerJobStatus[]> {
+    const statuses = await this.getJobStatuses(now);
+    return statuses.filter((status) => status.stale);
+  }
+}

--- a/apps/backend/src/scheduler/scheduler.module.ts
+++ b/apps/backend/src/scheduler/scheduler.module.ts
@@ -3,10 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { JobRun } from './entities/job-run.entity';
 import { JobLockService } from './job-lock.service';
 import { JobHistoryService } from './job-history.service';
+import { SchedulerHealthService } from './scheduler-health.service';
+import { SchedulerHealthController } from './scheduler-health.controller';
 
 /**
  * Shared module that provides distributed job locking (PostgreSQL advisory
- * locks) and a unified job-run history store.
+ * locks), a unified job-run history store, and scheduler health visibility
+ * (last run times, staleness, lock contention).
  *
  * Import into any feature module whose scheduler needs hardening:
  *
@@ -14,7 +17,8 @@ import { JobHistoryService } from './job-history.service';
  */
 @Module({
   imports: [TypeOrmModule.forFeature([JobRun])],
-  providers: [JobLockService, JobHistoryService],
+  providers: [JobLockService, JobHistoryService, SchedulerHealthService],
+  controllers: [SchedulerHealthController],
   exports: [JobLockService, JobHistoryService],
 })
 export class SchedulerModule {}


### PR DESCRIPTION
## Summary

Adds unified health and lock-contention visibility to the backend's scheduled jobs (`reconciliation`, `daily-snapshot`, `model-retraining-daily`).

### Changes

- **`GET /health/schedulers`** — reports last start, last success, last failure, duration, and expected interval for every registered scheduled job. Returns HTTP 503 whenever any job has not succeeded within its expected interval (stale-job detection with a strict boundary: a run exactly at the interval edge is still healthy).
- **Job registry** (`scheduler/job-registry.ts`) — declares each tracked job and its expected interval.
- **Metrics for Grafana** — new Prometheus metrics:
  - `lumenpulse_scheduler_job_runs_total{job,status}`
  - `lumenpulse_scheduler_job_last_success_timestamp_seconds{job}`
  - `lumenpulse_scheduler_job_last_failure_timestamp_seconds{job}`
  - `lumenpulse_scheduler_job_duration_seconds{job}`
  - `lumenpulse_scheduler_lock_contention_total{job}`
- **Lock contention counting** — `JobLockService` now counts every failed advisory-lock acquisition; `JobHistoryService` emits outcome metrics on start/complete/fail/skipped.
- **Tests** — cover the stale-job detection boundary (exactly-at-interval vs just-past), per-job status reporting, never-succeeded detection, and metric emission.

### Verification

- `npm test` — 659 passed
- `npm run build` — clean
- `npm run lint` — no errors

Closes #1208
