### PR TITLE
feat(backend): implement request-scoped simulation trace logging

### DIFF
--- a/apps/backend/src/contributor-registry/contributor-registry.service.ts
+++ b/apps/backend/src/contributor-registry/contributor-registry.service.ts
@@ -135,7 +135,10 @@ export class ContributorRegistryService {
       .setTimeout(30)
       .build();
 
-    const simulation = await this.sorobanRpcClient.simulateTransaction(tx);
+    const simulation = await this.sorobanRpcClient.simulateTransaction(tx, {
+      contractId: 'contributor-registry',
+      method: 'register_contributor',
+    });
     const preparedTx = rpc.assembleTransaction(tx, simulation).build();
 
     return {
@@ -188,7 +191,10 @@ export class ContributorRegistryService {
       .setTimeout(30)
       .build();
 
-    const simulation = await this.sorobanRpcClient.simulateTransaction(tx);
+    const simulation = await this.sorobanRpcClient.simulateTransaction(tx, {
+      contractId: 'contributor-registry',
+      method: 'register_contributor_with_sig',
+    });
 
     // Assemble (applies resource fee and simulation-derived soroban data)
     const preparedTx = rpc.assembleTransaction(tx, simulation).build();
@@ -367,7 +373,10 @@ export class ContributorRegistryService {
 
     let simulation: rpc.Api.SimulateTransactionResponse;
     try {
-      simulation = await this.sorobanRpcClient.simulateTransaction(tx);
+      simulation = await this.sorobanRpcClient.simulateTransaction(tx, {
+        contractId: 'contributor-registry',
+        method: 'get_contributor',
+      });
     } catch (err) {
       if (
         err instanceof SorobanRpcError &&
@@ -423,7 +432,10 @@ export class ContributorRegistryService {
 
     let simulation: rpc.Api.SimulateTransactionResponse;
     try {
-      simulation = await this.sorobanRpcClient.simulateTransaction(tx);
+      simulation = await this.sorobanRpcClient.simulateTransaction(tx, {
+        contractId: 'contributor-registry',
+        method: 'get_contributor_by_github',
+      });
     } catch (err) {
       if (
         err instanceof SorobanRpcError &&
@@ -479,7 +491,10 @@ export class ContributorRegistryService {
 
     let simulation: rpc.Api.SimulateTransactionResponse;
     try {
-      simulation = await this.sorobanRpcClient.simulateTransaction(tx);
+      simulation = await this.sorobanRpcClient.simulateTransaction(tx, {
+        contractId: 'contributor-registry',
+        method: 'get_reputation',
+      });
     } catch (err) {
       if (
         err instanceof SorobanRpcError &&
@@ -528,7 +543,10 @@ export class ContributorRegistryService {
       .build();
 
     try {
-      const simulation = await this.sorobanRpcClient.simulateTransaction(tx);
+      const simulation = await this.sorobanRpcClient.simulateTransaction(tx, {
+        contractId: 'contributor-registry',
+        method: 'get_registration_nonce',
+      });
 
       if (!rpc.Api.isSimulationSuccess(simulation) || !simulation.result) {
         return 0;

--- a/apps/backend/src/stellar/services/soroban-rpc-client.service.spec.ts
+++ b/apps/backend/src/stellar/services/soroban-rpc-client.service.spec.ts
@@ -1,8 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SorobanRpcClientService } from './soroban-rpc-client.service';
 import { RequestContextService } from '../../common/services/request-context.service';
-import { Logger } from '@nestjs/common';
-import { rpc } from '@stellar/stellar-sdk';
 
 describe('SorobanRpcClientService', () => {
   let service: SorobanRpcClientService;

--- a/apps/backend/src/stellar/services/soroban-rpc-client.service.spec.ts
+++ b/apps/backend/src/stellar/services/soroban-rpc-client.service.spec.ts
@@ -1,0 +1,58 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SorobanRpcClientService } from './soroban-rpc-client.service';
+import { RequestContextService } from '../../common/services/request-context.service';
+import { Logger } from '@nestjs/common';
+import { rpc } from '@stellar/stellar-sdk';
+
+describe('SorobanRpcClientService', () => {
+  let service: SorobanRpcClientService;
+  let loggerSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SorobanRpcClientService,
+        {
+          provide: RequestContextService,
+          useValue: { getRequestId: jest.fn(() => 'test-request-id') },
+        },
+      ],
+    }).compile();
+
+    service = module.get<SorobanRpcClientService>(SorobanRpcClientService);
+    // Logger is a protected property in NestJS classes, but here it's defined as
+    // private readonly logger = new Logger(...);
+    // Accessing it with ['logger'] should work in TS.
+    loggerSpy = jest.spyOn(service['logger'], 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should log an error when simulation fails', async () => {
+    // Mock simulateTransaction to return an error response
+    // The stellar sdk's `isSimulationError` checks for `result.error`
+    jest.spyOn(service['server'], 'simulateTransaction').mockResolvedValue({
+      error: 'Simulated error',
+      id: 1,
+    } as any);
+
+    await expect(
+      service.simulateTransaction({} as any, {
+        contractId: 'test-contract',
+        method: 'test-method',
+      }),
+    ).rejects.toThrow();
+
+    expect(loggerSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestId: 'test-request-id',
+        contract: 'test-contract',
+        method: 'test-method',
+        error: 'Simulated error',
+      }),
+      'Soroban contract simulation failed',
+    );
+  });
+});

--- a/apps/backend/src/stellar/services/soroban-rpc-client.service.ts
+++ b/apps/backend/src/stellar/services/soroban-rpc-client.service.ts
@@ -34,6 +34,8 @@ export interface SorobanClientOptions {
   timeoutMs?: number;
   maxRetries?: number;
   initialBackoffMs?: number;
+  contractId?: string;
+  method?: string;
 }
 
 const DEFAULT_OPTIONS: Required<SorobanClientOptions> = {
@@ -111,6 +113,17 @@ export class SorobanRpcClientService {
     return this.withRetry('simulateTransaction', opts, async () => {
       const result = await this.server.simulateTransaction(tx);
       if (rpc.Api.isSimulationError(result)) {
+        const requestId = this.requestContextService.getRequestId();
+        this.logger.error(
+          {
+            requestId,
+            contract: opts?.contractId,
+            method: opts?.method,
+            error: result.error,
+          },
+          'Soroban contract simulation failed',
+        );
+
         throw new SorobanRpcError(
           SorobanErrorCode.SIMULATION_FAILED,
           `Simulation failed: ${result.error ?? 'Unknown error'}`,

--- a/apps/backend/src/stellar/services/soroban-rpc-client.service.ts
+++ b/apps/backend/src/stellar/services/soroban-rpc-client.service.ts
@@ -214,6 +214,7 @@ export class SorobanRpcClientService {
           {
             requestId,
             method,
+            contract: opts?.contractId,
             attempt,
             maxRetries,
             retrying: isRetryable && !exhausted,


### PR DESCRIPTION
feat(backend): implement request-scoped simulation trace logging
    
    Improved debuggability of failed testnet contract invocations by capturing simulation traces in a structured way.
 - Included requestId and contractId in RPC failure logs to ensure trace searchability.
 - Resolved linting errors in SorobanRpcClientService specs by removing unused imports.

closes #858 