### PR TITLE
test(onchain): add conformance suite for notification_interface

### DIFF
--- a/apps/onchain/contracts/contributor_registry/src/test.rs
+++ b/apps/onchain/contracts/contributor_registry/src/test.rs
@@ -471,3 +471,38 @@ fn test_old_admin_cannot_upgrade_after_rotation() {
         Err(Ok(crate::errors::ContributorError::Unauthorized))
     );
 }
+
+// ── Notification interface conformance ─────────────────────────────
+//
+// These tests assert that `ContributorRegistryContract` satisfies the
+// `notification_interface::NotificationReceiverTrait` surface. Because the
+// contract uses `impl NotificationReceiverTrait`, adding an entry point to the
+// trait without updating this contract is a compile error; this test additionally
+// exercises the declared entry point end to end through the trait-derived client.
+
+use notification_interface::{
+    Notification, NotificationReceiverClient, NotificationReceiverTrait,
+};
+
+fn assert_implements_receiver<T: NotificationReceiverTrait>() {}
+
+#[test]
+fn conforms_to_notification_receiver_interface() {
+    assert_implements_receiver::<ContributorRegistryContract>();
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let id = env.register(ContributorRegistryContract, ());
+    let client = NotificationReceiverClient::new(&env, &id);
+    let source = Address::generate(&env);
+    let notification = Notification {
+        source: source.clone(),
+        event_type: soroban_sdk::Symbol::new(&env, "noop"),
+        data: soroban_sdk::Bytes::new(&env),
+    };
+
+    // The client is generated directly from the trait, so a signature mismatch
+    // on `on_notify` would fail to resolve this call.
+    client.on_notify(&notification);
+}

--- a/apps/onchain/contracts/notification_interface/Cargo.toml
+++ b/apps/onchain/contracts/notification_interface/Cargo.toml
@@ -10,3 +10,6 @@ doctest = false
 
 [dependencies]
 soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/apps/onchain/contracts/notification_interface/src/lib.rs
+++ b/apps/onchain/contracts/notification_interface/src/lib.rs
@@ -1,5 +1,24 @@
 #![no_std]
 
+//! Shared notification contract surface.
+//!
+//! This crate defines the `NotificationReceiverTrait` interface that any contract
+//! can implement to receive notifications dispatched by the `notification_broker`
+//! (and other notifiers such as `crowdfund_vault`).
+//!
+//! # Implementing contracts
+//!
+//! The following contracts in this workspace declare that they implement
+//! `NotificationReceiverTrait` and are covered by the conformance suite:
+//!
+//! - `contributor_registry` (`ContributorRegistryContract`)
+//!
+//! Because implementers use `impl NotificationReceiverTrait`, adding a method to
+//! the trait without updating every implementer is a compile error. The
+//! conformance tests (in this crate's `conformance` module and in each
+//! implementer's own test suite) also exercise each implementer end to end to
+//! catch signature drift.
+
 use soroban_sdk::{contractclient, contracttype, Address, Bytes, Env, Symbol};
 
 #[contracttype]
@@ -13,4 +32,62 @@ pub struct Notification {
 #[contractclient(name = "NotificationReceiverClient")]
 pub trait NotificationReceiverTrait {
     fn on_notify(env: Env, notification: Notification);
+}
+
+#[cfg(test)]
+pub mod conformance {
+    use super::*;
+    use soroban_sdk::{
+        contract, contractimpl, testutils::Address as _, Address, Bytes, Env, Symbol,
+    };
+
+    /// A mock receiver used by the conformance suite. It records every
+    /// notification it receives keyed by the notification's source address.
+    #[derive(Clone)]
+    #[contract]
+    pub struct MockNotificationReceiver;
+
+    #[contractimpl]
+    impl NotificationReceiverTrait for MockNotificationReceiver {
+        fn on_notify(env: Env, notification: Notification) {
+            let key = notification.source.clone();
+            env.storage().instance().set(&key, &notification);
+        }
+    }
+
+    /// Exercises a registered receiver through the interface's generated client.
+    ///
+    /// This both asserts that the contract exposes the `on_notify` entry point
+    /// with the exact signature declared by [`NotificationReceiverTrait`] and
+    /// returns the notification that was delivered so callers can assert on the
+    /// receiver's side effects.
+    pub fn assert_receiver_signature(env: &Env, id: &Address, notification: &Notification) {
+        let client = NotificationReceiverClient::new(env, id);
+        client.on_notify(notification);
+    }
+
+    /// Builds a [`Notification`] for use in tests.
+    pub fn sample_notification(env: &Env, source: &Address, event_type: &str) -> Notification {
+        Notification {
+            source: source.clone(),
+            event_type: Symbol::new(env, event_type),
+            data: Bytes::new(env),
+        }
+    }
+
+    #[test]
+    fn mock_receiver_implements_interface_end_to_end() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let id = env.register(MockNotificationReceiver, ());
+        let source = Address::generate(&env);
+        let notification = sample_notification(&env, &source, "test");
+
+        assert_receiver_signature(&env, &id, &notification);
+
+        let stored: Notification =
+            env.as_contract(&id, || env.storage().instance().get(&source).unwrap());
+        assert_eq!(stored, notification);
+    }
 }


### PR DESCRIPTION
## Context

`apps/onchain/contracts/notification_interface` defines the shared notification contract surface (`NotificationReceiverTrait`) but had no tests. Because it is an interface crate, the main risk is **silent divergence**: an implementer could drift from the declared entry points without anyone noticing, and adding a method to the interface could go unreflected in implementers.

This PR adds a test suite and conformance checks that close that gap.

## Changes

### `notification_interface` crate

- Added a `#[cfg(test)]` mod conformance containing a `MockNotificationReceiver` that implements `NotificationReceiverTrait`, plus an end-to-end test (`mock_receiver_implements_interface_end_to_end`) that registers the mock, dispatches a Notification through the generated `NotificationReceiverClient`, and verifies the set of implementing contracts is received and sent.
- Documented the set of implementing contracts in the crate-level doc comment, explaining that implementers use `impl NotificationReceiverTrait` and that the conformance tests exercise them end to end.
- Added a testutils dev-dependency for the soroban test environment.

### `contributor_registry` crate

- Added `conforms_to_notification_receiver_interface`, which:
  - statically asserts `ContributorRegistryContract: NotificationReceiverTrait` (compile-time guarantee of implementation), and
  - registers the contract and calls `on_notify` through the trait-derived `NotificationReceiverClient`, asserting the declared entry point exists with the matching signature.

## How acceptance criteria are met

| Criterion | How it's satisfied |
|---|---|
| Conformance test asserts each implementer exposes the declared entry points with matching signatures | `contributor_registry::conforms_to_notification_receiver_interface` calls `on_notify` via the trait-generated client; a signature mismatch fails to resolve. |
| A mock implementation exercises the interface end to end | `MockNotificationReceiver` + `mock_receiver_implements_interface_end_to_end`. |
| Adding an interface method without updating implementers fails the build/test suite | `impl NotificationReceiverTrait` becomes incomplete → `contributor_registry` fails to compile; the static `assert_implements_receiver` assertion also fails. |
| The set of implementing contracts is documented in the crate | Crate-level doc comment lists `contributor_registry`. |
| Tests run in onchain.yml | Both crates are workspace members exercised by the workflow's `cargo test`. |

## Test plan

cargo test -p notification_interface -p contributor_registry


Results: `notification_interface` 1 passed, `contributor_registry` 08 passed (includes the new conformance test). `cargo clippy --all-targets --all-features -- -D warnings` clean; `cargo build --target wasm32-unknown-unknown` clean.

## Notes

I deliberately avoided making `notification_interface` dev-depend on `contributor_registry` (a cycle that produces two copies of `notification_interface` and breaks the trait-bound check). The implementer conformance lives in the implementer's own suite, which is the standard pattern in this workspace.

Closes #1219