### PR TITLE
feat(backend): reviewer assignment and triage queue API

### DIFF
--- a/apps/backend/src/moderation/dto/assign-reviewer.dto.ts
+++ b/apps/backend/src/moderation/dto/assign-reviewer.dto.ts
@@ -1,0 +1,12 @@
+import { IsOptional, IsString } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class AssignReviewerDto {
+  @ApiPropertyOptional({
+    description: 'The ID of the reviewer to assign. Null to unassign.',
+    example: 'uuid-1234',
+  })
+  @IsOptional()
+  @IsString()
+  reviewerId?: string;
+}

--- a/apps/backend/src/moderation/dto/query-reports.dto.ts
+++ b/apps/backend/src/moderation/dto/query-reports.dto.ts
@@ -44,4 +44,12 @@ export class QueryReportsDto {
   @IsOptional()
   @IsString()
   limit?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by assigned reviewer ID, or "unassigned" to get reports without a reviewer',
+    example: 'uuid-1234',
+  })
+  @IsOptional()
+  @IsString()
+  reviewerId?: string;
 }

--- a/apps/backend/src/moderation/moderation.controller.ts
+++ b/apps/backend/src/moderation/moderation.controller.ts
@@ -24,6 +24,7 @@ import { ModerationService } from './moderation.service';
 import { CreateReportDto } from './dto/create-report.dto';
 import { UpdateReportDto } from './dto/update-report.dto';
 import { QueryReportsDto } from './dto/query-reports.dto';
+import { AssignReviewerDto } from './dto/assign-reviewer.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/decorators/auth.decorators';
@@ -129,4 +130,24 @@ export class ModerationController {
       updateReportDto,
     );
   }
+
+  @Patch('queue/:id/assign')
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @UsePipes(new ValidationPipe())
+  @ApiOperation({ summary: 'Assign a reviewer to a report (Admin only)' })
+  @ApiResponse({ status: 200, description: 'Reviewer assigned successfully' })
+  @ApiResponse({ status: 404, description: 'Report not found' })
+  async assignReviewer(
+    @Req() req: RequestWithUser,
+    @Param('id') id: string,
+    @Body() assignReviewerDto: AssignReviewerDto,
+  ) {
+    return this.moderationService.assignReviewer(
+      id,
+      req.user.id,
+      assignReviewerDto.reviewerId,
+    );
+  }
 }
+

--- a/apps/backend/src/moderation/moderation.module.ts
+++ b/apps/backend/src/moderation/moderation.module.ts
@@ -5,6 +5,7 @@ import { ModerationService } from './moderation.service';
 import { ModerationController } from './moderation.controller';
 import { ContentReport } from './entities/content-report.entity';
 import { ModerationEventPublisherService } from './services/moderation-event-publisher.service';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
   imports: [
@@ -12,6 +13,7 @@ import { ModerationEventPublisherService } from './services/moderation-event-pub
     BullModule.registerQueue({
       name: 'moderation-events',
     }),
+    AuditModule,
   ],
   providers: [ModerationService, ModerationEventPublisherService],
   controllers: [ModerationController],

--- a/apps/backend/src/moderation/moderation.service.ts
+++ b/apps/backend/src/moderation/moderation.service.ts
@@ -12,6 +12,8 @@ import { UpdateReportDto } from './dto/update-report.dto';
 import { QueryReportsDto } from './dto/query-reports.dto';
 import { ModerationEventPublisherService } from './services/moderation-event-publisher.service';
 
+import { AuditService } from '../audit/audit.service';
+
 @Injectable()
 export class ModerationService {
   private readonly logger = new Logger(ModerationService.name);
@@ -20,6 +22,7 @@ export class ModerationService {
     @InjectRepository(ContentReport)
     private reportsRepository: Repository<ContentReport>,
     private readonly eventPublisher: ModerationEventPublisherService,
+    private readonly auditService: AuditService,
   ) {}
 
   /**
@@ -123,6 +126,16 @@ export class ModerationService {
       queryBuilder.andWhere('report.targetId = :targetId', {
         targetId: query.targetId,
       });
+    }
+
+    if (query.reviewerId !== undefined) {
+      if (query.reviewerId === 'unassigned') {
+        queryBuilder.andWhere('report.reviewerId IS NULL');
+      } else {
+        queryBuilder.andWhere('report.reviewerId = :reviewerId', {
+          reviewerId: query.reviewerId,
+        });
+      }
     }
 
     const [reports, total] = await queryBuilder.getManyAndCount();
@@ -238,6 +251,40 @@ export class ModerationService {
     };
 
     return mapping[status];
+  }
+
+  /**
+   * Assign a reviewer to a report
+   */
+  async assignReviewer(
+    id: string,
+    assignerId: string,
+    reviewerId?: string,
+  ): Promise<ContentReport> {
+    const report = await this.getReportById(id);
+    const previousReviewerId = report.reviewerId;
+
+    if (report.status !== ReportStatus.PENDING && report.status !== ReportStatus.UNDER_REVIEW) {
+      throw new BadRequestException(
+        `Cannot assign reviewer to report in status ${report.status}`,
+      );
+    }
+
+    report.reviewerId = reviewerId || null;
+    const updatedReport = await this.reportsRepository.save(report);
+
+    this.logger.log(
+      `Report ${id} reviewer updated to ${reviewerId || 'unassigned'} by ${assignerId}`,
+    );
+
+    await this.auditService.log(
+      'assign_moderation_report_reviewer',
+      assignerId,
+      null,
+      { reportId: id, previousReviewerId, newReviewerId: reviewerId || null }
+    );
+
+    return updatedReport;
   }
 
   /**

--- a/apps/backend/src/verification/dto/verification.dto.ts
+++ b/apps/backend/src/verification/dto/verification.dto.ts
@@ -304,3 +304,14 @@ export class ProjectSubmissionDto {
   @ApiProperty({ example: 1775000000 })
   updatedAt: number;
 }
+
+export class AssignSubmissionReviewerDto {
+  @ApiProperty({
+    description: 'ID of the reviewer to assign (or null to unassign)',
+    required: false,
+    example: 'uuid-1234',
+  })
+  @IsOptional()
+  @IsString()
+  reviewerId?: string;
+}

--- a/apps/backend/src/verification/verification.controller.ts
+++ b/apps/backend/src/verification/verification.controller.ts
@@ -5,8 +5,10 @@ import {
   Param,
   ParseIntPipe,
   Post,
+  Patch,
   Put,
   Query,
+  Req,
   UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
@@ -31,6 +33,7 @@ import {
   ProjectSubmissionDto,
   SubmissionStatus,
   SubmissionActionDto,
+  AssignSubmissionReviewerDto,
 } from './dto/verification.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
@@ -200,13 +203,17 @@ export class VerificationController {
       'Returns project submissions across draft/review/approval/publish workflow states.',
   })
   @ApiQuery({ name: 'status', required: false, enum: SubmissionStatus })
+  @ApiQuery({ name: 'reviewerId', required: false, description: 'Filter by reviewer ID or "unassigned"' })
   @ApiResponse({
     status: 200,
     description: 'Submission records retrieved successfully',
     type: [ProjectSubmissionDto],
   })
-  listSubmissions(@Query('status') status?: SubmissionStatus) {
-    return this.svc.listSubmissions(status);
+  listSubmissions(
+    @Query('status') status?: SubmissionStatus,
+    @Query('reviewerId') reviewerId?: string,
+  ) {
+    return this.svc.listSubmissions(status, reviewerId);
   }
 
   @Get('submissions/:id')
@@ -260,6 +267,21 @@ export class VerificationController {
     @Body() dto: SubmissionActionDto,
   ) {
     return this.svc.requestSubmissionChanges(id, dto);
+  }
+
+  @Patch('submissions/:id/assign')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth('JWT-auth')
+  @Roles(UserRole.ADMIN)
+  @ApiOperation({
+    summary: 'Assign a reviewer to a submission (Admin only)',
+  })
+  assignReviewer(
+    @Req() req: any,
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: AssignSubmissionReviewerDto,
+  ) {
+    return this.svc.assignReviewer(id, req.user.id, dto.reviewerId);
   }
 
   @Post('submissions/:id/approve')

--- a/apps/backend/src/verification/verification.module.ts
+++ b/apps/backend/src/verification/verification.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { VerificationController } from './verification.controller';
 import { VerificationService } from './verification.service';
 import { AdminAuditModule } from '../admin-audit/admin-audit.module';
+import { AuditModule } from '../audit/audit.module';
 
 @Module({
-  imports: [AdminAuditModule],
+  imports: [AdminAuditModule, AuditModule],
   controllers: [VerificationController],
   providers: [VerificationService],
   exports: [VerificationService],

--- a/apps/backend/src/verification/verification.service.ts
+++ b/apps/backend/src/verification/verification.service.ts
@@ -56,6 +56,8 @@ interface ProjectSubmissionRecord {
   updatedAt: number;
 }
 
+import { AuditService } from '../audit/audit.service';
+
 @Injectable()
 export class VerificationService {
   private readonly logger = new Logger(VerificationService.name);
@@ -63,7 +65,10 @@ export class VerificationService {
   private submissions = new Map<number, ProjectSubmissionRecord>();
   private config: RegistryConfig;
 
-  constructor(private readonly configSvc: ConfigService) {
+  constructor(
+    private readonly configSvc: ConfigService,
+    private readonly auditService: AuditService,
+  ) {
     this.config = {
       quorumThreshold: Number(this.configSvc.get('VERIFICATION_QUORUM', '100')),
       weightMode: this.configSvc.get(
@@ -303,9 +308,14 @@ export class VerificationService {
     return this.toSubmissionDto(this.getSubmissionRecord(projectId));
   }
 
-  listSubmissions(status?: SubmissionStatus): ProjectSubmissionDto[] {
+  listSubmissions(status?: SubmissionStatus, reviewerId?: string): ProjectSubmissionDto[] {
     return [...this.submissions.values()]
       .filter((submission) => !status || submission.status === status)
+      .filter((submission) => {
+        if (reviewerId === undefined) return true;
+        if (reviewerId === 'unassigned') return !submission.reviewerId;
+        return submission.reviewerId === reviewerId;
+      })
       .map((submission) => this.toSubmissionDto(submission));
   }
 
@@ -378,6 +388,37 @@ export class VerificationService {
     submission.reviewerId = dto.actorId;
     submission.reviewNote = dto.note;
     submission.updatedAt = Math.floor(Date.now() / 1000);
+    return this.toSubmissionDto(submission);
+  }
+
+  async assignReviewer(
+    projectId: number,
+    assignerId: string,
+    reviewerId?: string,
+  ): Promise<ProjectSubmissionDto> {
+    const submission = this.getSubmissionRecord(projectId);
+    const previousReviewerId = submission.reviewerId;
+
+    if (submission.status === SubmissionStatus.Published) {
+      throw new BadRequestException(
+        `Cannot assign reviewer to published submission ${projectId}`,
+      );
+    }
+
+    submission.reviewerId = reviewerId;
+    submission.updatedAt = Math.floor(Date.now() / 1000);
+
+    this.logger.log(
+      `Submission ${projectId} reviewer updated to ${reviewerId || 'unassigned'} by ${assignerId}`,
+    );
+
+    await this.auditService.log(
+      'assign_submission_reviewer',
+      assignerId,
+      null,
+      { projectId, previousReviewerId, newReviewerId: reviewerId || null }
+    );
+
     return this.toSubmissionDto(submission);
   }
 


### PR DESCRIPTION
Closes #1078 

Resolves backend requirements for reviewer assignments and a triage queue API.

**Changes:**
- **Moderation Module:** 
  - Added `assignReviewer` functionality in `ModerationService` to assign a reviewer to pending or under-review moderation items.
  - Added the `PATCH /moderation/queue/:id/assign` endpoint with a corresponding `AssignReviewerDto`.
  - Added a `reviewerId` query filter to `QueryReportsDto` and exposed it in `getReports`.
  
- **Verification/Submissions Module:**
  - Added `assignReviewer` functionality in `VerificationService` to assign reviewers to drafted/submitted project submissions.
  - Added the `PATCH /submissions/:id/assign` endpoint with `AssignSubmissionReviewerDto`.
  - Added a `reviewerId` query filter to the `listSubmissions` triage queue endpoint to return specific reviewer assignments or unassigned queues.
  
- **Auditing:**
  - Integrated `AuditService` into both `ModerationService` and `VerificationService`.
  - Safely audits `assign_moderation_report_reviewer` and `assign_submission_reviewer` events, capturing the `assignerId` and reviewer transition metadata without leaking sensitive data.