### PR TITLE
fix: add soroban simulation trace logs

### DIFF
--- a/apps/backend/src/lib/config.spec.ts
+++ b/apps/backend/src/lib/config.spec.ts
@@ -117,6 +117,7 @@ describe('config validation', () => {
 
     expect(config.rateLimit.global.limit).toBe(300);
     expect(config.logging.level).toBe('log');
+    expect(config.stellar.simulationTraceLevel).toBe('summary');
   });
 });
 

--- a/apps/backend/src/lib/config.ts
+++ b/apps/backend/src/lib/config.ts
@@ -38,6 +38,7 @@ import { z } from 'zod';
  * - STELLAR_TIMEOUT
  * - STELLAR_RETRY_ATTEMPTS
  * - STELLAR_RETRY_DELAY
+ * - SOROBAN_SIMULATION_TRACE_LEVEL
  * - STELLAR_CONTRACT_LUMEN_TOKEN
  * - STELLAR_CONTRACT_CROWDFUND_VAULT
  * - STELLAR_CONTRACT_PROJECT_REGISTRY
@@ -442,6 +443,9 @@ const envSchema = z
     STELLAR_TIMEOUT: z.coerce.number().int().min(1).default(30_000),
     STELLAR_RETRY_ATTEMPTS: z.coerce.number().int().min(0).default(3),
     STELLAR_RETRY_DELAY: z.coerce.number().int().min(0).default(1_000),
+    SOROBAN_SIMULATION_TRACE_LEVEL: z
+      .enum(['off', 'summary', 'verbose'])
+      .default('summary'),
     STELLAR_SERVER_SECRET: z.string().min(1), // SECRET — never log
     STELLAR_BALANCE_CACHE_TTL: z.coerce.number().int().min(1).default(30_000),
     STELLAR_OPERATIONS_CACHE_TTL: z.coerce
@@ -912,6 +916,10 @@ const optionalSummary = [
   ['STELLAR_RETRY_ATTEMPTS', String(parsedEnv.STELLAR_RETRY_ATTEMPTS)],
   ['STELLAR_RETRY_DELAY', String(parsedEnv.STELLAR_RETRY_DELAY)],
   [
+    'SOROBAN_SIMULATION_TRACE_LEVEL',
+    parsedEnv.SOROBAN_SIMULATION_TRACE_LEVEL,
+  ],
+  [
     'STELLAR_CONTRACT_LUMEN_TOKEN',
     parsedEnv.STELLAR_CONTRACT_LUMEN_TOKEN ?? '(not set)',
   ],
@@ -1116,6 +1124,7 @@ export const config = Object.freeze({
     timeout: parsedEnv.STELLAR_TIMEOUT,
     retryAttempts: parsedEnv.STELLAR_RETRY_ATTEMPTS,
     retryDelay: parsedEnv.STELLAR_RETRY_DELAY,
+    simulationTraceLevel: parsedEnv.SOROBAN_SIMULATION_TRACE_LEVEL,
     balanceCacheTTL: parsedEnv.STELLAR_BALANCE_CACHE_TTL,
     operationsCacheTTL: parsedEnv.STELLAR_OPERATIONS_CACHE_TTL,
     serverSecret: new SecretString(parsedEnv.STELLAR_SERVER_SECRET),

--- a/apps/backend/src/stellar/services/soroban-rpc-client.service.spec.ts
+++ b/apps/backend/src/stellar/services/soroban-rpc-client.service.spec.ts
@@ -1,0 +1,138 @@
+const mockConfig = {
+  stellar: {
+    network: 'testnet' as const,
+    sorobanRpcUrl: 'https://soroban-testnet.stellar.org',
+    timeout: 3000,
+    simulationTraceLevel: 'summary' as 'off' | 'summary' | 'verbose',
+  },
+};
+
+jest.mock('../../lib/config', () => ({
+  config: mockConfig,
+}));
+
+import { Logger } from '@nestjs/common';
+import {
+  Account,
+  BASE_FEE,
+  Contract,
+  Networks,
+  rpc,
+  TransactionBuilder,
+} from '@stellar/stellar-sdk';
+import { Registry } from 'prom-client';
+import { RequestContextService } from '../../common/services/request-context.service';
+import {
+  SorobanErrorCode,
+  SorobanRpcClientService,
+} from './soroban-rpc-client.service';
+
+describe('SorobanRpcClientService simulation trace logging', () => {
+  let service: SorobanRpcClientService;
+  let errorSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+
+  const simulationError = {
+    error: 'HostError: Error(Contract, #3)',
+    events: ['raw-event-xdr-that-should-not-be-logged'],
+    transactionData: 'raw-transaction-data-that-should-not-be-logged',
+    cost: {
+      cpuInsns: '12000',
+      memBytes: '4096',
+    },
+  } as unknown as rpc.Api.SimulateTransactionErrorResponse;
+
+  beforeEach(() => {
+    mockConfig.stellar.simulationTraceLevel = 'summary';
+    service = new SorobanRpcClientService(
+      {
+        getRequestId: jest.fn(() => 'req-858'),
+      } as unknown as RequestContextService,
+      new Registry(),
+    );
+    (service as unknown as { server: { simulateTransaction: jest.Mock } }).server =
+      {
+        simulateTransaction: jest.fn().mockResolvedValue(simulationError),
+      };
+
+    jest.spyOn(rpc.Api, 'isSimulationError').mockReturnValue(true);
+    errorSpy = jest
+      .spyOn(Logger.prototype, 'error')
+      .mockImplementation(() => undefined);
+    warnSpy = jest
+      .spyOn(Logger.prototype, 'warn')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('logs request-scoped failed simulation summary without raw payloads', async () => {
+    const tx = new TransactionBuilder(
+      new Account('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', '1'),
+      { fee: BASE_FEE, networkPassphrase: Networks.TESTNET },
+    )
+      .addOperation(
+        new Contract(
+          'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4',
+        ).call('create_round'),
+      )
+      .setTimeout(30)
+      .build();
+    (tx as unknown as { secret: string }).secret = 'do-not-log-this-secret';
+
+    await expect(
+      service.simulateTransaction(tx, { maxRetries: 0 }),
+    ).rejects.toMatchObject({
+      code: SorobanErrorCode.SIMULATION_FAILED,
+    });
+
+    const trace = errorSpy.mock.calls[0][0];
+    expect(trace).toMatchObject({
+      event: 'soroban.simulation.failed',
+      requestId: 'req-858',
+      network: 'testnet',
+      contract: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4',
+      method: 'create_round',
+      operationCount: 1,
+      operationTypes: ['invokeHostFunction'],
+      simulationSummary: {
+        status: 'failed',
+        error: 'HostError: Error(Contract, #3)',
+        eventCount: 1,
+        hasTransactionData: true,
+        cost: {
+          cpuInsns: '12000',
+          memBytes: '4096',
+        },
+      },
+    });
+
+    const serializedTrace = JSON.stringify(trace);
+    expect(serializedTrace).not.toContain('do-not-log-this-secret');
+    expect(serializedTrace).not.toContain('raw-event-xdr');
+    expect(serializedTrace).not.toContain('raw-transaction-data');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: 'req-858' }),
+      'Soroban RPC call failed',
+    );
+  });
+
+  it('does not emit simulation trace logs when disabled', async () => {
+    mockConfig.stellar.simulationTraceLevel = 'off';
+
+    await expect(
+      service.simulateTransaction(
+        {
+          operations: [{ contractId: 'CAAA', method: 'deposit' }],
+        } as never,
+        { maxRetries: 0 },
+      ),
+    ).rejects.toMatchObject({
+      code: SorobanErrorCode.SIMULATION_FAILED,
+    });
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/stellar/services/soroban-rpc-client.service.ts
+++ b/apps/backend/src/stellar/services/soroban-rpc-client.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import {
   rpc,
   Account,
+  Address,
   TransactionBuilder,
   BASE_FEE,
   Contract,
@@ -34,6 +35,29 @@ export interface SorobanClientOptions {
   timeoutMs?: number;
   maxRetries?: number;
   initialBackoffMs?: number;
+}
+
+type SimulationTraceLevel = 'off' | 'summary' | 'verbose';
+
+interface ContractInvocationSummary {
+  contract: string;
+  method: string;
+  operationCount: number;
+  operationTypes: string[];
+  source?: string;
+}
+
+interface SimulationSummary {
+  status: 'failed';
+  error: string;
+  eventCount?: number;
+  hasTransactionData?: boolean;
+  hasRestorePreamble?: boolean;
+  minResourceFee?: string;
+  cost?: {
+    cpuInsns?: string;
+    memBytes?: string;
+  };
 }
 
 const DEFAULT_OPTIONS: Required<SorobanClientOptions> = {
@@ -111,9 +135,11 @@ export class SorobanRpcClientService {
     return this.withRetry('simulateTransaction', opts, async () => {
       const result = await this.server.simulateTransaction(tx);
       if (rpc.Api.isSimulationError(result)) {
+        this.logFailedSimulationTrace(tx, result);
         throw new SorobanRpcError(
           SorobanErrorCode.SIMULATION_FAILED,
           `Simulation failed: ${result.error ?? 'Unknown error'}`,
+          result,
         );
       }
       return result;
@@ -252,10 +278,231 @@ export class SorobanRpcClientService {
         },
         (e: unknown) => {
           clearTimeout(id);
-          reject(new Error(e instanceof Error ? e.message : String(e)));
+          reject(e instanceof Error ? e : new Error(String(e)));
         },
       );
     });
+  }
+
+  private logFailedSimulationTrace(
+    tx: Parameters<rpc.Server['simulateTransaction']>[0],
+    result: rpc.Api.SimulateTransactionErrorResponse,
+  ): void {
+    const traceLevel = config.stellar
+      .simulationTraceLevel as SimulationTraceLevel;
+    if (traceLevel === 'off') {
+      return;
+    }
+
+    const requestId = this.requestContextService.getRequestId();
+    const invocation = this.extractContractInvocation(tx);
+    const simulationSummary = this.buildSimulationSummary(result);
+
+    const trace = {
+      event: 'soroban.simulation.failed',
+      requestId,
+      network: config.stellar.network,
+      contract: invocation.contract,
+      method: invocation.method,
+      simulationSummary,
+      operationCount: invocation.operationCount,
+      operationTypes: invocation.operationTypes,
+      ...(traceLevel === 'verbose' && invocation.source
+        ? { transactionSource: invocation.source }
+        : {}),
+    };
+
+    this.logger.error(trace, 'Soroban simulation trace captured');
+  }
+
+  private extractContractInvocation(
+    tx: Parameters<rpc.Server['simulateTransaction']>[0],
+  ): ContractInvocationSummary {
+    const record = this.asRecord(tx);
+    const operations = Array.isArray(record.operations)
+      ? record.operations
+      : [];
+    const operationTypes = operations.map((op) =>
+      this.safeString(this.asRecord(op).type ?? 'unknown'),
+    );
+    const source = this.safeString(
+      record.source ?? record.sourceAccount ?? record.sourceAccountId,
+    );
+
+    for (const op of operations) {
+      const operation = this.asRecord(op);
+      const directContract = this.safeString(
+        operation.contractId ??
+          operation.contract ??
+          operation.contractAddress ??
+          operation.address,
+      );
+      const directMethod = this.safeString(
+        operation.method ??
+          operation.functionName ??
+          operation.function ??
+          operation.name,
+      );
+
+      if (directContract !== 'unknown' || directMethod !== 'unknown') {
+        return {
+          contract: directContract,
+          method: directMethod,
+          operationCount: operations.length,
+          operationTypes,
+          ...(source !== 'unknown' ? { source } : {}),
+        };
+      }
+
+      const hostFunction = operation.func ?? operation.hostFunction;
+      const extracted = this.extractHostFunctionInvocation(hostFunction);
+      if (extracted.contract !== 'unknown' || extracted.method !== 'unknown') {
+        return {
+          ...extracted,
+          operationCount: operations.length,
+          operationTypes,
+          ...(source !== 'unknown' ? { source } : {}),
+        };
+      }
+    }
+
+    return {
+      contract: 'unknown',
+      method: 'unknown',
+      operationCount: operations.length,
+      operationTypes,
+      ...(source !== 'unknown' ? { source } : {}),
+    };
+  }
+
+  private extractHostFunctionInvocation(hostFunction: unknown): {
+    contract: string;
+    method: string;
+  } {
+    try {
+      const hostRecord = this.asRecord(hostFunction);
+      const unionValue = this.asRecord(hostRecord._value);
+      const unionInvocation = this.extractInvocationFields(unionValue);
+      if (
+        unionInvocation.contract !== 'unknown' ||
+        unionInvocation.method !== 'unknown'
+      ) {
+        return unionInvocation;
+      }
+
+      const invokeContract = (
+        hostFunction as { invokeContract?: () => unknown } | undefined
+      )?.invokeContract;
+      if (typeof invokeContract !== 'function') {
+        return { contract: 'unknown', method: 'unknown' };
+      }
+
+      const invocation = this.asRecord(invokeContract.call(hostFunction));
+      return this.extractInvocationFields(invocation);
+    } catch {
+      return { contract: 'unknown', method: 'unknown' };
+    }
+  }
+
+  private extractInvocationFields(invocation: Record<string, unknown>): {
+    contract: string;
+    method: string;
+  } {
+    const attrs = this.asRecord(invocation._attributes);
+    return {
+      contract: this.safeString(this.toStellarAddress(invocation)),
+      method: this.safeString(
+        this.readRecordField(invocation, 'functionName') ?? attrs.functionName,
+      ),
+    };
+  }
+
+  private buildSimulationSummary(
+    result: rpc.Api.SimulateTransactionErrorResponse,
+  ): SimulationSummary {
+    const record = this.asRecord(result);
+    const cost = this.asRecord(record.cost);
+    const summary: SimulationSummary = {
+      status: 'failed',
+      error: this.safeString(record.error ?? 'Unknown error', 500),
+    };
+
+    if (Array.isArray(record.events)) {
+      summary.eventCount = record.events.length;
+    }
+
+    if (record.transactionData) {
+      summary.hasTransactionData = true;
+    }
+
+    if (record.restorePreamble) {
+      summary.hasRestorePreamble = true;
+    }
+
+    if (record.minResourceFee !== undefined) {
+      summary.minResourceFee = this.safeString(record.minResourceFee);
+    }
+
+    if (cost.cpuInsns !== undefined || cost.memBytes !== undefined) {
+      summary.cost = {
+        ...(cost.cpuInsns !== undefined
+          ? { cpuInsns: this.safeString(cost.cpuInsns) }
+          : {}),
+        ...(cost.memBytes !== undefined
+          ? { memBytes: this.safeString(cost.memBytes) }
+          : {}),
+      };
+    }
+
+    return summary;
+  }
+
+  private asRecord(value: unknown): Record<string, unknown> {
+    return value && typeof value === 'object'
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  private callIfFunction(value: unknown): unknown {
+    return typeof value === 'function' ? value() : value;
+  }
+
+  private readRecordField(
+    record: Record<string, unknown>,
+    key: string,
+  ): unknown {
+    const value = record[key];
+    return typeof value === 'function' ? value.call(record) : value;
+  }
+
+  private toStellarAddress(invocation: Record<string, unknown>): string {
+    const attrs = this.asRecord(invocation._attributes);
+    const contractAddress =
+      this.readRecordField(invocation, 'contractAddress') ??
+      attrs.contractAddress;
+    if (!contractAddress) {
+      return 'unknown';
+    }
+
+    try {
+      return Address.fromScAddress(contractAddress as never).toString();
+    } catch {
+      return this.safeString(contractAddress);
+    }
+  }
+
+  private safeString(value: unknown, maxLength = 120): string {
+    if (value === undefined || value === null) {
+      return 'unknown';
+    }
+
+    const raw =
+      typeof value === 'string'
+        ? value
+        : Buffer.isBuffer(value)
+          ? value.toString('hex')
+          : String(value);
+    return raw.length > maxLength ? `${raw.slice(0, maxLength)}...` : raw;
   }
 
   private isRetryable(err: unknown): boolean {

--- a/apps/backend/src/stellar/services/soroban-rpc-client.service.ts
+++ b/apps/backend/src/stellar/services/soroban-rpc-client.service.ts
@@ -463,16 +463,17 @@ export class SorobanRpcClientService {
       : {};
   }
 
-  private callIfFunction(value: unknown): unknown {
-    return typeof value === 'function' ? value() : value;
-  }
-
   private readRecordField(
     record: Record<string, unknown>,
     key: string,
   ): unknown {
     const value = record[key];
-    return typeof value === 'function' ? value.call(record) : value;
+    if (typeof value !== 'function') {
+      return value;
+    }
+
+    const accessor = value as (this: Record<string, unknown>) => unknown;
+    return accessor.call(record);
   }
 
   private toStellarAddress(invocation: Record<string, unknown>): string {
@@ -496,12 +497,25 @@ export class SorobanRpcClientService {
       return 'unknown';
     }
 
-    const raw =
-      typeof value === 'string'
-        ? value
-        : Buffer.isBuffer(value)
-          ? value.toString('hex')
-          : String(value);
+    let raw: string;
+    if (typeof value === 'string') {
+      raw = value;
+    } else if (Buffer.isBuffer(value)) {
+      raw = value.toString('hex');
+    } else if (
+      typeof value === 'number' ||
+      typeof value === 'boolean' ||
+      typeof value === 'bigint'
+    ) {
+      raw = value.toString();
+    } else if (typeof value === 'symbol') {
+      raw = value.description ?? 'symbol';
+    } else if (value instanceof Error) {
+      raw = value.message;
+    } else {
+      raw = Array.isArray(value) ? `array(${value.length})` : 'object';
+    }
+
     return raw.length > maxLength ? `${raw.slice(0, maxLength)}...` : raw;
   }
 


### PR DESCRIPTION
## Overview

Adds request-scoped structured trace logging for failed Soroban simulation calls so backend operators can search failures by request ID without exposing raw transaction payloads or secrets.

This replaces the closed PR #1283, which could not be reopened after the branch was updated. The branch has been merged with current `main` and the failing backend lint check has been fixed.

## Related Issue

Closes #858

## Changes

- Added `SOROBAN_SIMULATION_TRACE_LEVEL` with `summary` default and `off` / `verbose` options.
- Captures failed simulation traces in `SorobanRpcClientService` with request ID, network, contract, method, operation metadata, and sanitized simulation summary.
- Avoids logging raw transaction bodies, auth entries, diagnostic event payloads, transaction data, or arbitrary object stringification.
- Preserves typed `SorobanRpcError` instances through the timeout wrapper so simulation failures keep their code/cause.
- Fixes backend lint failures from #1283 by typing dynamic accessor calls and avoiding unsafe object stringification.

## Verification Results

| Check | Result |
| --- | --- |
| `gh api user --jq .login` | Passed, active account is `0x-fyve` |
| `npm.cmd ci` | Passed, reported existing audit findings |
| `npm.cmd run lint` | Passed |
| `npm.cmd run test -- soroban-rpc-client.service.spec.ts config.spec.ts --runInBand` | Passed, 2 suites / 19 tests |
| `npm.cmd run test -- --runInBand` | Passed, 80 suites passed / 1 skipped; 661 tests passed / 19 skipped |
| `npm.cmd run build` | Passed |
| `git diff --check` | Passed |

## Acceptance Criteria

| Requirement | Status |
| --- | --- |
| Failed calls log requestId, contract, method, and simulation summary | Done |
| Logs avoid secrets and raw sensitive payloads | Done |
| Trace output is searchable by requestId | Done |
| Trace logging can be disabled or reduced in noisy environments | Done |