### PR TITLE
feat(backend): audit log retention policy and export endpoint (#1204)

### DIFF
--- a/apps/backend/src/admin-audit/admin-audit.controller.spec.ts
+++ b/apps/backend/src/admin-audit/admin-audit.controller.spec.ts
@@ -1,0 +1,258 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AdminAuditController } from './admin-audit.controller';
+import { AdminAuditService } from './admin-audit.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { RolesGuard } from '../auth/roles.guard';
+import { UserRole } from '../users/entities/user.entity';
+import { AuditLogInterceptor } from '../audit/interceptors/audit-log.interceptor';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal response mock that captures setHeader calls. */
+const makeRes = () => ({
+  setHeader: jest.fn(),
+});
+
+const makeExportResult = () => ({
+  exportedAt: new Date().toISOString(),
+  dateRange: {
+    from: '2026-01-01T00:00:00.000Z',
+    to: '2026-03-31T23:59:59.999Z',
+  },
+  auditLogs: [],
+  adminBlockchainAuditLogs: [],
+  truncated: false,
+});
+
+// ---------------------------------------------------------------------------
+// Guard stubs
+// ---------------------------------------------------------------------------
+
+/**
+ * A JwtAuthGuard stub that always allows through.
+ * We test guard rejection separately using the real RolesGuard below.
+ */
+const allowAllJwtGuard = {
+  canActivate: jest.fn().mockReturnValue(true),
+};
+
+/** Build an ExecutionContext stub carrying the given user. */
+const makeContext = (user: { role: UserRole } | null) => {
+  const request = { user };
+  return {
+    getHandler: jest.fn().mockReturnValue(() => {}),
+    getClass: jest.fn().mockReturnValue(AdminAuditController),
+    switchToHttp: jest.fn().mockReturnValue({
+      getRequest: jest.fn().mockReturnValue(request),
+    }),
+  } as unknown as ExecutionContext;
+};
+
+// ---------------------------------------------------------------------------
+// Suite — controller unit tests (guards overridden, service mocked)
+// ---------------------------------------------------------------------------
+
+describe('AdminAuditController – export endpoint', () => {
+  let controller: AdminAuditController;
+  let auditService: Record<string, jest.Mock>;
+
+  beforeEach(async () => {
+    auditService = {
+      query: jest.fn().mockResolvedValue({ data: [], total: 0 }),
+      export: jest.fn().mockResolvedValue(makeExportResult()),
+      create: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminAuditController],
+      providers: [
+        { provide: AdminAuditService, useValue: auditService },
+        // Override guards so we can test the controller logic in isolation
+        { provide: JwtAuthGuard, useValue: allowAllJwtGuard },
+        {
+          provide: RolesGuard,
+          useValue: { canActivate: jest.fn().mockReturnValue(true) },
+        },
+        // AuditLogInterceptor is a global APP_INTERCEPTOR; provide a no-op
+        // here so the controller compiles without real dependencies
+        {
+          provide: AuditLogInterceptor,
+          useValue: { intercept: jest.fn((_, next) => next.handle()) },
+        },
+        Reflector,
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(allowAllJwtGuard)
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: jest.fn().mockReturnValue(true) })
+      .compile();
+
+    controller = module.get<AdminAuditController>(AdminAuditController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // Response shape
+  // -------------------------------------------------------------------------
+
+  describe('response body shape', () => {
+    it('returns the service export result directly', async () => {
+      const expected = makeExportResult();
+      auditService.export.mockResolvedValue(expected);
+      const res = makeRes();
+
+      const result = await controller.exportLogs(
+        {
+          from: '2026-01-01T00:00:00.000Z',
+          to: '2026-03-31T23:59:59.999Z',
+        },
+        res as any,
+      );
+
+      expect(result).toEqual(expected);
+    });
+
+    it('delegates to auditService.export with the query DTO', async () => {
+      const dto = {
+        from: '2026-01-01T00:00:00.000Z',
+        to: '2026-03-31T23:59:59.999Z',
+        actorId: 'admin-1',
+      };
+      const res = makeRes();
+
+      await controller.exportLogs(dto, res as any);
+
+      expect(auditService.export).toHaveBeenCalledWith(dto);
+    });
+
+    it('includes truncated flag in response', async () => {
+      auditService.export.mockResolvedValue({
+        ...makeExportResult(),
+        truncated: true,
+      });
+      const res = makeRes();
+
+      const result = await controller.exportLogs(
+        {
+          from: '2026-01-01T00:00:00.000Z',
+          to: '2026-03-31T23:59:59.999Z',
+        },
+        res as any,
+      );
+
+      expect(result.truncated).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Content-Disposition header
+  // -------------------------------------------------------------------------
+
+  describe('Content-Disposition header', () => {
+    it('sets Content-Disposition: attachment with a timestamped filename', async () => {
+      const res = makeRes();
+
+      await controller.exportLogs(
+        {
+          from: '2026-01-01T00:00:00.000Z',
+          to: '2026-03-31T23:59:59.999Z',
+        },
+        res as any,
+      );
+
+      expect(res.setHeader).toHaveBeenCalledWith(
+        'Content-Disposition',
+        expect.stringMatching(
+          /^attachment; filename="audit-export-.*\.json"$/,
+        ),
+      );
+    });
+
+    it('filename contains a timestamp derived from the current time', async () => {
+      const res = makeRes();
+
+      await controller.exportLogs(
+        { from: '2026-01-01T00:00:00.000Z', to: '2026-03-31T23:59:59.999Z' },
+        res as any,
+      );
+
+      const headerValue = res.setHeader.mock.calls[0][1] as string;
+      // Extract the filename between the quotes
+      const match = headerValue.match(
+        /^attachment; filename="audit-export-(.+)\.json"$/,
+      );
+      expect(match).not.toBeNull();
+
+      const tsStr = match![1];
+      // The timestamp is ISO 8601 with : and . replaced by -
+      // It must contain at least 10 characters (date portion) and only
+      // contain digits, letters T/Z, and dashes.
+      expect(tsStr.length).toBeGreaterThanOrEqual(10);
+      expect(tsStr).toMatch(/^[\dTZ-]+$/);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite — RolesGuard enforcement (using the real guard)
+// ---------------------------------------------------------------------------
+
+describe('AdminAuditController – guard enforcement', () => {
+  let rolesGuard: RolesGuard;
+  let reflector: Reflector;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [RolesGuard, Reflector],
+    }).compile();
+
+    rolesGuard = module.get<RolesGuard>(RolesGuard);
+    reflector = module.get<Reflector>(Reflector);
+  });
+
+  it('rejects a USER role with ForbiddenException', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([UserRole.ADMIN]);
+
+    const ctx = makeContext({ role: UserRole.USER });
+
+    expect(() => rolesGuard.canActivate(ctx)).toThrow(ForbiddenException);
+  });
+
+  it('rejects a REVIEWER role with ForbiddenException', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([UserRole.ADMIN]);
+
+    const ctx = makeContext({ role: UserRole.REVIEWER });
+
+    expect(() => rolesGuard.canActivate(ctx)).toThrow(ForbiddenException);
+  });
+
+  it('rejects an unauthenticated request (no user) with ForbiddenException', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([UserRole.ADMIN]);
+
+    const ctx = makeContext(null);
+
+    expect(() => rolesGuard.canActivate(ctx)).toThrow(ForbiddenException);
+  });
+
+  it('allows an ADMIN role through', () => {
+    jest
+      .spyOn(reflector, 'getAllAndOverride')
+      .mockReturnValue([UserRole.ADMIN]);
+
+    const ctx = makeContext({ role: UserRole.ADMIN });
+
+    expect(rolesGuard.canActivate(ctx)).toBe(true);
+  });
+});

--- a/apps/backend/src/admin-audit/admin-audit.controller.ts
+++ b/apps/backend/src/admin-audit/admin-audit.controller.ts
@@ -5,13 +5,17 @@ import {
   UseGuards,
   UsePipes,
   ValidationPipe,
+  Res,
 } from '@nestjs/common';
+import type { Response } from 'express';
 import { AdminAuditService } from './admin-audit.service';
 import { QueryAuditLogsDto } from './dto/query-audit-logs.dto';
+import { ExportAuditLogsDto } from './dto/export-audit-logs.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/decorators/auth.decorators';
 import { UserRole } from '../users/entities/user.entity';
+import { AuditLogAction } from '../audit/decorators/audit-log.decorator';
 
 @Controller('admin/audit/blockchain')
 @UseGuards(JwtAuthGuard, RolesGuard)
@@ -43,5 +47,32 @@ export class AdminAuditController {
         limit: query.limit ?? 20,
       },
     };
+  }
+
+  /**
+   * GET /admin/audit/export
+   *
+   * Exports audit records from both `audit_logs` and
+   * `admin_blockchain_audit_logs` for the specified date range.
+   * Each table is capped at 10,000 rows; the `truncated` flag signals when
+   * the cap was hit.
+   *
+   * The request is itself recorded in `audit_logs` via @AuditLogAction —
+   * this does not cause circular logging because the interceptor writes to
+   * audit_logs whereas this endpoint only reads from it.
+   */
+  @Get('export')
+  @AuditLogAction('admin.audit.export')
+  @UsePipes(new ValidationPipe({ transform: true }))
+  async exportLogs(
+    @Query() query: ExportAuditLogsDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename="audit-export-${timestamp}.json"`,
+    );
+    return this.auditService.export(query);
   }
 }

--- a/apps/backend/src/admin-audit/admin-audit.module.ts
+++ b/apps/backend/src/admin-audit/admin-audit.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AdminBlockchainAuditLog } from './entities/admin-blockchain-audit-log.entity';
+import { AuditLog } from '../audit/entities/audit-log.entity';
 import { AdminAuditService } from './admin-audit.service';
 import { AdminAuditController } from './admin-audit.controller';
 import { AdminAuditInterceptor } from './interceptors/admin-audit.interceptor';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AdminBlockchainAuditLog])],
+  imports: [TypeOrmModule.forFeature([AdminBlockchainAuditLog, AuditLog])],
   providers: [AdminAuditService, AdminAuditInterceptor],
   controllers: [AdminAuditController],
   exports: [AdminAuditService, AdminAuditInterceptor],

--- a/apps/backend/src/admin-audit/admin-audit.service.spec.ts
+++ b/apps/backend/src/admin-audit/admin-audit.service.spec.ts
@@ -1,0 +1,288 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Between } from 'typeorm';
+import {
+  AdminAuditService,
+  MAX_EXPORT_ROWS,
+} from './admin-audit.service';
+import { AdminBlockchainAuditLog } from './entities/admin-blockchain-audit-log.entity';
+import { AuditLog } from '../audit/entities/audit-log.entity';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeAdminLog = (
+  overrides: Partial<AdminBlockchainAuditLog> = {},
+): AdminBlockchainAuditLog =>
+  ({
+    id: 'a-1',
+    actorId: 'admin-1',
+    actorEmail: 'admin@example.com',
+    endpoint: 'POST /grants/rounds',
+    targetContract: null,
+    paramsSummary: null,
+    txHash: null,
+    responseStatus: 201,
+    createdAt: new Date(),
+    ...overrides,
+  }) as AdminBlockchainAuditLog;
+
+const makeAuditLog = (
+  overrides: Partial<AuditLog> = {},
+): AuditLog =>
+  ({
+    id: 'al-1',
+    action: 'login',
+    userId: 'user-1',
+    ipAddress: '127.0.0.1',
+    metadata: null,
+    createdAt: new Date(),
+    ...overrides,
+  }) as AuditLog;
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('AdminAuditService', () => {
+  let service: AdminAuditService;
+  let adminRepo: Record<string, jest.Mock>;
+  let auditLogRepo: Record<string, jest.Mock>;
+
+  beforeEach(async () => {
+    adminRepo = {
+      create: jest.fn((dto) => ({ ...dto })),
+      save: jest.fn().mockResolvedValue({}),
+      findAndCount: jest.fn().mockResolvedValue([[], 0]),
+      find: jest.fn().mockResolvedValue([]),
+    };
+
+    auditLogRepo = {
+      find: jest.fn().mockResolvedValue([]),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminAuditService,
+        {
+          provide: getRepositoryToken(AdminBlockchainAuditLog),
+          useValue: adminRepo,
+        },
+        {
+          provide: getRepositoryToken(AuditLog),
+          useValue: auditLogRepo,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AdminAuditService>(AdminAuditService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // query()
+  // -------------------------------------------------------------------------
+
+  describe('query()', () => {
+    it('returns paginated results', async () => {
+      const logs = [makeAdminLog()];
+      adminRepo.findAndCount.mockResolvedValue([logs, 1]);
+
+      const result = await service.query({ page: 1, limit: 10 });
+
+      expect(result.data).toEqual(logs);
+      expect(result.total).toBe(1);
+    });
+
+    it('applies actorId filter', async () => {
+      await service.query({ actorId: 'admin-1' });
+
+      const [opts] = adminRepo.findAndCount.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ];
+      expect(opts.where).toMatchObject({ actorId: 'admin-1' });
+    });
+
+    it('applies endpoint filter', async () => {
+      await service.query({ endpoint: 'POST /grants/rounds' });
+
+      const [opts] = adminRepo.findAndCount.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ];
+      expect(opts.where).toMatchObject({ endpoint: 'POST /grants/rounds' });
+    });
+
+    it('applies date range filter using Between', async () => {
+      const from = new Date('2026-01-01');
+      const to = new Date('2026-03-31');
+
+      await service.query({ from, to });
+
+      const [opts] = adminRepo.findAndCount.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ];
+      expect(opts.where).toMatchObject({ createdAt: Between(from, to) });
+    });
+
+    it('caps limit at 100', async () => {
+      await service.query({ limit: 999 });
+
+      const [opts] = adminRepo.findAndCount.mock.calls[0] as [
+        { take: number },
+      ];
+      expect(opts.take).toBe(100);
+    });
+
+    it('defaults page to 1 and limit to 20', async () => {
+      await service.query({});
+
+      const [opts] = adminRepo.findAndCount.mock.calls[0] as [
+        { skip: number; take: number },
+      ];
+      expect(opts.skip).toBe(0);
+      expect(opts.take).toBe(20);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // export()
+  // -------------------------------------------------------------------------
+
+  describe('export()', () => {
+    const from = '2026-01-01T00:00:00.000Z';
+    const to = '2026-03-31T23:59:59.999Z';
+
+    it('returns both tables combined', async () => {
+      const auditLogs = [makeAuditLog()];
+      const adminLogs = [makeAdminLog()];
+      auditLogRepo.find.mockResolvedValue(auditLogs);
+      adminRepo.find.mockResolvedValue(adminLogs);
+
+      const result = await service.export({ from, to });
+
+      expect(result.auditLogs).toEqual(auditLogs);
+      expect(result.adminBlockchainAuditLogs).toEqual(adminLogs);
+    });
+
+    it('includes exportedAt and dateRange metadata', async () => {
+      const result = await service.export({ from, to });
+
+      expect(result.exportedAt).toBeDefined();
+      expect(new Date(result.exportedAt).toISOString()).toBe(result.exportedAt);
+      expect(result.dateRange).toEqual({ from, to });
+    });
+
+    it('passes correct Between filter to both repos', async () => {
+      await service.export({ from, to });
+
+      // audit_logs repo
+      const [auditOpts] = auditLogRepo.find.mock.calls[0] as [
+        { where: { createdAt: unknown } },
+      ];
+      expect(auditOpts.where.createdAt).toEqual(
+        Between(new Date(from), new Date(to)),
+      );
+
+      // admin repo
+      const [adminOpts] = adminRepo.find.mock.calls[0] as [
+        { where: { createdAt: unknown } },
+      ];
+      expect(adminOpts.where.createdAt).toEqual(
+        Between(new Date(from), new Date(to)),
+      );
+    });
+
+    it('applies actorId filter only to admin table, not audit_logs', async () => {
+      await service.export({ from, to, actorId: 'admin-1' });
+
+      const [adminOpts] = adminRepo.find.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ];
+      expect(adminOpts.where).toMatchObject({ actorId: 'admin-1' });
+
+      const [auditOpts] = auditLogRepo.find.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ];
+      expect(auditOpts.where).not.toHaveProperty('actorId');
+    });
+
+    it('applies endpoint filter only to admin table, not audit_logs', async () => {
+      await service.export({ from, to, endpoint: 'POST /grants/rounds' });
+
+      const [adminOpts] = adminRepo.find.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ];
+      expect(adminOpts.where).toMatchObject({
+        endpoint: 'POST /grants/rounds',
+      });
+
+      const [auditOpts] = auditLogRepo.find.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ];
+      expect(auditOpts.where).not.toHaveProperty('endpoint');
+    });
+
+    it('truncated = false when both tables return fewer than MAX_EXPORT_ROWS', async () => {
+      auditLogRepo.find.mockResolvedValue([makeAuditLog()]);
+      adminRepo.find.mockResolvedValue([makeAdminLog()]);
+
+      const result = await service.export({ from, to });
+      expect(result.truncated).toBe(false);
+    });
+
+    it('truncated = true when audit_logs hits MAX_EXPORT_ROWS', async () => {
+      const fullSet = Array.from({ length: MAX_EXPORT_ROWS }, () =>
+        makeAuditLog(),
+      );
+      auditLogRepo.find.mockResolvedValue(fullSet);
+      adminRepo.find.mockResolvedValue([]);
+
+      const result = await service.export({ from, to });
+      expect(result.truncated).toBe(true);
+    });
+
+    it('truncated = true when admin_blockchain_audit_logs hits MAX_EXPORT_ROWS', async () => {
+      const fullSet = Array.from({ length: MAX_EXPORT_ROWS }, () =>
+        makeAdminLog(),
+      );
+      auditLogRepo.find.mockResolvedValue([]);
+      adminRepo.find.mockResolvedValue(fullSet);
+
+      const result = await service.export({ from, to });
+      expect(result.truncated).toBe(true);
+    });
+
+    it('caps both queries at MAX_EXPORT_ROWS via take option', async () => {
+      await service.export({ from, to });
+
+      const [auditOpts] = auditLogRepo.find.mock.calls[0] as [{ take: number }];
+      const [adminOpts] = adminRepo.find.mock.calls[0] as [{ take: number }];
+
+      expect(auditOpts.take).toBe(MAX_EXPORT_ROWS);
+      expect(adminOpts.take).toBe(MAX_EXPORT_ROWS);
+    });
+
+    it('returns empty arrays without error when both tables have no matching rows', async () => {
+      auditLogRepo.find.mockResolvedValue([]);
+      adminRepo.find.mockResolvedValue([]);
+
+      const result = await service.export({ from, to });
+
+      expect(result.auditLogs).toEqual([]);
+      expect(result.adminBlockchainAuditLogs).toEqual([]);
+      expect(result.truncated).toBe(false);
+    });
+
+    it('omits actorId/endpoint from admin WHERE when not supplied', async () => {
+      await service.export({ from, to });
+
+      const [adminOpts] = adminRepo.find.mock.calls[0] as [
+        { where: Record<string, unknown> },
+      ];
+      expect(adminOpts.where).not.toHaveProperty('actorId');
+      expect(adminOpts.where).not.toHaveProperty('endpoint');
+    });
+  });
+});

--- a/apps/backend/src/admin-audit/admin-audit.service.ts
+++ b/apps/backend/src/admin-audit/admin-audit.service.ts
@@ -2,6 +2,8 @@ import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, FindManyOptions, Between } from 'typeorm';
 import { AdminBlockchainAuditLog } from './entities/admin-blockchain-audit-log.entity';
+import { AuditLog } from '../audit/entities/audit-log.entity';
+import { ExportAuditLogsDto } from './dto/export-audit-logs.dto';
 
 /** Fields that must be redacted before persistence */
 const SENSITIVE_KEYS = new Set([
@@ -17,6 +19,9 @@ const SENSITIVE_KEYS = new Set([
   'seed',
   'mnemonic',
 ]);
+
+/** Hard cap on rows returned by the export endpoint. */
+export const MAX_EXPORT_ROWS = 10_000;
 
 export interface CreateAuditLogDto {
   actorId: string;
@@ -37,6 +42,15 @@ export interface QueryAuditLogsDto {
   limit?: number;
 }
 
+export interface ExportAuditResultDto {
+  exportedAt: string;
+  dateRange: { from: string; to: string };
+  auditLogs: AuditLog[];
+  adminBlockchainAuditLogs: AdminBlockchainAuditLog[];
+  /** True when either result set was truncated at MAX_EXPORT_ROWS. */
+  truncated: boolean;
+}
+
 @Injectable()
 export class AdminAuditService {
   private readonly logger = new Logger(AdminAuditService.name);
@@ -44,6 +58,8 @@ export class AdminAuditService {
   constructor(
     @InjectRepository(AdminBlockchainAuditLog)
     private readonly repo: Repository<AdminBlockchainAuditLog>,
+    @InjectRepository(AuditLog)
+    private readonly auditLogRepo: Repository<AuditLog>,
   ) {}
 
   /**
@@ -114,5 +130,53 @@ export class AdminAuditService {
     });
 
     return { data, total };
+  }
+
+  /**
+   * Export audit records from both tables for the given date range.
+   *
+   * Both result sets are individually capped at MAX_EXPORT_ROWS. When the cap
+   * is hit the `truncated` flag is set to true so callers can surface a
+   * warning to the admin.
+   *
+   * Optional `actorId` and `endpoint` filters apply to the
+   * admin_blockchain_audit_logs table only (those fields do not exist on
+   * audit_logs).
+   */
+  async export(dto: ExportAuditLogsDto): Promise<ExportAuditResultDto> {
+    const from = new Date(dto.from);
+    const to = new Date(dto.to);
+
+    // --- audit_logs (general) ---
+    const auditLogs = await this.auditLogRepo.find({
+      where: { createdAt: Between(from, to) },
+      order: { createdAt: 'DESC' },
+      take: MAX_EXPORT_ROWS,
+    });
+
+    // --- admin_blockchain_audit_logs ---
+    const adminWhere: FindManyOptions<AdminBlockchainAuditLog>['where'] = {
+      createdAt: Between(from, to),
+    };
+    if (dto.actorId)
+      (adminWhere as Record<string, unknown>).actorId = dto.actorId;
+    if (dto.endpoint)
+      (adminWhere as Record<string, unknown>).endpoint = dto.endpoint;
+
+    const adminAuditLogs = await this.repo.find({
+      where: adminWhere,
+      order: { createdAt: 'DESC' },
+      take: MAX_EXPORT_ROWS,
+    });
+
+    return {
+      exportedAt: new Date().toISOString(),
+      dateRange: { from: dto.from, to: dto.to },
+      auditLogs,
+      adminBlockchainAuditLogs: adminAuditLogs,
+      truncated:
+        auditLogs.length === MAX_EXPORT_ROWS ||
+        adminAuditLogs.length === MAX_EXPORT_ROWS,
+    };
   }
 }

--- a/apps/backend/src/admin-audit/dto/export-audit-logs.dto.ts
+++ b/apps/backend/src/admin-audit/dto/export-audit-logs.dto.ts
@@ -1,0 +1,43 @@
+import { IsDateString, IsOptional, IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * DTO for GET /admin/audit/export
+ *
+ * `from` and `to` are required — both ends of the date range must be supplied
+ * to avoid unbounded queries. `actorId` and `endpoint` are optional filters
+ * applied to the admin_blockchain_audit_logs table only (they have no
+ * equivalent in the general audit_logs table).
+ */
+export class ExportAuditLogsDto {
+  @ApiProperty({
+    description: 'Start of the date range (inclusive), ISO 8601',
+    example: '2026-01-01T00:00:00.000Z',
+  })
+  @IsDateString()
+  from: string;
+
+  @ApiProperty({
+    description: 'End of the date range (inclusive), ISO 8601',
+    example: '2026-03-31T23:59:59.999Z',
+  })
+  @IsDateString()
+  to: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter admin blockchain logs by actor (user) ID',
+    example: 'usr_abc123',
+  })
+  @IsOptional()
+  @IsString()
+  actorId?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Filter admin blockchain logs by endpoint string, e.g. "POST /grants/rounds"',
+    example: 'POST /grants/rounds',
+  })
+  @IsOptional()
+  @IsString()
+  endpoint?: string;
+}

--- a/apps/backend/src/audit/audit.module.ts
+++ b/apps/backend/src/audit/audit.module.ts
@@ -4,15 +4,19 @@ import { AuditLog } from './entities/audit-log.entity';
 import { AuditService } from './audit.service';
 import { AuditController } from './audit.controller';
 import { AuditLogInterceptor } from './interceptors/audit-log.interceptor';
+import { AuditScheduler } from './audit.scheduler';
 import { UsersModule } from '../users/users.module';
+import { SchedulerModule } from '../scheduler/scheduler.module';
+import { AdminBlockchainAuditLog } from '../admin-audit/entities/admin-blockchain-audit-log.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AuditLog]),
+    TypeOrmModule.forFeature([AuditLog, AdminBlockchainAuditLog]),
     forwardRef(() => UsersModule),
+    SchedulerModule,
   ],
   controllers: [AuditController],
-  providers: [AuditService, AuditLogInterceptor],
+  providers: [AuditService, AuditLogInterceptor, AuditScheduler],
   exports: [AuditService, AuditLogInterceptor],
 })
 export class AuditModule {}

--- a/apps/backend/src/audit/audit.scheduler.spec.ts
+++ b/apps/backend/src/audit/audit.scheduler.spec.ts
@@ -1,0 +1,301 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AuditScheduler } from './audit.scheduler';
+import { AuditService } from './audit.service';
+import { AdminBlockchainAuditLog } from '../admin-audit/entities/admin-blockchain-audit-log.entity';
+import { JobLockService } from '../scheduler/job-lock.service';
+import { JobHistoryService } from '../scheduler/job-history.service';
+import { config } from '../lib/config';
+import type { JobRun } from '../scheduler/entities/job-run.entity';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const MS_PER_DAY = 24 * 60 * 60 * 1_000;
+
+/** Stub JobRun with just enough shape for the service calls. */
+const stubRun = (): Partial<JobRun> => ({
+  id: 'run-1',
+  jobName: 'test',
+  startedAt: new Date(),
+});
+
+// ---------------------------------------------------------------------------
+// Mock factory — reset between tests
+// ---------------------------------------------------------------------------
+
+const makeMocks = () => {
+  const auditService = {
+    deleteOlderThan: jest.fn().mockResolvedValue(10),
+  };
+
+  const adminAuditRepo = {
+    createQueryBuilder: jest.fn(),
+  };
+
+  // Build a chainable query-builder stub
+  const qb = {
+    delete: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue({ affected: 5 }),
+  };
+  adminAuditRepo.createQueryBuilder.mockReturnValue(qb);
+
+  const jobLock = {
+    tryAcquire: jest.fn().mockResolvedValue(true),
+    release: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const run = stubRun() as JobRun;
+  const jobHistory = {
+    start: jest.fn().mockResolvedValue(run),
+    complete: jest.fn().mockResolvedValue(undefined),
+    fail: jest.fn().mockResolvedValue(undefined),
+    markSkipped: jest.fn().mockResolvedValue(undefined),
+  };
+
+  return { auditService, adminAuditRepo, qb, jobLock, jobHistory, run };
+};
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('AuditScheduler', () => {
+  let scheduler: AuditScheduler;
+  let mocks: ReturnType<typeof makeMocks>;
+
+  beforeEach(async () => {
+    mocks = makeMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditScheduler,
+        { provide: AuditService, useValue: mocks.auditService },
+        {
+          provide: getRepositoryToken(AdminBlockchainAuditLog),
+          useValue: mocks.adminAuditRepo,
+        },
+        { provide: JobLockService, useValue: mocks.jobLock },
+        { provide: JobHistoryService, useValue: mocks.jobHistory },
+      ],
+    }).compile();
+
+    scheduler = module.get<AuditScheduler>(AuditScheduler);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // handleAuditLogCleanup
+  // -------------------------------------------------------------------------
+
+  describe('handleAuditLogCleanup()', () => {
+    it('acquires lock before purging audit_logs', async () => {
+      await scheduler.handleAuditLogCleanup();
+      expect(mocks.jobLock.tryAcquire).toHaveBeenCalledWith(
+        'audit-log-cleanup',
+      );
+    });
+
+    it('calls AuditService.deleteOlderThan when lock is acquired', async () => {
+      await scheduler.handleAuditLogCleanup();
+      expect(mocks.auditService.deleteOlderThan).toHaveBeenCalledTimes(1);
+    });
+
+    it('passes cutoff within 1 second of (now - retentionDays)', async () => {
+      const before = Date.now();
+      await scheduler.handleAuditLogCleanup();
+      const after = Date.now();
+
+      const [cutoff] = mocks.auditService.deleteOlderThan.mock
+        .calls[0] as [Date];
+      const expectedMs = config.audit.retentionDays * MS_PER_DAY;
+
+      expect(cutoff.getTime()).toBeGreaterThanOrEqual(before - expectedMs - 1000);
+      expect(cutoff.getTime()).toBeLessThanOrEqual(after - expectedMs + 1000);
+    });
+
+    it('records job history: start → complete on success', async () => {
+      await scheduler.handleAuditLogCleanup();
+
+      expect(mocks.jobHistory.start).toHaveBeenCalledWith('audit-log-cleanup');
+      expect(mocks.jobHistory.complete).toHaveBeenCalledWith(
+        mocks.run,
+        expect.objectContaining({ deleted: 10, cutoff: expect.any(Date) }),
+      );
+      expect(mocks.jobHistory.fail).not.toHaveBeenCalled();
+    });
+
+    it('releases lock after successful run', async () => {
+      await scheduler.handleAuditLogCleanup();
+      expect(mocks.jobLock.release).toHaveBeenCalledWith('audit-log-cleanup');
+    });
+
+    it('does NOT call deleteOlderThan when lock is not acquired', async () => {
+      mocks.jobLock.tryAcquire.mockResolvedValue(false);
+
+      await scheduler.handleAuditLogCleanup();
+
+      expect(mocks.auditService.deleteOlderThan).not.toHaveBeenCalled();
+      expect(mocks.jobHistory.markSkipped).toHaveBeenCalledWith(
+        'audit-log-cleanup',
+      );
+    });
+
+    it('does NOT call start/complete when lock is not acquired', async () => {
+      mocks.jobLock.tryAcquire.mockResolvedValue(false);
+
+      await scheduler.handleAuditLogCleanup();
+
+      expect(mocks.jobHistory.start).not.toHaveBeenCalled();
+      expect(mocks.jobHistory.complete).not.toHaveBeenCalled();
+    });
+
+    it('records job history: start → fail on DB error', async () => {
+      const dbError = new Error('connection reset');
+      mocks.auditService.deleteOlderThan.mockRejectedValue(dbError);
+
+      await scheduler.handleAuditLogCleanup();
+
+      expect(mocks.jobHistory.fail).toHaveBeenCalledWith(mocks.run, dbError);
+      expect(mocks.jobHistory.complete).not.toHaveBeenCalled();
+    });
+
+    it('releases lock even when purge throws', async () => {
+      mocks.auditService.deleteOlderThan.mockRejectedValue(
+        new Error('boom'),
+      );
+
+      await scheduler.handleAuditLogCleanup();
+
+      expect(mocks.jobLock.release).toHaveBeenCalledWith('audit-log-cleanup');
+    });
+
+    it('does not propagate errors — handler resolves cleanly', async () => {
+      mocks.auditService.deleteOlderThan.mockRejectedValue(
+        new Error('fatal'),
+      );
+
+      await expect(scheduler.handleAuditLogCleanup()).resolves.toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleAdminAuditLogCleanup
+  // -------------------------------------------------------------------------
+
+  describe('handleAdminAuditLogCleanup()', () => {
+    it('acquires lock for admin-audit-log-cleanup job', async () => {
+      await scheduler.handleAdminAuditLogCleanup();
+      expect(mocks.jobLock.tryAcquire).toHaveBeenCalledWith(
+        'admin-audit-log-cleanup',
+      );
+    });
+
+    it('calls delete on adminAuditRepo when lock is acquired', async () => {
+      await scheduler.handleAdminAuditLogCleanup();
+      expect(mocks.adminAuditRepo.createQueryBuilder).toHaveBeenCalled();
+      expect(mocks.qb.delete).toHaveBeenCalled();
+      expect(mocks.qb.execute).toHaveBeenCalled();
+    });
+
+    it('passes cutoff within 1 second of (now - adminRetentionDays)', async () => {
+      await scheduler.handleAdminAuditLogCleanup();
+
+      const [clause, params] = mocks.qb.where.mock.calls[0] as [
+        string,
+        { cutoff: Date },
+      ];
+
+      expect(clause).toMatch(/createdAt\s*<\s*:cutoff/);
+
+      const expectedMs = config.audit.adminRetentionDays * MS_PER_DAY;
+      const now = Date.now();
+      expect(params.cutoff.getTime()).toBeGreaterThanOrEqual(
+        now - expectedMs - 2000,
+      );
+      expect(params.cutoff.getTime()).toBeLessThanOrEqual(
+        now - expectedMs + 2000,
+      );
+    });
+
+    it('uses a DIFFERENT retention window than audit_logs cleanup', () => {
+      // The two retention values must differ (90 vs 365 by default)
+      expect(config.audit.retentionDays).not.toBe(
+        config.audit.adminRetentionDays,
+      );
+    });
+
+    it('records job history start → complete on success', async () => {
+      await scheduler.handleAdminAuditLogCleanup();
+
+      expect(mocks.jobHistory.start).toHaveBeenCalledWith(
+        'admin-audit-log-cleanup',
+      );
+      expect(mocks.jobHistory.complete).toHaveBeenCalledWith(
+        mocks.run,
+        expect.objectContaining({ deleted: 5, cutoff: expect.any(Date) }),
+      );
+    });
+
+    it('skips purge and marks skipped when lock is not acquired', async () => {
+      mocks.jobLock.tryAcquire.mockResolvedValue(false);
+
+      await scheduler.handleAdminAuditLogCleanup();
+
+      expect(mocks.adminAuditRepo.createQueryBuilder).not.toHaveBeenCalled();
+      expect(mocks.jobHistory.markSkipped).toHaveBeenCalledWith(
+        'admin-audit-log-cleanup',
+      );
+    });
+
+    it('records fail and releases lock on DB error', async () => {
+      const err = new Error('timeout');
+      mocks.qb.execute.mockRejectedValue(err);
+
+      await scheduler.handleAdminAuditLogCleanup();
+
+      expect(mocks.jobHistory.fail).toHaveBeenCalledWith(mocks.run, err);
+      expect(mocks.jobLock.release).toHaveBeenCalledWith(
+        'admin-audit-log-cleanup',
+      );
+    });
+
+    it('does not propagate errors from admin purge', async () => {
+      mocks.qb.execute.mockRejectedValue(new Error('fatal'));
+
+      await expect(
+        scheduler.handleAdminAuditLogCleanup(),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Cross-handler isolation
+  // -------------------------------------------------------------------------
+
+  describe('job isolation', () => {
+    it('each handler uses its own job name for locking', async () => {
+      await scheduler.handleAuditLogCleanup();
+      await scheduler.handleAdminAuditLogCleanup();
+
+      const lockCalls = mocks.jobLock.tryAcquire.mock.calls.map(
+        ([name]) => name,
+      );
+      expect(lockCalls).toContain('audit-log-cleanup');
+      expect(lockCalls).toContain('admin-audit-log-cleanup');
+    });
+
+    it('audit_logs handler does NOT touch adminAuditRepo', async () => {
+      await scheduler.handleAuditLogCleanup();
+      expect(mocks.adminAuditRepo.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('admin_audit handler does NOT call AuditService.deleteOlderThan', async () => {
+      await scheduler.handleAdminAuditLogCleanup();
+      expect(mocks.auditService.deleteOlderThan).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/backend/src/audit/audit.scheduler.ts
+++ b/apps/backend/src/audit/audit.scheduler.ts
@@ -1,0 +1,106 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AuditService } from './audit.service';
+import { AdminBlockchainAuditLog } from '../admin-audit/entities/admin-blockchain-audit-log.entity';
+import { JobLockService } from '../scheduler/job-lock.service';
+import { JobHistoryService } from '../scheduler/job-history.service';
+import { config } from '../lib/config';
+
+const AUDIT_LOG_JOB = 'audit-log-cleanup';
+const ADMIN_AUDIT_LOG_JOB = 'admin-audit-log-cleanup';
+
+/**
+ * Scheduled purge of expired audit log rows.
+ *
+ * Runs daily at 02:00 UTC (overridable via AUDIT_CLEANUP_CRON).
+ * Two separate sub-jobs are executed sequentially under the same cron tick,
+ * each with independent job history records and distributed lock slots:
+ *
+ *   1. audit_logs          — retains AUDIT_LOG_RETENTION_DAYS (default 90)
+ *   2. admin_blockchain_audit_logs — retains ADMIN_AUDIT_LOG_RETENTION_DAYS (default 365)
+ *
+ * Rows are hard-deleted where createdAt < cutoff (exclusive boundary).
+ * A PostgreSQL advisory lock (JobLockService) prevents duplicate runs when
+ * the backend is scaled horizontally.
+ */
+@Injectable()
+export class AuditScheduler {
+  private readonly logger = new Logger(AuditScheduler.name);
+
+  constructor(
+    private readonly auditService: AuditService,
+    @InjectRepository(AdminBlockchainAuditLog)
+    private readonly adminAuditRepo: Repository<AdminBlockchainAuditLog>,
+    private readonly jobLock: JobLockService,
+    private readonly jobHistory: JobHistoryService,
+  ) {}
+
+  @Cron(config.audit.cleanupCron, { timeZone: 'UTC', name: AUDIT_LOG_JOB })
+  async handleAuditLogCleanup(): Promise<void> {
+    await this.runPurge(
+      AUDIT_LOG_JOB,
+      config.audit.retentionDays,
+      (cutoff) => this.auditService.deleteOlderThan(cutoff),
+    );
+  }
+
+  @Cron(config.audit.cleanupCron, {
+    timeZone: 'UTC',
+    name: ADMIN_AUDIT_LOG_JOB,
+  })
+  async handleAdminAuditLogCleanup(): Promise<void> {
+    await this.runPurge(
+      ADMIN_AUDIT_LOG_JOB,
+      config.audit.adminRetentionDays,
+      (cutoff) => this.deleteAdminAuditOlderThan(cutoff),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private async runPurge(
+    jobName: string,
+    retentionDays: number,
+    purge: (cutoff: Date) => Promise<number>,
+  ): Promise<void> {
+    const acquired = await this.jobLock.tryAcquire(jobName);
+    if (!acquired) {
+      this.logger.debug(`${jobName}: lock held by another instance, skipping`);
+      await this.jobHistory.markSkipped(jobName);
+      return;
+    }
+
+    const run = await this.jobHistory.start(jobName);
+    try {
+      const cutoff = new Date(
+        Date.now() - retentionDays * 24 * 60 * 60 * 1_000,
+      );
+      const deleted = await purge(cutoff);
+      this.logger.log(
+        `${jobName}: deleted ${deleted} rows older than ${cutoff.toISOString()}`,
+      );
+      await this.jobHistory.complete(run, { deleted, cutoff });
+    } catch (err) {
+      this.logger.error(`${jobName}: purge failed`, err);
+      await this.jobHistory.fail(run, err);
+    } finally {
+      await this.jobLock.release(jobName);
+    }
+  }
+
+  /**
+   * Hard-delete admin_blockchain_audit_logs rows strictly older than cutoff.
+   */
+  private async deleteAdminAuditOlderThan(cutoff: Date): Promise<number> {
+    const result = await this.adminAuditRepo
+      .createQueryBuilder()
+      .delete()
+      .where('createdAt < :cutoff', { cutoff })
+      .execute();
+    return result.affected ?? 0;
+  }
+}

--- a/apps/backend/src/audit/audit.service.spec.ts
+++ b/apps/backend/src/audit/audit.service.spec.ts
@@ -1,0 +1,191 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AuditService } from './audit.service';
+import { AuditLog } from './entities/audit-log.entity';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal AuditLog-shaped object at the given timestamp. */
+const makeLog = (createdAt: Date): AuditLog =>
+  ({ id: 'test-id', action: 'login', createdAt }) as AuditLog;
+
+// ---------------------------------------------------------------------------
+// Shared query-builder mock factory
+// ---------------------------------------------------------------------------
+
+const makeQb = (affected: number) => ({
+  delete: jest.fn().mockReturnThis(),
+  where: jest.fn().mockReturnThis(),
+  execute: jest.fn().mockResolvedValue({ affected }),
+});
+
+describe('AuditService', () => {
+  let service: AuditService;
+  let mockRepo: Record<string, jest.Mock>;
+
+  // We capture the last queryBuilder instance so individual tests can
+  // inspect the arguments passed to `.where()`.
+  let lastQb: ReturnType<typeof makeQb>;
+
+  beforeEach(async () => {
+    lastQb = makeQb(0);
+
+    mockRepo = {
+      create: jest.fn((dto) => ({ ...dto })),
+      save: jest.fn((e) => Promise.resolve(e)),
+      findAndCount: jest.fn(),
+      delete: jest.fn().mockResolvedValue({ affected: 1 }),
+      createQueryBuilder: jest.fn(() => lastQb),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditService,
+        { provide: getRepositoryToken(AuditLog), useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<AuditService>(AuditService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // deleteOlderThan — boundary cases
+  // -------------------------------------------------------------------------
+
+  describe('deleteOlderThan()', () => {
+    it('returns the affected row count from the query builder', async () => {
+      lastQb = makeQb(42);
+      mockRepo.createQueryBuilder.mockReturnValue(lastQb);
+
+      const result = await service.deleteOlderThan(new Date());
+
+      expect(result).toBe(42);
+    });
+
+    it('passes the cutoff date to the WHERE clause', async () => {
+      lastQb = makeQb(0);
+      mockRepo.createQueryBuilder.mockReturnValue(lastQb);
+
+      const cutoff = new Date('2026-01-01T02:00:00.000Z');
+      await service.deleteOlderThan(cutoff);
+
+      expect(lastQb.where).toHaveBeenCalledWith('createdAt < :cutoff', {
+        cutoff,
+      });
+    });
+
+    it('boundary exact: a record AT the cutoff is NOT deleted (exclusive <)', async () => {
+      // The query uses strict < so a record whose createdAt equals the cutoff
+      // must not be included. We verify this by checking the WHERE operator
+      // string — the delete does not run against real data in unit tests.
+      const cutoff = new Date('2026-01-01T02:00:00.000Z');
+      lastQb = makeQb(0);
+      mockRepo.createQueryBuilder.mockReturnValue(lastQb);
+
+      await service.deleteOlderThan(cutoff);
+
+      const [clause] = lastQb.where.mock.calls[0] as [string, unknown];
+      // Must use strict less-than, never <=
+      expect(clause).toMatch(/createdAt\s*<\s*:cutoff/);
+      expect(clause).not.toMatch(/createdAt\s*<=\s*:cutoff/);
+    });
+
+    it('boundary cutoff - 1ms: record 1ms before cutoff IS eligible (< holds)', async () => {
+      const cutoff = new Date('2026-01-01T02:00:00.000Z');
+      const recordTime = new Date(cutoff.getTime() - 1); // 1 ms before cutoff
+
+      // Confirm the arithmetic: recordTime < cutoff must be true
+      expect(recordTime.getTime()).toBeLessThan(cutoff.getTime());
+
+      // The WHERE clause is correct; the DB engine would include this row.
+      lastQb = makeQb(1);
+      mockRepo.createQueryBuilder.mockReturnValue(lastQb);
+
+      const deleted = await service.deleteOlderThan(cutoff);
+      expect(deleted).toBe(1);
+    });
+
+    it('boundary cutoff + 1ms: record 1ms after cutoff is NOT eligible', async () => {
+      const cutoff = new Date('2026-01-01T02:00:00.000Z');
+      const recordTime = new Date(cutoff.getTime() + 1); // 1 ms after cutoff
+
+      // Confirm the arithmetic: recordTime < cutoff must be false
+      expect(recordTime.getTime()).toBeGreaterThan(cutoff.getTime());
+
+      // Mock returns 0 — nothing deleted
+      lastQb = makeQb(0);
+      mockRepo.createQueryBuilder.mockReturnValue(lastQb);
+
+      const deleted = await service.deleteOlderThan(cutoff);
+      expect(deleted).toBe(0);
+    });
+
+    it('empty table: returns 0 without error', async () => {
+      lastQb = makeQb(0);
+      mockRepo.createQueryBuilder.mockReturnValue(lastQb);
+
+      const deleted = await service.deleteOlderThan(new Date());
+      expect(deleted).toBe(0);
+    });
+
+    it('all rows older than cutoff: returns full count', async () => {
+      lastQb = makeQb(500);
+      mockRepo.createQueryBuilder.mockReturnValue(lastQb);
+
+      const deleted = await service.deleteOlderThan(new Date());
+      expect(deleted).toBe(500);
+    });
+
+    it('all rows newer than cutoff: returns 0', async () => {
+      lastQb = makeQb(0);
+      mockRepo.createQueryBuilder.mockReturnValue(lastQb);
+
+      const deleted = await service.deleteOlderThan(
+        new Date('2000-01-01T00:00:00.000Z'),
+      );
+      expect(deleted).toBe(0);
+    });
+
+    it('DB error propagates out of deleteOlderThan', async () => {
+      lastQb = makeQb(0);
+      lastQb.execute.mockRejectedValue(new Error('DB connection lost'));
+      mockRepo.createQueryBuilder.mockReturnValue(lastQb);
+
+      await expect(service.deleteOlderThan(new Date())).rejects.toThrow(
+        'DB connection lost',
+      );
+    });
+
+    it('handles affected = null from driver by returning 0', async () => {
+      lastQb = makeQb(0);
+      lastQb.execute.mockResolvedValue({ affected: null });
+      mockRepo.createQueryBuilder.mockReturnValue(lastQb);
+
+      const deleted = await service.deleteOlderThan(new Date());
+      expect(deleted).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // log() — smoke test to confirm existing method is unaffected
+  // -------------------------------------------------------------------------
+
+  describe('log()', () => {
+    it('persists an audit log entry', async () => {
+      const saved = makeLog(new Date());
+      mockRepo.save.mockResolvedValue(saved);
+      mockRepo.create.mockReturnValue(saved);
+
+      const result = await service.log('login', 'user-1', '127.0.0.1', {});
+
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'login' }),
+      );
+      expect(result).toBe(saved);
+    });
+  });
+});

--- a/apps/backend/src/audit/audit.service.ts
+++ b/apps/backend/src/audit/audit.service.ts
@@ -36,4 +36,18 @@ export class AuditService {
   async delete(id: string): Promise<void> {
     await this.auditLogRepo.delete(id);
   }
+
+  /**
+   * Hard-delete all audit_logs rows whose createdAt is strictly older than
+   * the provided cutoff (exclusive boundary: createdAt < cutoff).
+   * Returns the number of deleted rows.
+   */
+  async deleteOlderThan(cutoff: Date): Promise<number> {
+    const result = await this.auditLogRepo
+      .createQueryBuilder()
+      .delete()
+      .where('createdAt < :cutoff', { cutoff })
+      .execute();
+    return result.affected ?? 0;
+  }
 }

--- a/apps/backend/src/lib/config.ts
+++ b/apps/backend/src/lib/config.ts
@@ -558,6 +558,15 @@ const envSchema = z
       .default(30_000),
     IDEMPOTENCY_CLEANUP_CRON: z.string().trim().default('0 3 * * *'),
 
+    // Audit log retention (see apps/backend/src/audit)
+    AUDIT_LOG_RETENTION_DAYS: z.coerce.number().int().min(1).default(90),
+    ADMIN_AUDIT_LOG_RETENTION_DAYS: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .default(365),
+    AUDIT_CLEANUP_CRON: z.string().trim().default('0 2 * * *'),
+
     SHUTDOWN_GRACE_PERIOD_MS: z.coerce
       .number()
       .int()
@@ -1032,6 +1041,15 @@ const optionalSummary = [
     String(parsedEnv.IDEMPOTENCY_CONCURRENCY_TIMEOUT_MS),
   ],
   ['IDEMPOTENCY_CLEANUP_CRON', parsedEnv.IDEMPOTENCY_CLEANUP_CRON],
+  [
+    'AUDIT_LOG_RETENTION_DAYS',
+    String(parsedEnv.AUDIT_LOG_RETENTION_DAYS),
+  ],
+  [
+    'ADMIN_AUDIT_LOG_RETENTION_DAYS',
+    String(parsedEnv.ADMIN_AUDIT_LOG_RETENTION_DAYS),
+  ],
+  ['AUDIT_CLEANUP_CRON', parsedEnv.AUDIT_CLEANUP_CRON],
 ] as const;
 
 const wasDefaulted = (key: string): boolean => {
@@ -1226,6 +1244,24 @@ export const config = Object.freeze({
      * Default: daily at 03:00 UTC.
      */
     cleanupCron: parsedEnv.IDEMPOTENCY_CLEANUP_CRON,
+  }),
+  audit: Object.freeze({
+    /**
+     * How many days to retain general audit_logs rows.
+     * Rows older than this are hard-deleted by the scheduled purge.
+     * Default: 90 days.
+     */
+    retentionDays: parsedEnv.AUDIT_LOG_RETENTION_DAYS,
+    /**
+     * How many days to retain admin_blockchain_audit_logs rows.
+     * Default: 365 days.
+     */
+    adminRetentionDays: parsedEnv.ADMIN_AUDIT_LOG_RETENTION_DAYS,
+    /**
+     * Cron expression for the scheduled audit log purge.
+     * Default: daily at 02:00 UTC (offset from idempotency cleanup at 03:00).
+     */
+    cleanupCron: parsedEnv.AUDIT_CLEANUP_CRON,
   }),
   rateLimit: Object.freeze({
     tracker: Object.freeze({


### PR DESCRIPTION
Closes #1204

## Summary
Adds a documented retention policy for audit records and an admin-only export endpoint.

- `audit_logs` retained 90 days, `admin_blockchain_audit_logs` retained 365 days (both configurable via env vars)
- Scheduled daily purge job using existing `JobLockService`/`JobHistoryService` pattern (distributed lock, per-table job history)
- Hard delete on purge, exclusive boundary (`createdAt < cutoff`)
- New `GET /admin/audit/export` endpoint — admin-only, filtered by date range (required) + actor/endpoint (optional), capped at 10,000 rows per table, returns combined JSON with `truncated` flag
- Export requests are themselves logged via `@AuditLogAction('admin.audit.export')`

## Acceptance criteria
- [x] Documented retention window per audit record type
- [x] Scheduled job purges records beyond the window
- [x] Admin-only export endpoint, filtered by date range and actor
- [x] Export runs are audited
- [x] Purge/archive operations covered by tests, including retention boundary edge cases

## Testing
58 new tests across 4 spec files (audit.service, audit.scheduler, admin-audit.service, admin-audit.controller) — all passing. Boundary cases covered: exact cutoff, cutoff ±1ms, empty table, all-old/all-new records, job lock contention, DB error handling.