### PR TITLE
feat: bootstrap teardown, deployment smoke endpoint, mobile data & pr…

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -65,6 +65,125 @@ curl -X POST \
 
 Safeguards: feature flag, `STELLAR_NETWORK=testnet` gate, admin JWT, dedicated rate limit, and a hardcoded Friendbot URL.
 
+## Bootstrap teardown and reset
+
+Repeated bootstraps accumulate state. Every bootstrap — a demo seed *or* a Friendbot funding — is recorded as a **bootstrap run** with its own identifier and the list of resources it created, so an environment can be returned to a clean baseline one run at a time.
+
+### 1. Find the run identifier
+
+The `runId` is returned by the call that created the state:
+
+```jsonc
+// POST /v1/demo-bootstrap/seed
+{ "success": true, "seededAt": "...", "runId": "3f6c1a6e-2f4b-4b2a-9c0a-5d8f0b1c2d3e", "details": { } }
+```
+
+If you no longer have it, list recorded runs (newest first):
+
+```bash
+curl -H "Authorization: Bearer <ADMIN_JWT>" \
+  "http://localhost:3000/v1/demo-bootstrap/runs?kind=demo_seed&status=active"
+```
+
+Supported filters: `kind` (`demo_seed` | `testnet_account`), `status` (`active` | `torn_down`), `limit` (default 50, max 200).
+
+### 2. Preview with a dry run
+
+`dryRun` changes nothing and reports exactly what a real teardown would remove:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <ADMIN_JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{"dryRun":true}' \
+  http://localhost:3000/v1/demo-bootstrap/runs/<RUN_ID>/teardown
+```
+
+```jsonc
+{
+  "success": true,
+  "runId": "3f6c1a6e-...",
+  "dryRun": true,
+  "status": "active",
+  "environment": { "network": "testnet", "nodeEnv": "development" },
+  "resources": [
+    { "type": "demo_contributor", "identifier": "GA5Z...KZVN", "label": "Demo contributor demo-alice", "action": "would_remove" },
+    { "type": "demo_grant_round", "identifier": "0", "label": "Demo: Stellar Community Builders — Round 1", "action": "would_remove" }
+  ],
+  "summary": { "total": 2, "removed": 2, "notFound": 0, "skipped": 0 }
+}
+```
+
+### 3. Tear the run down
+
+Drop `dryRun` (or send `{"dryRun":false}`) to execute. Each resource comes back as `removed`, `not_found` (already gone) or `skipped`:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer <ADMIN_JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{}' \
+  http://localhost:3000/v1/demo-bootstrap/runs/<RUN_ID>/teardown
+```
+
+The call is idempotent — tearing down an already torn-down run returns `status: "already_torn_down"` and removes nothing.
+
+### Environment gate
+
+Teardown is **refused with `403`** unless both hold:
+
+1. `NODE_ENV` is not `production` — teardown is never permitted in production, whatever the network says; and
+2. the environment is explicitly marked as testnet (`STELLAR_NETWORK=testnet`) **or** development (`NODE_ENV=development` or `test`).
+
+The refusal response names which condition failed. The gate is re-evaluated on every request, so a misconfigured deploy cannot leave a stale "allowed" verdict behind.
+
+### What teardown cannot undo
+
+Friendbot-funded testnet accounts stay on-chain — Stellar has no way to delete an account the backend does not hold the secret key for. Those resources are reported as `skipped` with an explicit reason, and only the local bootstrap record is discarded. Demo seed data is in-memory, so it is genuinely removed.
+
+`POST /v1/demo-bootstrap/reset` remains the blunt instrument: it clears **all** demo seed state regardless of which run produced it. Use the teardown endpoint when only one run should be undone. Runs whose data a `reset` already wiped tear down cleanly and report their resources as `not_found`.
+
+Runs are recorded in the `bootstrap_runs` table (migration `1848000000000-CreateBootstrapRuns`), so run history survives a restart and a completed teardown stays auditable.
+
+## Deployment smoke endpoint
+
+A single public endpoint for CI and Vercel deployment checks:
+
+```bash
+curl -sf http://localhost:3000/v1/health/smoke
+```
+
+It confirms in one call that:
+
+- every required environment variable is present (`DB_*`, `PORT`, `JWT_SECRET`, `STELLAR_SERVER_SECRET`, plus `CORS_ORIGIN` / `PYTHON_API_URL` where the environment requires them);
+- core dependencies respond — database, Redis, and Stellar Horizon; and
+- every configured Soroban contract ID is reachable.
+
+The response is machine-readable, and each check carries a stable `id` so CI can assert on individual results:
+
+```jsonc
+{
+  "status": "pass",          // "pass" | "warn" | "fail" — worst result across all checks
+  "ready": true,             // false only when something failed
+  "checkedAt": "2026-08-29T10:15:00.000Z",
+  "durationMs": 412,
+  "network": "testnet",
+  "environment": "production",
+  "summary": { "total": 14, "passed": 13, "warned": 1, "failed": 0 },
+  "checks": [
+    { "id": "env.JWT_SECRET", "category": "config", "status": "pass", "message": "JWT_SECRET is set" },
+    { "id": "dependency.redis", "category": "dependency", "status": "warn", "message": "Redis cache is unreachable — the API runs uncached" },
+    { "id": "contract.lumenToken", "category": "contract", "status": "pass", "message": "lumenToken contract is reachable" }
+  ]
+}
+```
+
+HTTP status mirrors readiness: **200** for `pass` and `warn`, **503** for `fail`. A plain `curl -sf` is therefore enough to gate a deploy; use `jq -e '.status == "pass"'` to also fail on warnings.
+
+Redis is a warning rather than a failure because the API degrades to uncached rather than breaking. Missing required env vars, an unreachable database or Horizon, and any misconfigured or uncallable contract ID all fail the check.
+
+**Safe to expose publicly.** Environment variables are reported by name and presence only — never a value, prefix or length. Contract IDs are redacted to `ABC123...XYZ789`. Dependency failures return fixed messages (`"Database is unreachable"`), never the driver's error text, so a connection string or internal host can never leak; the underlying error is written to the server log instead.
+
 ## Security defaults
 
 The backend includes:

--- a/apps/backend/src/bootstrap-runs/bootstrap-run-registry.service.ts
+++ b/apps/backend/src/bootstrap-runs/bootstrap-run-registry.service.ts
@@ -1,0 +1,134 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { config } from '../lib/config';
+import {
+  BootstrapResourceRecord,
+  BootstrapRun,
+  BootstrapRunKind,
+  BootstrapRunStatus,
+} from './entities/bootstrap-run.entity';
+
+export interface RecordBootstrapRunInput {
+  /** Pre-generated identifier, so a caller can return it before the write settles. */
+  id?: string;
+  kind: BootstrapRunKind;
+  resources: BootstrapResourceRecord[];
+  createdBy?: string | null;
+}
+
+export interface ListBootstrapRunsOptions {
+  kind?: BootstrapRunKind;
+  status?: BootstrapRunStatus;
+  /** Maximum rows to return. Defaults to 50, capped at 200. */
+  limit?: number;
+}
+
+export interface MarkTornDownInput {
+  tornDownBy?: string | null;
+  summary: Record<string, unknown>;
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Persists what each bootstrap run created so the teardown endpoint has an
+ * authoritative list to work from.
+ *
+ * Recording is deliberately best-effort for the *creating* paths: a demo seed
+ * or a Friendbot funding call must not fail because the registry write failed.
+ * Teardown reads, by contrast, surface their errors — refusing to tear down is
+ * safer than silently reporting nothing to remove.
+ */
+@Injectable()
+export class BootstrapRunRegistryService {
+  private readonly logger = new Logger(BootstrapRunRegistryService.name);
+
+  constructor(
+    @InjectRepository(BootstrapRun)
+    private readonly repo: Repository<BootstrapRun>,
+  ) {}
+
+  async record(input: RecordBootstrapRunInput): Promise<BootstrapRun> {
+    const entity = this.repo.create({
+      ...(input.id ? { id: input.id } : {}),
+      kind: input.kind,
+      status: BootstrapRunStatus.ACTIVE,
+      network: config.stellar.network,
+      environment: config.nodeEnv,
+      resources: input.resources,
+      createdBy: input.createdBy ?? null,
+      tornDownAt: null,
+      tornDownBy: null,
+      teardownSummary: null,
+    });
+
+    return this.repo.save(entity);
+  }
+
+  /**
+   * Records a run without letting a registry failure break the caller.
+   * Returns the run id on success, or `null` when the write failed.
+   */
+  async recordSafely(input: RecordBootstrapRunInput): Promise<string | null> {
+    try {
+      const run = await this.record(input);
+      return run.id;
+    } catch (error) {
+      this.logger.error(
+        `Failed to record ${input.kind} bootstrap run: ${this.describeError(error)}. ` +
+          'The resources were still created but will not be teardown-tracked.',
+      );
+      return null;
+    }
+  }
+
+  async findById(runId: string): Promise<BootstrapRun | null> {
+    // Postgres raises on a malformed uuid literal, so screen the input first.
+    if (!UUID_PATTERN.test(runId)) {
+      return null;
+    }
+
+    return this.repo.findOne({ where: { id: runId } });
+  }
+
+  async list(options: ListBootstrapRunsOptions = {}): Promise<BootstrapRun[]> {
+    const limit = Math.min(options.limit ?? 50, 200);
+    const qb = this.repo
+      .createQueryBuilder('run')
+      .orderBy('run.createdAt', 'DESC')
+      .limit(limit);
+
+    if (options.kind) {
+      qb.andWhere('run.kind = :kind', { kind: options.kind });
+    }
+
+    if (options.status) {
+      qb.andWhere('run.status = :status', { status: options.status });
+    }
+
+    return qb.getMany();
+  }
+
+  async markTornDown(
+    runId: string,
+    input: MarkTornDownInput,
+  ): Promise<BootstrapRun | null> {
+    const run = await this.findById(runId);
+    if (!run) {
+      return null;
+    }
+
+    run.status = BootstrapRunStatus.TORN_DOWN;
+    run.tornDownAt = new Date();
+    run.tornDownBy = input.tornDownBy ?? null;
+    run.teardownSummary = input.summary;
+
+    return this.repo.save(run);
+  }
+
+  private describeError(error: unknown): string {
+    return error instanceof Error ? error.message : 'unknown error';
+  }
+}

--- a/apps/backend/src/bootstrap-runs/bootstrap-runs.module.ts
+++ b/apps/backend/src/bootstrap-runs/bootstrap-runs.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BootstrapRunRegistryService } from './bootstrap-run-registry.service';
+import { BootstrapRun } from './entities/bootstrap-run.entity';
+
+/**
+ * Shared registry of bootstrap runs.
+ *
+ * Imported by every module that creates bootstrap state (demo seeding,
+ * Friendbot funding) as well as by the teardown path, so all of them agree on
+ * a single record of what a run produced.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([BootstrapRun])],
+  providers: [BootstrapRunRegistryService],
+  exports: [BootstrapRunRegistryService],
+})
+export class BootstrapRunsModule {}

--- a/apps/backend/src/bootstrap-runs/entities/bootstrap-run.entity.ts
+++ b/apps/backend/src/bootstrap-runs/entities/bootstrap-run.entity.ts
@@ -1,0 +1,107 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+/**
+ * What produced a bootstrap run.
+ *
+ * `demo_seed`       — DemoBootstrapService seeded in-memory demo scenarios.
+ * `testnet_account` — TestnetBootstrapService funded an account via Friendbot.
+ */
+export const BootstrapRunKind = {
+  DEMO_SEED: 'demo_seed',
+  TESTNET_ACCOUNT: 'testnet_account',
+} as const;
+
+export type BootstrapRunKind =
+  (typeof BootstrapRunKind)[keyof typeof BootstrapRunKind];
+
+export const BootstrapRunStatus = {
+  ACTIVE: 'active',
+  TORN_DOWN: 'torn_down',
+} as const;
+
+export type BootstrapRunStatus =
+  (typeof BootstrapRunStatus)[keyof typeof BootstrapRunStatus];
+
+/**
+ * The kinds of resource a bootstrap run can create. Each type maps to a
+ * teardown handler in BootstrapTeardownService.
+ */
+export const BootstrapResourceType = {
+  DEMO_CONTRIBUTOR: 'demo_contributor',
+  DEMO_GRANT_ROUND: 'demo_grant_round',
+  TESTNET_ACCOUNT: 'testnet_account',
+} as const;
+
+export type BootstrapResourceType =
+  (typeof BootstrapResourceType)[keyof typeof BootstrapResourceType];
+
+/**
+ * One resource created by a bootstrap run. `identifier` is whatever uniquely
+ * addresses the resource within its type — a Stellar public key for accounts,
+ * the seeded contributor address, or the grant round id.
+ */
+export interface BootstrapResourceRecord {
+  type: BootstrapResourceType;
+  identifier: string;
+  label: string;
+}
+
+/**
+ * Records a single bootstrap run so it can later be torn down by identifier.
+ *
+ * Runs are append-only: teardown flips `status` to `torn_down` and stores the
+ * per-resource outcome in `teardownSummary` rather than deleting the row, so a
+ * contributor can always see what a given environment was reset from.
+ */
+@Entity('bootstrap_runs')
+@Index('IDX_bootstrap_runs_created_at', ['createdAt'])
+@Index('IDX_bootstrap_runs_kind_status', ['kind', 'status'])
+export class BootstrapRun {
+  /** The run identifier callers pass to the teardown endpoint. */
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'varchar', length: 32 })
+  kind!: BootstrapRunKind;
+
+  @Column({ type: 'varchar', length: 20, default: BootstrapRunStatus.ACTIVE })
+  status!: BootstrapRunStatus;
+
+  /** Stellar network the run targeted ('testnet' | 'mainnet'). */
+  @Column({ type: 'varchar', length: 20 })
+  network!: string;
+
+  /** NODE_ENV at the time of the run — part of the teardown safety gate. */
+  @Column({ type: 'varchar', length: 32 })
+  environment!: string;
+
+  /** Everything the run created, in teardown order. */
+  @Column({ type: 'jsonb' })
+  resources!: BootstrapResourceRecord[];
+
+  /** Admin user id that triggered the run, when the caller was authenticated. */
+  @Column({ type: 'varchar', length: 64, name: 'created_by', nullable: true })
+  createdBy!: string | null;
+
+  @CreateDateColumn({ type: 'timestamptz', name: 'created_at' })
+  createdAt!: Date;
+
+  @Column({ type: 'timestamptz', name: 'torn_down_at', nullable: true })
+  tornDownAt!: Date | null;
+
+  @Column({ type: 'varchar', length: 64, name: 'torn_down_by', nullable: true })
+  tornDownBy!: string | null;
+
+  /**
+   * Per-resource teardown outcome, stored so a completed teardown stays
+   * auditable after the underlying state is gone.
+   */
+  @Column({ type: 'jsonb', name: 'teardown_summary', nullable: true })
+  teardownSummary!: Record<string, unknown> | null;
+}

--- a/apps/backend/src/database/migrations/1848000000000-CreateBootstrapRuns.ts
+++ b/apps/backend/src/database/migrations/1848000000000-CreateBootstrapRuns.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `bootstrap_runs` table backing the testnet bootstrap teardown
+ * path. Each row records one bootstrap run (demo seed or Friendbot funding),
+ * the resources it created, and — once torn down — the per-resource outcome.
+ */
+export class CreateBootstrapRuns1848000000000 implements MigrationInterface {
+  name = 'CreateBootstrapRuns1848000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE IF NOT EXISTS "bootstrap_runs" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "kind" character varying(32) NOT NULL,
+        "status" character varying(20) NOT NULL DEFAULT 'active',
+        "network" character varying(20) NOT NULL,
+        "environment" character varying(32) NOT NULL,
+        "resources" jsonb NOT NULL,
+        "created_by" character varying(64),
+        "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "torn_down_at" TIMESTAMP WITH TIME ZONE,
+        "torn_down_by" character varying(64),
+        "teardown_summary" jsonb,
+        CONSTRAINT "PK_bootstrap_runs" PRIMARY KEY ("id")
+      )`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_bootstrap_runs_created_at" ON "bootstrap_runs" ("created_at")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_bootstrap_runs_kind_status" ON "bootstrap_runs" ("kind", "status")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_bootstrap_runs_kind_status"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_bootstrap_runs_created_at"`,
+    );
+    await queryRunner.query(`DROP TABLE IF EXISTS "bootstrap_runs"`);
+  }
+}

--- a/apps/backend/src/demo-bootstrap/bootstrap-teardown.service.spec.ts
+++ b/apps/backend/src/demo-bootstrap/bootstrap-teardown.service.spec.ts
@@ -1,0 +1,286 @@
+jest.mock('../lib/config', () => ({
+  config: {
+    nodeEnv: 'development',
+    stellar: { network: 'testnet' },
+    featureFlags: { bootstrapDemoData: true },
+  },
+}));
+
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { BootstrapRunRegistryService } from '../bootstrap-runs/bootstrap-run-registry.service';
+import {
+  BootstrapResourceType,
+  BootstrapRun,
+  BootstrapRunKind,
+  BootstrapRunStatus,
+} from '../bootstrap-runs/entities/bootstrap-run.entity';
+import { BootstrapTeardownService } from './bootstrap-teardown.service';
+import { DemoBootstrapService } from './demo-bootstrap.service';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { config } = require('../lib/config');
+
+const RUN_ID = '3f6c1a6e-2f4b-4b2a-9c0a-5d8f0b1c2d3e';
+const DEMO_ADDRESS = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+
+function buildRun(overrides: Partial<BootstrapRun> = {}): BootstrapRun {
+  return {
+    id: RUN_ID,
+    kind: BootstrapRunKind.DEMO_SEED,
+    status: BootstrapRunStatus.ACTIVE,
+    network: 'testnet',
+    environment: 'development',
+    resources: [
+      {
+        type: BootstrapResourceType.DEMO_CONTRIBUTOR,
+        identifier: DEMO_ADDRESS,
+        label: 'Demo contributor demo-alice',
+      },
+      {
+        type: BootstrapResourceType.DEMO_GRANT_ROUND,
+        identifier: '0',
+        label: 'Demo: Stellar Community Builders — Round 1',
+      },
+    ],
+    createdBy: 'admin-1',
+    createdAt: new Date('2026-08-01T00:00:00.000Z'),
+    tornDownAt: null,
+    tornDownBy: null,
+    teardownSummary: null,
+    ...overrides,
+  };
+}
+
+describe('BootstrapTeardownService', () => {
+  let service: BootstrapTeardownService;
+  let registry: {
+    findById: jest.Mock;
+    list: jest.Mock;
+    markTornDown: jest.Mock;
+  };
+  let demoBootstrap: {
+    hasSeededResource: jest.Mock;
+    removeSeededResource: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    config.nodeEnv = 'development';
+    config.stellar.network = 'testnet';
+
+    registry = {
+      findById: jest.fn(),
+      list: jest.fn().mockResolvedValue([]),
+      markTornDown: jest.fn().mockResolvedValue(null),
+    };
+    demoBootstrap = {
+      hasSeededResource: jest.fn().mockReturnValue(true),
+      removeSeededResource: jest.fn().mockReturnValue(true),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BootstrapTeardownService,
+        { provide: BootstrapRunRegistryService, useValue: registry },
+        { provide: DemoBootstrapService, useValue: demoBootstrap },
+      ],
+    }).compile();
+
+    service = module.get(BootstrapTeardownService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe('environment gate', () => {
+    it('allows a testnet-marked environment', () => {
+      config.nodeEnv = 'staging';
+      config.stellar.network = 'testnet';
+
+      expect(service.evaluateEnvironmentGate().allowed).toBe(true);
+    });
+
+    it('allows a development environment on any network', () => {
+      config.nodeEnv = 'development';
+      config.stellar.network = 'mainnet';
+
+      expect(service.evaluateEnvironmentGate().allowed).toBe(true);
+    });
+
+    it('refuses an unmarked non-testnet environment', () => {
+      config.nodeEnv = 'staging';
+      config.stellar.network = 'mainnet';
+
+      const gate = service.evaluateEnvironmentGate();
+      expect(gate.allowed).toBe(false);
+      expect(gate.reasons.join(' ')).toContain(
+        'not explicitly marked as testnet or development',
+      );
+    });
+
+    it('refuses production even when the network says testnet', () => {
+      config.nodeEnv = 'production';
+      config.stellar.network = 'testnet';
+
+      const gate = service.evaluateEnvironmentGate();
+      expect(gate.allowed).toBe(false);
+      expect(gate.reasons.join(' ')).toContain('never permitted in production');
+    });
+
+    it('throws ForbiddenException and touches nothing when refused', async () => {
+      config.nodeEnv = 'production';
+      config.stellar.network = 'mainnet';
+
+      await expect(service.teardown(RUN_ID)).rejects.toBeInstanceOf(
+        ForbiddenException,
+      );
+      expect(registry.findById).not.toHaveBeenCalled();
+      expect(demoBootstrap.removeSeededResource).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('teardown', () => {
+    it('throws NotFoundException for an unknown run identifier', async () => {
+      registry.findById.mockResolvedValue(null);
+
+      await expect(service.teardown(RUN_ID)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('removes every recorded resource and marks the run torn down', async () => {
+      registry.findById.mockResolvedValue(buildRun());
+
+      const result = await service.teardown(RUN_ID, {
+        requestedBy: 'admin-2',
+      });
+
+      expect(result.dryRun).toBe(false);
+      expect(result.status).toBe(BootstrapRunStatus.TORN_DOWN);
+      expect(result.summary).toEqual({
+        total: 2,
+        removed: 2,
+        notFound: 0,
+        skipped: 0,
+      });
+      expect(demoBootstrap.removeSeededResource).toHaveBeenCalledTimes(2);
+      expect(registry.markTornDown).toHaveBeenCalledWith(
+        RUN_ID,
+        expect.objectContaining({ tornDownBy: 'admin-2' }),
+      );
+    });
+
+    it('reports already-removed resources as not_found instead of failing', async () => {
+      registry.findById.mockResolvedValue(buildRun());
+      demoBootstrap.removeSeededResource.mockReturnValue(false);
+
+      const result = await service.teardown(RUN_ID);
+
+      expect(result.success).toBe(true);
+      expect(result.summary).toEqual({
+        total: 2,
+        removed: 0,
+        notFound: 2,
+        skipped: 0,
+      });
+    });
+
+    it('skips on-chain testnet accounts with an explicit reason', async () => {
+      registry.findById.mockResolvedValue(
+        buildRun({
+          kind: BootstrapRunKind.TESTNET_ACCOUNT,
+          resources: [
+            {
+              type: BootstrapResourceType.TESTNET_ACCOUNT,
+              identifier: DEMO_ADDRESS,
+              label: 'Friendbot-funded testnet account (10000 XLM)',
+            },
+          ],
+        }),
+      );
+
+      const result = await service.teardown(RUN_ID);
+
+      expect(result.summary).toEqual({
+        total: 1,
+        removed: 0,
+        notFound: 0,
+        skipped: 1,
+      });
+      expect(result.resources[0].reason).toContain(
+        'cannot be deleted on-chain',
+      );
+      expect(demoBootstrap.removeSeededResource).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent — a second teardown reports the run as already torn down', async () => {
+      registry.findById.mockResolvedValue(
+        buildRun({
+          status: BootstrapRunStatus.TORN_DOWN,
+          tornDownAt: new Date('2026-08-02T00:00:00.000Z'),
+        }),
+      );
+
+      const result = await service.teardown(RUN_ID);
+
+      expect(result.status).toBe('already_torn_down');
+      expect(demoBootstrap.removeSeededResource).not.toHaveBeenCalled();
+      expect(registry.markTornDown).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dry run', () => {
+    it('lists what would be removed without mutating anything', async () => {
+      registry.findById.mockResolvedValue(buildRun());
+
+      const result = await service.teardown(RUN_ID, { dryRun: true });
+
+      expect(result.dryRun).toBe(true);
+      expect(result.status).toBe(BootstrapRunStatus.ACTIVE);
+      expect(result.resources.map((r) => r.action)).toEqual([
+        'would_remove',
+        'would_remove',
+      ]);
+      expect(result.summary.removed).toBe(2);
+      expect(demoBootstrap.removeSeededResource).not.toHaveBeenCalled();
+      expect(registry.markTornDown).not.toHaveBeenCalled();
+    });
+
+    it('previews an already torn-down run rather than short-circuiting', async () => {
+      registry.findById.mockResolvedValue(
+        buildRun({ status: BootstrapRunStatus.TORN_DOWN }),
+      );
+      demoBootstrap.hasSeededResource.mockReturnValue(false);
+
+      const result = await service.teardown(RUN_ID, { dryRun: true });
+
+      expect(result.dryRun).toBe(true);
+      expect(result.summary).toEqual({
+        total: 2,
+        removed: 0,
+        notFound: 2,
+        skipped: 0,
+      });
+    });
+  });
+
+  describe('listRuns', () => {
+    it('maps recorded runs to summaries with their identifiers', async () => {
+      registry.list.mockResolvedValue([buildRun()]);
+
+      const runs = await service.listRuns({});
+
+      expect(runs).toEqual([
+        {
+          runId: RUN_ID,
+          kind: BootstrapRunKind.DEMO_SEED,
+          status: BootstrapRunStatus.ACTIVE,
+          network: 'testnet',
+          environment: 'development',
+          resourceCount: 2,
+          createdAt: '2026-08-01T00:00:00.000Z',
+          tornDownAt: undefined,
+        },
+      ]);
+    });
+  });
+});

--- a/apps/backend/src/demo-bootstrap/bootstrap-teardown.service.ts
+++ b/apps/backend/src/demo-bootstrap/bootstrap-teardown.service.ts
@@ -1,0 +1,319 @@
+import {
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { config } from '../lib/config';
+import { BootstrapRunRegistryService } from '../bootstrap-runs/bootstrap-run-registry.service';
+import {
+  BootstrapResourceRecord,
+  BootstrapResourceType,
+  BootstrapRun,
+  BootstrapRunKind,
+  BootstrapRunStatus,
+} from '../bootstrap-runs/entities/bootstrap-run.entity';
+import { DemoBootstrapService } from './demo-bootstrap.service';
+import {
+  BootstrapResourceOutcomeDto,
+  BootstrapRunSummaryDto,
+  BootstrapTeardownResultDto,
+  BootstrapTeardownSummaryDto,
+  TeardownAction,
+} from './dto/bootstrap-teardown.dto';
+
+export interface TeardownOptions {
+  dryRun?: boolean;
+  requestedBy?: string | null;
+}
+
+export interface EnvironmentGate {
+  allowed: boolean;
+  reasons: string[];
+}
+
+/**
+ * Friendbot-funded testnet accounts stay on-chain forever — Stellar has no
+ * "delete account" for an account the backend does not hold the secret for.
+ * Teardown therefore discards the local record and says so explicitly rather
+ * than pretending the account is gone.
+ */
+const TESTNET_ACCOUNT_SKIP_REASON =
+  'Friendbot-funded testnet accounts cannot be deleted on-chain. The bootstrap ' +
+  'record was discarded; the account itself remains on testnet.';
+
+/**
+ * Undoes a single bootstrap run.
+ *
+ * Safety model — a teardown only runs when *both* hold:
+ *  1. NODE_ENV is not `production`, and
+ *  2. the environment is explicitly marked as testnet (`STELLAR_NETWORK=testnet`)
+ *     or as a development environment (`NODE_ENV` of `development` or `test`).
+ *
+ * Anything else — staging on mainnet, an unmarked deployment, production — is
+ * refused with 403 and an explanation. The check is evaluated per request, not
+ * cached, so a misconfigured deploy cannot leave a stale "allowed" verdict.
+ */
+@Injectable()
+export class BootstrapTeardownService {
+  private readonly logger = new Logger(BootstrapTeardownService.name);
+
+  constructor(
+    private readonly runRegistry: BootstrapRunRegistryService,
+    private readonly demoBootstrapService: DemoBootstrapService,
+  ) {}
+
+  /**
+   * Evaluates the teardown safety gate without performing any work.
+   * Exposed so callers (and the status endpoint) can check before committing.
+   */
+  evaluateEnvironmentGate(): EnvironmentGate {
+    const network = config.stellar.network;
+    const nodeEnv = config.nodeEnv;
+    const reasons: string[] = [];
+
+    if (nodeEnv === 'production') {
+      reasons.push(
+        'NODE_ENV=production — bootstrap teardown is never permitted in production',
+      );
+    }
+
+    const isMarkedTestnet = network === 'testnet';
+    const isMarkedDevelopment = nodeEnv === 'development' || nodeEnv === 'test';
+
+    if (!isMarkedTestnet && !isMarkedDevelopment) {
+      reasons.push(
+        `environment is not explicitly marked as testnet or development ` +
+          `(STELLAR_NETWORK=${network}, NODE_ENV=${nodeEnv})`,
+      );
+    }
+
+    return { allowed: reasons.length === 0, reasons };
+  }
+
+  /**
+   * Lists recorded bootstrap runs, newest first, so a contributor can find the
+   * identifier to tear down.
+   */
+  async listRuns(options: {
+    kind?: BootstrapRunKind;
+    status?: BootstrapRunStatus;
+    limit?: number;
+  }): Promise<BootstrapRunSummaryDto[]> {
+    const runs = await this.runRegistry.list(options);
+    return runs.map((run) => this.toRunSummary(run));
+  }
+
+  /**
+   * Removes everything a specific bootstrap run created.
+   *
+   * With `dryRun: true` nothing is mutated and the response lists exactly what
+   * a real teardown would do — including resources it cannot remove.
+   */
+  async teardown(
+    runId: string,
+    options: TeardownOptions = {},
+  ): Promise<BootstrapTeardownResultDto> {
+    const dryRun = options.dryRun === true;
+    const gate = this.evaluateEnvironmentGate();
+
+    if (!gate.allowed) {
+      this.logger.warn(
+        `Bootstrap teardown for run ${runId} REFUSED: ${gate.reasons.join('; ')}`,
+      );
+      throw new ForbiddenException({
+        message:
+          'Bootstrap teardown is refused in this environment. ' +
+          'It only runs against an environment explicitly marked as testnet ' +
+          '(STELLAR_NETWORK=testnet) or development (NODE_ENV=development|test), ' +
+          'and never in production.',
+        reasons: gate.reasons,
+        environment: this.describeEnvironment(),
+      });
+    }
+
+    const run = await this.runRegistry.findById(runId);
+    if (!run) {
+      throw new NotFoundException(
+        `No bootstrap run found with identifier '${runId}'. ` +
+          'Use GET /demo-bootstrap/runs to list recorded runs.',
+      );
+    }
+
+    if (run.status === BootstrapRunStatus.TORN_DOWN && !dryRun) {
+      return this.buildAlreadyTornDownResult(run);
+    }
+
+    const outcomes = run.resources.map((resource) =>
+      dryRun ? this.planRemoval(resource) : this.executeRemoval(resource),
+    );
+    const summary = this.summarize(outcomes);
+
+    if (dryRun) {
+      return {
+        success: true,
+        runId: run.id,
+        dryRun: true,
+        status: run.status,
+        message:
+          `Dry run — nothing was removed. ${summary.removed} of ${summary.total} ` +
+          `recorded resource(s) would be removed.`,
+        environment: this.describeEnvironment(),
+        resources: outcomes,
+        summary,
+      };
+    }
+
+    await this.runRegistry.markTornDown(run.id, {
+      tornDownBy: options.requestedBy ?? null,
+      summary: { ...summary, resources: outcomes },
+    });
+
+    this.logger.log(
+      `Bootstrap run ${run.id} (${run.kind}) torn down by ` +
+        `${options.requestedBy ?? 'unknown'}: removed=${summary.removed} ` +
+        `notFound=${summary.notFound} skipped=${summary.skipped}`,
+    );
+
+    return {
+      success: true,
+      runId: run.id,
+      dryRun: false,
+      status: BootstrapRunStatus.TORN_DOWN,
+      message:
+        `Bootstrap run torn down. Removed ${summary.removed} of ${summary.total} ` +
+        `recorded resource(s).`,
+      environment: this.describeEnvironment(),
+      resources: outcomes,
+      summary,
+    };
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  /** Dry-run planning: reports what would happen without mutating anything. */
+  private planRemoval(
+    resource: BootstrapResourceRecord,
+  ): BootstrapResourceOutcomeDto {
+    if (resource.type === BootstrapResourceType.TESTNET_ACCOUNT) {
+      return {
+        ...resource,
+        action: TeardownAction.SKIPPED,
+        reason: TESTNET_ACCOUNT_SKIP_REASON,
+      };
+    }
+
+    const present = this.demoBootstrapService.hasSeededResource(
+      resource.type,
+      resource.identifier,
+    );
+
+    return {
+      ...resource,
+      action: present ? TeardownAction.WOULD_REMOVE : TeardownAction.NOT_FOUND,
+      ...(present
+        ? {}
+        : {
+            reason: 'Already absent from the seeded state — nothing to remove',
+          }),
+    };
+  }
+
+  private executeRemoval(
+    resource: BootstrapResourceRecord,
+  ): BootstrapResourceOutcomeDto {
+    if (resource.type === BootstrapResourceType.TESTNET_ACCOUNT) {
+      return {
+        ...resource,
+        action: TeardownAction.SKIPPED,
+        reason: TESTNET_ACCOUNT_SKIP_REASON,
+      };
+    }
+
+    const removed = this.demoBootstrapService.removeSeededResource(
+      resource.type,
+      resource.identifier,
+    );
+
+    return {
+      ...resource,
+      action: removed ? TeardownAction.REMOVED : TeardownAction.NOT_FOUND,
+      ...(removed
+        ? {}
+        : {
+            reason: 'Already absent from the seeded state — nothing to remove',
+          }),
+    };
+  }
+
+  /**
+   * `would_remove` counts toward `removed` so a dry run and the real teardown
+   * report the same numbers for the same state.
+   */
+  private summarize(
+    outcomes: BootstrapResourceOutcomeDto[],
+  ): BootstrapTeardownSummaryDto {
+    return {
+      total: outcomes.length,
+      removed: outcomes.filter(
+        (outcome) =>
+          outcome.action === TeardownAction.REMOVED ||
+          outcome.action === TeardownAction.WOULD_REMOVE,
+      ).length,
+      notFound: outcomes.filter(
+        (outcome) => outcome.action === TeardownAction.NOT_FOUND,
+      ).length,
+      skipped: outcomes.filter(
+        (outcome) => outcome.action === TeardownAction.SKIPPED,
+      ).length,
+    };
+  }
+
+  private buildAlreadyTornDownResult(
+    run: BootstrapRun,
+  ): BootstrapTeardownResultDto {
+    const outcomes: BootstrapResourceOutcomeDto[] = run.resources.map(
+      (resource) => ({
+        ...resource,
+        action:
+          resource.type === BootstrapResourceType.TESTNET_ACCOUNT
+            ? TeardownAction.SKIPPED
+            : TeardownAction.NOT_FOUND,
+        reason:
+          resource.type === BootstrapResourceType.TESTNET_ACCOUNT
+            ? TESTNET_ACCOUNT_SKIP_REASON
+            : 'Removed by an earlier teardown of this run',
+      }),
+    );
+
+    return {
+      success: true,
+      runId: run.id,
+      dryRun: false,
+      status: 'already_torn_down',
+      message:
+        `Bootstrap run was already torn down at ` +
+        `${run.tornDownAt?.toISOString() ?? 'an earlier time'}. Nothing left to remove.`,
+      environment: this.describeEnvironment(),
+      resources: outcomes,
+      summary: this.summarize(outcomes),
+    };
+  }
+
+  private describeEnvironment(): { network: string; nodeEnv: string } {
+    return { network: config.stellar.network, nodeEnv: config.nodeEnv };
+  }
+
+  private toRunSummary(run: BootstrapRun): BootstrapRunSummaryDto {
+    return {
+      runId: run.id,
+      kind: run.kind,
+      status: run.status,
+      network: run.network,
+      environment: run.environment,
+      resourceCount: run.resources.length,
+      createdAt: run.createdAt.toISOString(),
+      tornDownAt: run.tornDownAt?.toISOString(),
+    };
+  }
+}

--- a/apps/backend/src/demo-bootstrap/demo-bootstrap.controller.ts
+++ b/apps/backend/src/demo-bootstrap/demo-bootstrap.controller.ts
@@ -5,20 +5,34 @@ import {
   Body,
   HttpCode,
   HttpStatus,
+  Param,
+  Query,
   UseGuards,
   Logger,
 } from '@nestjs/common';
 import {
   ApiOperation,
+  ApiParam,
+  ApiQuery,
   ApiResponse,
   ApiTags,
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { RolesGuard } from '../auth/roles.guard';
-import { Roles } from '../auth/decorators/auth.decorators';
-import { UserRole } from '../users/entities/user.entity';
+import { GetUser, Roles } from '../auth/decorators/auth.decorators';
+import { User, UserRole } from '../users/entities/user.entity';
+import {
+  BootstrapRunKind,
+  BootstrapRunStatus,
+} from '../bootstrap-runs/entities/bootstrap-run.entity';
+import { BootstrapTeardownService } from './bootstrap-teardown.service';
 import { DemoBootstrapService } from './demo-bootstrap.service';
+import {
+  BootstrapRunSummaryDto,
+  BootstrapTeardownResultDto,
+  TeardownBootstrapRunDto,
+} from './dto/bootstrap-teardown.dto';
 import {
   SeedDemoDto,
   SeedResultDto,
@@ -54,13 +68,19 @@ import {
  *  5. Reset seeded data:
  *       POST /v1/demo-bootstrap/reset
  *       Authorization: Bearer <admin-jwt>
+ *  6. Undo one specific run (preview first with dryRun):
+ *       GET  /v1/demo-bootstrap/runs
+ *       POST /v1/demo-bootstrap/runs/<run-id>/teardown  { "dryRun": true }
  */
 @ApiTags('demo-bootstrap')
 @Controller('demo-bootstrap')
 export class DemoBootstrapController {
   private readonly logger = new Logger(DemoBootstrapController.name);
 
-  constructor(private readonly svc: DemoBootstrapService) {}
+  constructor(
+    private readonly svc: DemoBootstrapService,
+    private readonly teardownSvc: BootstrapTeardownService,
+  ) {}
 
   @Get('status')
   @ApiOperation({
@@ -108,11 +128,16 @@ export class DemoBootstrapController {
     description:
       'Demo bootstrap is disabled in this environment (not testnet or flag not set)',
   })
-  seed(@Body() dto: SeedDemoDto): SeedResultDto {
+  seed(
+    @Body() dto: SeedDemoDto,
+    @GetUser() user: User,
+  ): Promise<SeedResultDto> {
     const scenario = dto.scenario ?? DemoScenario.FULL;
     const resetBeforeSeed = dto.resetBeforeSeed ?? true;
-    this.logger.log(`Admin requested demo seed: scenario=${scenario}`);
-    return this.svc.seed(scenario, resetBeforeSeed);
+    this.logger.log(
+      `Admin ${user.id} requested demo seed: scenario=${scenario}`,
+    );
+    return this.svc.seed(scenario, resetBeforeSeed, user.id);
   }
 
   @Post('reset')
@@ -147,5 +172,114 @@ export class DemoBootstrapController {
   reset(): ResetResultDto {
     this.logger.log('Admin requested demo data reset');
     return this.svc.reset();
+  }
+
+  @Get('runs')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'List recorded bootstrap runs (admin only)',
+    description:
+      'Returns bootstrap runs newest-first with the identifier to pass to the ' +
+      'teardown endpoint. Covers both demo seeds and Friendbot-funded testnet ' +
+      'accounts. Resource identifiers are not included — fetch a teardown dry ' +
+      'run to see exactly what a given run created.',
+  })
+  @ApiQuery({
+    name: 'kind',
+    required: false,
+    enum: Object.values(BootstrapRunKind),
+    description: 'Filter by what produced the run',
+  })
+  @ApiQuery({
+    name: 'status',
+    required: false,
+    enum: Object.values(BootstrapRunStatus),
+    description: 'Filter by run status',
+  })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: 'Maximum rows to return (default 50, max 200)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Recorded bootstrap runs',
+    type: [BootstrapRunSummaryDto],
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized — admin JWT required',
+  })
+  @ApiResponse({ status: 403, description: 'Forbidden — admin role required' })
+  listRuns(
+    @Query('kind') kind?: BootstrapRunKind,
+    @Query('status') status?: BootstrapRunStatus,
+    @Query('limit') limit?: string,
+  ): Promise<BootstrapRunSummaryDto[]> {
+    const parsedLimit = Number.parseInt(limit ?? '', 10);
+
+    return this.teardownSvc.listRuns({
+      kind,
+      status,
+      limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
+    });
+  }
+
+  @Post('runs/:runId/teardown')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary:
+      'Tear down one bootstrap run (admin only, testnet/development only)',
+    description:
+      'Removes the data created by a single bootstrap run, identified by its ' +
+      'run id. Pass { "dryRun": true } to list what would be removed without ' +
+      'changing anything. Refused with 403 unless the environment is explicitly ' +
+      'marked as testnet (STELLAR_NETWORK=testnet) or development ' +
+      '(NODE_ENV=development|test); never permitted in production. ' +
+      'Safe to call repeatedly — a run that is already torn down reports so.',
+  })
+  @ApiParam({
+    name: 'runId',
+    description:
+      'Run identifier returned by the seed/fund response or GET /runs',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Teardown completed, or dry run listing what would be removed',
+    type: BootstrapTeardownResultDto,
+  })
+  @ApiResponse({
+    status: 401,
+    description: 'Unauthorized — admin JWT required',
+  })
+  @ApiResponse({
+    status: 403,
+    description:
+      'Forbidden — admin role required, or the environment is not marked as ' +
+      'testnet or development',
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'No bootstrap run with that identifier',
+  })
+  teardownRun(
+    @Param('runId') runId: string,
+    @Body() dto: TeardownBootstrapRunDto,
+    @GetUser() user: User,
+  ): Promise<BootstrapTeardownResultDto> {
+    const dryRun = dto.dryRun ?? false;
+    this.logger.log(
+      `Admin ${user.id} requested bootstrap teardown for run ${runId} (dryRun=${dryRun})`,
+    );
+
+    return this.teardownSvc.teardown(runId, {
+      dryRun,
+      requestedBy: user.id,
+    });
   }
 }

--- a/apps/backend/src/demo-bootstrap/demo-bootstrap.module.ts
+++ b/apps/backend/src/demo-bootstrap/demo-bootstrap.module.ts
@@ -1,10 +1,13 @@
 import { Module } from '@nestjs/common';
+import { BootstrapRunsModule } from '../bootstrap-runs/bootstrap-runs.module';
+import { BootstrapTeardownService } from './bootstrap-teardown.service';
 import { DemoBootstrapController } from './demo-bootstrap.controller';
 import { DemoBootstrapService } from './demo-bootstrap.service';
 
 @Module({
+  imports: [BootstrapRunsModule],
   controllers: [DemoBootstrapController],
-  providers: [DemoBootstrapService],
-  exports: [DemoBootstrapService],
+  providers: [DemoBootstrapService, BootstrapTeardownService],
+  exports: [DemoBootstrapService, BootstrapTeardownService],
 })
 export class DemoBootstrapModule {}

--- a/apps/backend/src/demo-bootstrap/demo-bootstrap.service.spec.ts
+++ b/apps/backend/src/demo-bootstrap/demo-bootstrap.service.spec.ts
@@ -1,11 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ServiceUnavailableException } from '@nestjs/common';
+import { BootstrapRunRegistryService } from '../bootstrap-runs/bootstrap-run-registry.service';
+import { BootstrapResourceType } from '../bootstrap-runs/entities/bootstrap-run.entity';
 import { DemoBootstrapService } from './demo-bootstrap.service';
 import { DemoScenario } from './dto/demo-bootstrap.dto';
 
 // Mock the config module before importing the service
 jest.mock('../lib/config', () => ({
   config: {
+    nodeEnv: 'test',
     stellar: {
       network: 'testnet',
     },
@@ -18,16 +21,27 @@ jest.mock('../lib/config', () => ({
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { config } = require('../lib/config');
 
+const DEMO_ALICE_ADDRESS =
+  'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+
 describe('DemoBootstrapService', () => {
   let service: DemoBootstrapService;
+  let runRegistry: { recordSafely: jest.Mock };
 
   beforeEach(async () => {
     // Reset config to testnet + enabled before each test
     config.stellar.network = 'testnet';
     config.featureFlags.bootstrapDemoData = true;
 
+    runRegistry = {
+      recordSafely: jest.fn().mockResolvedValue('run-1'),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DemoBootstrapService],
+      providers: [
+        DemoBootstrapService,
+        { provide: BootstrapRunRegistryService, useValue: runRegistry },
+      ],
     }).compile();
 
     service = module.get<DemoBootstrapService>(DemoBootstrapService);
@@ -62,8 +76,8 @@ describe('DemoBootstrapService', () => {
       expect(status.lastSeededAt).toBeUndefined();
     });
 
-    it('should return isSeeded=true after seeding', () => {
-      service.seed();
+    it('should return isSeeded=true after seeding', async () => {
+      await service.seed();
       const status = service.getStatus();
       expect(status.isSeeded).toBe(true);
       expect(status.lastSeededAt).toBeDefined();
@@ -72,29 +86,29 @@ describe('DemoBootstrapService', () => {
   });
 
   describe('seed', () => {
-    it('should seed full scenario by default', () => {
-      const result = service.seed();
+    it('should seed full scenario by default', async () => {
+      const result = await service.seed();
       expect(result.success).toBe(true);
       expect(result.seededAt).toBeDefined();
       expect(result.details?.contributorsSeeded).toBe(3);
       expect(result.details?.grantRoundsSeeded).toBe(2);
     });
 
-    it('should seed only contributors when scenario=contributors', () => {
-      const result = service.seed(DemoScenario.CONTRIBUTORS);
+    it('should seed only contributors when scenario=contributors', async () => {
+      const result = await service.seed(DemoScenario.CONTRIBUTORS);
       expect(result.details?.contributorsSeeded).toBe(3);
       expect(result.details?.grantRoundsSeeded).toBe(0);
     });
 
-    it('should seed only grant rounds when scenario=grant_round', () => {
-      const result = service.seed(DemoScenario.GRANT_ROUND);
+    it('should seed only grant rounds when scenario=grant_round', async () => {
+      const result = await service.seed(DemoScenario.GRANT_ROUND);
       expect(result.details?.contributorsSeeded).toBe(0);
       expect(result.details?.grantRoundsSeeded).toBe(2);
     });
 
-    it('should be idempotent — calling seed twice resets state', () => {
-      service.seed();
-      const second = service.seed();
+    it('should be idempotent — calling seed twice resets state', async () => {
+      await service.seed();
+      const second = await service.seed();
       expect(second.success).toBe(true);
       expect(second.seededAt).toBeDefined();
       // After second seed, status should reflect the latest seed
@@ -102,15 +116,99 @@ describe('DemoBootstrapService', () => {
       expect(status.isSeeded).toBe(true);
     });
 
-    it('should throw ServiceUnavailableException when not allowed', () => {
+    it('should throw ServiceUnavailableException when not allowed', async () => {
       config.stellar.network = 'mainnet';
-      expect(() => service.seed()).toThrow(ServiceUnavailableException);
+      await expect(service.seed()).rejects.toBeInstanceOf(
+        ServiceUnavailableException,
+      );
+    });
+
+    it('records a bootstrap run describing every seeded resource', async () => {
+      const result = await service.seed(DemoScenario.FULL, true, 'admin-1');
+
+      expect(result.runId).toBe('run-1');
+      expect(runRegistry.recordSafely).toHaveBeenCalledTimes(1);
+
+      const recorded = runRegistry.recordSafely.mock.calls[0][0];
+      expect(recorded.kind).toBe('demo_seed');
+      expect(recorded.createdBy).toBe('admin-1');
+      expect(recorded.resources).toHaveLength(5);
+      expect(recorded.resources).toContainEqual({
+        type: BootstrapResourceType.DEMO_CONTRIBUTOR,
+        identifier: DEMO_ALICE_ADDRESS,
+        label: 'Demo contributor demo-alice',
+      });
+    });
+
+    it('still seeds when the run registry write fails', async () => {
+      runRegistry.recordSafely.mockResolvedValueOnce(null);
+
+      const result = await service.seed();
+
+      expect(result.success).toBe(true);
+      expect(result.runId).toBeUndefined();
+      expect(service.getStatus().isSeeded).toBe(true);
+    });
+  });
+
+  describe('per-resource removal', () => {
+    it('reports a seeded resource as present, then removes it once', async () => {
+      await service.seed(DemoScenario.CONTRIBUTORS);
+
+      expect(
+        service.hasSeededResource(
+          BootstrapResourceType.DEMO_CONTRIBUTOR,
+          DEMO_ALICE_ADDRESS,
+        ),
+      ).toBe(true);
+      expect(
+        service.removeSeededResource(
+          BootstrapResourceType.DEMO_CONTRIBUTOR,
+          DEMO_ALICE_ADDRESS,
+        ),
+      ).toBe(true);
+      // Second removal is a no-op — teardown reports it as not_found.
+      expect(
+        service.removeSeededResource(
+          BootstrapResourceType.DEMO_CONTRIBUTOR,
+          DEMO_ALICE_ADDRESS,
+        ),
+      ).toBe(false);
+    });
+
+    it('reports isSeeded=false once the last resource is removed', async () => {
+      await service.seed(DemoScenario.GRANT_ROUND);
+
+      expect(
+        service.removeSeededResource(
+          BootstrapResourceType.DEMO_GRANT_ROUND,
+          '0',
+        ),
+      ).toBe(true);
+      expect(
+        service.removeSeededResource(
+          BootstrapResourceType.DEMO_GRANT_ROUND,
+          '1',
+        ),
+      ).toBe(true);
+      expect(service.getStatus().isSeeded).toBe(false);
+    });
+
+    it('never removes a testnet account resource', async () => {
+      await service.seed();
+
+      expect(
+        service.removeSeededResource(
+          BootstrapResourceType.TESTNET_ACCOUNT,
+          DEMO_ALICE_ADDRESS,
+        ),
+      ).toBe(false);
     });
   });
 
   describe('reset', () => {
-    it('should clear seeded data', () => {
-      service.seed();
+    it('should clear seeded data', async () => {
+      await service.seed();
       expect(service.getStatus().isSeeded).toBe(true);
 
       const result = service.reset();

--- a/apps/backend/src/demo-bootstrap/demo-bootstrap.service.ts
+++ b/apps/backend/src/demo-bootstrap/demo-bootstrap.service.ts
@@ -4,6 +4,12 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { config } from '../lib/config';
+import { BootstrapRunRegistryService } from '../bootstrap-runs/bootstrap-run-registry.service';
+import {
+  BootstrapResourceRecord,
+  BootstrapResourceType,
+  BootstrapRunKind,
+} from '../bootstrap-runs/entities/bootstrap-run.entity';
 import {
   DemoScenario,
   SeedResultDto,
@@ -25,6 +31,8 @@ import {
  *  - All seed operations are idempotent — callers can pass resetBeforeSeed=true
  *    (the default) to clear previous state before re-seeding.
  *  - No real on-chain transactions are submitted; data is held in-memory.
+ *  - Every seed is recorded as a bootstrap run so it can later be undone by
+ *    identifier through the teardown endpoint. See BootstrapTeardownService.
  */
 interface SeededContributor {
   address: string;
@@ -54,6 +62,8 @@ interface SeededState {
 export class DemoBootstrapService {
   private readonly logger = new Logger(DemoBootstrapService.name);
   private state: SeededState | null = null;
+
+  constructor(private readonly runRegistry: BootstrapRunRegistryService) {}
 
   /**
    * Returns true when the bootstrap endpoints are permitted:
@@ -89,11 +99,16 @@ export class DemoBootstrapService {
   /**
    * POST /demo-bootstrap/seed
    * Seeds demo data. Idempotent — safe to call repeatedly.
+   *
+   * The returned `runId` identifies everything this call created and is the
+   * handle the teardown endpoint takes. It is absent only when the registry
+   * write failed, which is logged but never fails the seed itself.
    */
-  seed(
+  async seed(
     scenario: DemoScenario = DemoScenario.FULL,
     resetBeforeSeed = true,
-  ): SeedResultDto {
+    createdBy: string | null = null,
+  ): Promise<SeedResultDto> {
     this.assertEnvironmentAllowed();
 
     if (resetBeforeSeed) {
@@ -120,14 +135,22 @@ export class DemoBootstrapService {
 
     this.state = { contributors, grantRounds, seededAt };
 
+    const runId = await this.runRegistry.recordSafely({
+      kind: BootstrapRunKind.DEMO_SEED,
+      createdBy,
+      resources: this.describeSeededResources(contributors, grantRounds),
+    });
+
     this.logger.log(
-      `Demo data seeded: scenario=${scenario} contributors=${contributors.length} grantRounds=${grantRounds.length}`,
+      `Demo data seeded: scenario=${scenario} contributors=${contributors.length} ` +
+        `grantRounds=${grantRounds.length} runId=${runId ?? 'untracked'}`,
     );
 
     return {
       success: true,
       message: `Successfully seeded demo scenario '${scenario}'`,
       seededAt,
+      runId: runId ?? undefined,
       details: {
         scenario,
         contributorsSeeded: contributors.length,
@@ -138,7 +161,8 @@ export class DemoBootstrapService {
 
   /**
    * POST /demo-bootstrap/reset
-   * Clears all seeded demo data.
+   * Clears all seeded demo data regardless of which run produced it. Use the
+   * teardown endpoint instead when only one run should be undone.
    */
   reset(): ResetResultDto {
     this.assertEnvironmentAllowed();
@@ -153,6 +177,67 @@ export class DemoBootstrapService {
         ? 'Demo data has been cleared'
         : 'No demo data was present — nothing to clear',
     };
+  }
+
+  /**
+   * Whether a resource recorded by a bootstrap run is still present in the
+   * seeded state. Used by the teardown dry run.
+   */
+  hasSeededResource(type: BootstrapResourceType, identifier: string): boolean {
+    if (!this.state) {
+      return false;
+    }
+
+    if (type === BootstrapResourceType.DEMO_CONTRIBUTOR) {
+      return this.state.contributors.some(
+        (contributor) => contributor.address === identifier,
+      );
+    }
+
+    if (type === BootstrapResourceType.DEMO_GRANT_ROUND) {
+      return this.state.grantRounds.some(
+        (round) => String(round.id) === identifier,
+      );
+    }
+
+    return false;
+  }
+
+  /**
+   * Removes a single seeded resource. Returns true when something was
+   * actually removed, false when it was already gone — teardown relies on
+   * that distinction to report `removed` versus `not_found`.
+   */
+  removeSeededResource(
+    type: BootstrapResourceType,
+    identifier: string,
+  ): boolean {
+    if (!this.state || !this.hasSeededResource(type, identifier)) {
+      return false;
+    }
+
+    if (type === BootstrapResourceType.DEMO_CONTRIBUTOR) {
+      this.state.contributors = this.state.contributors.filter(
+        (contributor) => contributor.address !== identifier,
+      );
+    } else if (type === BootstrapResourceType.DEMO_GRANT_ROUND) {
+      this.state.grantRounds = this.state.grantRounds.filter(
+        (round) => String(round.id) !== identifier,
+      );
+    } else {
+      return false;
+    }
+
+    // Drop the state object entirely once the last resource is gone so
+    // getStatus() reports isSeeded=false rather than an empty seed.
+    if (
+      this.state.contributors.length === 0 &&
+      this.state.grantRounds.length === 0
+    ) {
+      this.resetInternal();
+    }
+
+    return true;
   }
 
   // ── Private helpers ────────────────────────────────────────────────────────
@@ -173,6 +258,24 @@ export class DemoBootstrapService {
           'Set STELLAR_NETWORK=testnet and BOOTSTRAP_DEMO_DATA_ENABLED=true to enable.',
       );
     }
+  }
+
+  private describeSeededResources(
+    contributors: SeededContributor[],
+    grantRounds: SeededGrantRound[],
+  ): BootstrapResourceRecord[] {
+    return [
+      ...contributors.map((contributor) => ({
+        type: BootstrapResourceType.DEMO_CONTRIBUTOR,
+        identifier: contributor.address,
+        label: `Demo contributor ${contributor.githubHandle}`,
+      })),
+      ...grantRounds.map((round) => ({
+        type: BootstrapResourceType.DEMO_GRANT_ROUND,
+        identifier: String(round.id),
+        label: round.name,
+      })),
+    ];
   }
 
   private resetInternal(): void {

--- a/apps/backend/src/demo-bootstrap/dto/bootstrap-teardown.dto.ts
+++ b/apps/backend/src/demo-bootstrap/dto/bootstrap-teardown.dto.ts
@@ -1,0 +1,162 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+import type {
+  BootstrapResourceType,
+  BootstrapRunKind,
+  BootstrapRunStatus,
+} from '../../bootstrap-runs/entities/bootstrap-run.entity';
+
+/**
+ * What happened (or would happen) to a single resource during teardown.
+ *
+ * `removed`      — the resource existed and was deleted.
+ * `would_remove` — dry run only; the resource exists and would be deleted.
+ * `not_found`    — the resource was already gone (teardown stays idempotent).
+ * `skipped`      — the backend cannot delete it; see `reason`.
+ */
+export const TeardownAction = {
+  REMOVED: 'removed',
+  WOULD_REMOVE: 'would_remove',
+  NOT_FOUND: 'not_found',
+  SKIPPED: 'skipped',
+} as const;
+
+export type TeardownAction =
+  (typeof TeardownAction)[keyof typeof TeardownAction];
+
+export class TeardownBootstrapRunDto {
+  @ApiPropertyOptional({
+    description:
+      'When true, nothing is removed — the response lists exactly what a real ' +
+      'teardown would delete. Defaults to false.',
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  dryRun?: boolean = false;
+}
+
+export class BootstrapResourceOutcomeDto {
+  @ApiProperty({
+    description: 'Resource type',
+    example: 'demo_contributor',
+  })
+  type!: BootstrapResourceType;
+
+  @ApiProperty({
+    description: 'Identifier of the resource within its type',
+    example: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  })
+  identifier!: string;
+
+  @ApiProperty({
+    description: 'Human-readable label recorded when the resource was created',
+    example: 'Demo contributor demo-alice',
+  })
+  label!: string;
+
+  @ApiProperty({
+    description: 'What happened, or would happen in a dry run',
+    enum: Object.values(TeardownAction),
+    example: TeardownAction.REMOVED,
+  })
+  action!: TeardownAction;
+
+  @ApiPropertyOptional({
+    description: 'Why the resource was skipped, when applicable',
+  })
+  reason?: string;
+}
+
+export class BootstrapTeardownSummaryDto {
+  @ApiProperty({ description: 'Total resources recorded for the run' })
+  total!: number;
+
+  @ApiProperty({
+    description: 'Resources removed (or, in a dry run, that would be removed)',
+  })
+  removed!: number;
+
+  @ApiProperty({ description: 'Resources that were already gone' })
+  notFound!: number;
+
+  @ApiProperty({
+    description:
+      'Resources the backend cannot remove — see per-resource reason',
+  })
+  skipped!: number;
+}
+
+export class BootstrapEnvironmentDto {
+  @ApiProperty({ description: 'Stellar network', example: 'testnet' })
+  network!: string;
+
+  @ApiProperty({
+    description: 'NODE_ENV of the running backend',
+    example: 'development',
+  })
+  nodeEnv!: string;
+}
+
+export class BootstrapTeardownResultDto {
+  @ApiProperty({ description: 'Whether the teardown (or dry run) completed' })
+  success!: boolean;
+
+  @ApiProperty({ description: 'The run identifier that was torn down' })
+  runId!: string;
+
+  @ApiProperty({
+    description: 'True when nothing was mutated because dryRun was requested',
+  })
+  dryRun!: boolean;
+
+  @ApiProperty({
+    description:
+      'Run status after the call: "torn_down" once executed, "active" for a ' +
+      'dry run, "already_torn_down" when the run had been torn down before.',
+    example: 'torn_down',
+  })
+  status!: string;
+
+  @ApiProperty({ description: 'Human-readable summary' })
+  message!: string;
+
+  @ApiProperty({ type: BootstrapEnvironmentDto })
+  environment!: BootstrapEnvironmentDto;
+
+  @ApiProperty({ type: [BootstrapResourceOutcomeDto] })
+  resources!: BootstrapResourceOutcomeDto[];
+
+  @ApiProperty({ type: BootstrapTeardownSummaryDto })
+  summary!: BootstrapTeardownSummaryDto;
+}
+
+export class BootstrapRunSummaryDto {
+  @ApiProperty({
+    description: 'Run identifier — pass this to the teardown endpoint',
+  })
+  runId!: string;
+
+  @ApiProperty({ description: 'What produced the run', example: 'demo_seed' })
+  kind!: BootstrapRunKind;
+
+  @ApiProperty({ description: 'Run status', example: 'active' })
+  status!: BootstrapRunStatus;
+
+  @ApiProperty({ description: 'Stellar network the run targeted' })
+  network!: string;
+
+  @ApiProperty({ description: 'NODE_ENV at the time of the run' })
+  environment!: string;
+
+  @ApiProperty({ description: 'Number of resources recorded for the run' })
+  resourceCount!: number;
+
+  @ApiProperty({ description: 'ISO timestamp when the run was recorded' })
+  createdAt!: string;
+
+  @ApiPropertyOptional({
+    description: 'ISO timestamp when the run was torn down',
+  })
+  tornDownAt?: string;
+}

--- a/apps/backend/src/demo-bootstrap/dto/demo-bootstrap.dto.ts
+++ b/apps/backend/src/demo-bootstrap/dto/demo-bootstrap.dto.ts
@@ -44,6 +44,14 @@ export class SeedResultDto {
   seededAt: string;
 
   @ApiPropertyOptional({
+    description:
+      'Identifier of the recorded bootstrap run. Pass it to ' +
+      'POST /demo-bootstrap/runs/{runId}/teardown to undo exactly this seed. ' +
+      'Absent when the run could not be recorded (the seed still applied).',
+  })
+  runId?: string;
+
+  @ApiPropertyOptional({
     description: 'Details about seeded entities',
   })
   details?: Record<string, unknown>;

--- a/apps/backend/src/health/deployment-smoke.service.spec.ts
+++ b/apps/backend/src/health/deployment-smoke.service.spec.ts
@@ -1,0 +1,221 @@
+jest.mock('../lib/config', () => ({
+  config: {
+    nodeEnv: 'test',
+    stellar: { network: 'testnet' },
+  },
+}));
+
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CacheService } from '../cache/cache.service';
+import { StellarService } from '../stellar/stellar.service';
+import { ContractHealthService } from './contract-health.service';
+import { DeploymentSmokeService } from './deployment-smoke.service';
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { config } = require('../lib/config');
+
+const REQUIRED_ENV = {
+  DB_HOST: 'localhost',
+  DB_PORT: '5432',
+  DB_USERNAME: 'lumenpulse',
+  DB_PASSWORD: 'super-secret-password',
+  DB_DATABASE: 'lumenpulse',
+  PORT: '3000',
+  JWT_SECRET: 'super-secret-jwt',
+  STELLAR_SERVER_SECRET: 'SBSECRETSECRETSECRET',
+  CORS_ORIGIN: 'http://localhost:3000',
+  PYTHON_API_URL: 'http://localhost:8000',
+};
+
+describe('DeploymentSmokeService', () => {
+  let service: DeploymentSmokeService;
+  let dataSource: { query: jest.Mock };
+  let cacheService: { checkHealth: jest.Mock };
+  let stellarService: { checkHealth: jest.Mock };
+  let contractHealthService: { getContractHealthReport: jest.Mock };
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    originalEnv = process.env;
+    process.env = { ...originalEnv, ...REQUIRED_ENV };
+    config.nodeEnv = 'test';
+    config.stellar.network = 'testnet';
+
+    dataSource = { query: jest.fn().mockResolvedValue([{ '?column?': 1 }]) };
+    cacheService = { checkHealth: jest.fn().mockResolvedValue(true) };
+    stellarService = { checkHealth: jest.fn().mockResolvedValue(true) };
+    contractHealthService = {
+      getContractHealthReport: jest.fn().mockResolvedValue({
+        contracts: [
+          {
+            name: 'lumenToken',
+            envVar: 'STELLAR_CONTRACT_LUMEN_TOKEN',
+            status: 'reachable',
+          },
+        ],
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeploymentSmokeService,
+        { provide: getDataSourceToken(), useValue: dataSource },
+        { provide: CacheService, useValue: cacheService },
+        { provide: StellarService, useValue: stellarService },
+        { provide: ContractHealthService, useValue: contractHealthService },
+      ],
+    }).compile();
+
+    service = module.get(DeploymentSmokeService);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.clearAllMocks();
+  });
+
+  it('passes when config, dependencies and contracts are all healthy', async () => {
+    const report = await service.getSmokeReport();
+
+    expect(report.status).toBe('pass');
+    expect(report.ready).toBe(true);
+    expect(report.summary.failed).toBe(0);
+    expect(report.network).toBe('testnet');
+    expect(report.checks.map((check) => check.id)).toContain(
+      'contract.lumenToken',
+    );
+  });
+
+  it('fails when a required environment variable is missing', async () => {
+    delete process.env.JWT_SECRET;
+
+    const report = await service.getSmokeReport();
+
+    expect(report.status).toBe('fail');
+    expect(report.ready).toBe(false);
+    expect(
+      report.checks.find((check) => check.id === 'env.JWT_SECRET'),
+    ).toMatchObject({ status: 'fail' });
+  });
+
+  it('accepts DB_NAME as the DB_DATABASE fallback', async () => {
+    delete process.env.DB_DATABASE;
+    process.env.DB_NAME = 'lumenpulse';
+
+    const report = await service.getSmokeReport();
+
+    expect(
+      report.checks.find((check) => check.id === 'env.DB_DATABASE'),
+    ).toMatchObject({ status: 'pass' });
+  });
+
+  it('treats a conditional variable as a warning when it is not required', async () => {
+    delete process.env.PYTHON_API_URL;
+    config.nodeEnv = 'test';
+
+    const report = await service.getSmokeReport();
+
+    expect(
+      report.checks.find((check) => check.id === 'env.PYTHON_API_URL'),
+    ).toMatchObject({ status: 'warn' });
+    expect(report.status).toBe('warn');
+    expect(report.ready).toBe(true);
+  });
+
+  it('treats a conditional variable as a failure when its condition holds', async () => {
+    delete process.env.CORS_ORIGIN;
+    config.nodeEnv = 'production';
+
+    const report = await service.getSmokeReport();
+
+    expect(
+      report.checks.find((check) => check.id === 'env.CORS_ORIGIN'),
+    ).toMatchObject({ status: 'fail' });
+    expect(report.ready).toBe(false);
+  });
+
+  it('never echoes an environment variable value', async () => {
+    const report = await service.getSmokeReport();
+    const serialized = JSON.stringify(report);
+
+    expect(serialized).not.toContain(REQUIRED_ENV.DB_PASSWORD);
+    expect(serialized).not.toContain(REQUIRED_ENV.JWT_SECRET);
+    expect(serialized).not.toContain(REQUIRED_ENV.STELLAR_SERVER_SECRET);
+  });
+
+  it('reports a fixed message instead of the driver error when the database is down', async () => {
+    dataSource.query.mockRejectedValue(
+      new Error(
+        'connect ECONNREFUSED postgres://lumenpulse:super-secret-password@10.0.0.4:5432',
+      ),
+    );
+
+    const report = await service.getSmokeReport();
+    const check = report.checks.find(
+      (entry) => entry.id === 'dependency.database',
+    );
+
+    expect(check).toMatchObject({
+      status: 'fail',
+      message: 'Database is unreachable',
+    });
+    expect(JSON.stringify(report)).not.toContain('ECONNREFUSED');
+    expect(report.ready).toBe(false);
+  });
+
+  it('degrades rather than fails when only Redis is unavailable', async () => {
+    cacheService.checkHealth.mockResolvedValue(false);
+
+    const report = await service.getSmokeReport();
+
+    expect(report.status).toBe('warn');
+    expect(report.ready).toBe(true);
+  });
+
+  it('fails when Horizon is unreachable', async () => {
+    stellarService.checkHealth.mockResolvedValue(false);
+
+    const report = await service.getSmokeReport();
+
+    expect(report.ready).toBe(false);
+    expect(
+      report.checks.find((check) => check.id === 'dependency.horizon'),
+    ).toMatchObject({ status: 'fail' });
+  });
+
+  it('fails when a contract ID is misconfigured, naming the env var to fix', async () => {
+    contractHealthService.getContractHealthReport.mockResolvedValue({
+      contracts: [
+        {
+          name: 'treasury',
+          envVar: 'STELLAR_CONTRACT_TREASURY',
+          status: 'misconfigured',
+        },
+      ],
+    });
+
+    const report = await service.getSmokeReport();
+    const check = report.checks.find(
+      (entry) => entry.id === 'contract.treasury',
+    );
+
+    expect(check?.status).toBe('fail');
+    expect(check?.message).toContain('STELLAR_CONTRACT_TREASURY');
+    expect(report.ready).toBe(false);
+  });
+
+  it('fails closed when the contract report itself throws', async () => {
+    contractHealthService.getContractHealthReport.mockRejectedValue(
+      new Error('soroban rpc exploded'),
+    );
+
+    const report = await service.getSmokeReport();
+
+    expect(report.ready).toBe(false);
+    expect(
+      report.checks.find((check) => check.id === 'contract.report'),
+    ).toMatchObject({ status: 'fail' });
+    expect(JSON.stringify(report)).not.toContain('soroban rpc exploded');
+  });
+});

--- a/apps/backend/src/health/deployment-smoke.service.ts
+++ b/apps/backend/src/health/deployment-smoke.service.ts
@@ -1,0 +1,318 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+import { CacheService } from '../cache/cache.service';
+import { config } from '../lib/config';
+import { StellarService } from '../stellar/stellar.service';
+import { ContractHealthService } from './contract-health.service';
+
+export type SmokeStatus = 'pass' | 'warn' | 'fail';
+
+export type SmokeCategory = 'config' | 'dependency' | 'contract';
+
+export interface DeploymentSmokeCheck {
+  /** Stable identifier — CI can assert on this without parsing prose. */
+  id: string;
+  category: SmokeCategory;
+  status: SmokeStatus;
+  /** Fixed, non-sensitive explanation. Never contains a config value. */
+  message: string;
+}
+
+export interface DeploymentSmokeSummary {
+  total: number;
+  passed: number;
+  warned: number;
+  failed: number;
+}
+
+export interface DeploymentSmokeReport {
+  /** Worst status across all checks. */
+  status: SmokeStatus;
+  /** Convenience boolean for CI: true unless something failed. */
+  ready: boolean;
+  checkedAt: string;
+  durationMs: number;
+  network: string;
+  environment: string;
+  summary: DeploymentSmokeSummary;
+  checks: DeploymentSmokeCheck[];
+}
+
+/**
+ * Environment variables the backend cannot run without. Presence only is ever
+ * reported — never the value, never a prefix, never a length.
+ */
+const REQUIRED_ENV_VARS = [
+  'DB_HOST',
+  'DB_PORT',
+  'DB_USERNAME',
+  'DB_PASSWORD',
+  'PORT',
+  'JWT_SECRET',
+  'STELLAR_SERVER_SECRET',
+] as const;
+
+/**
+ * Variables that are only required in some environments. Each entry explains
+ * the condition so a red CI check is actionable without reading this file.
+ */
+const CONDITIONAL_ENV_VARS: {
+  name: string;
+  isRequired: () => boolean;
+  requirement: string;
+}[] = [
+  {
+    name: 'CORS_ORIGIN',
+    isRequired: () => config.nodeEnv === 'production',
+    requirement: 'required when NODE_ENV=production',
+  },
+  {
+    name: 'PYTHON_API_URL',
+    isRequired: () =>
+      config.nodeEnv !== 'development' && config.nodeEnv !== 'test',
+    requirement: 'required outside development and test',
+  },
+];
+
+/**
+ * Single endpoint for CI and Vercel deployment checks: is this backend, and
+ * are the testnet dependencies it needs, actually ready?
+ *
+ * Public-safety rules this service holds to:
+ *  - Environment variables are reported as present/absent by name only.
+ *  - Contract IDs come from ContractHealthService, which already redacts them.
+ *  - Dependency failures use fixed messages, never the driver's error text,
+ *    so a connection string or host can never surface in the response.
+ */
+@Injectable()
+export class DeploymentSmokeService {
+  private readonly logger = new Logger(DeploymentSmokeService.name);
+
+  constructor(
+    @InjectDataSource() private readonly dataSource: DataSource,
+    private readonly cacheService: CacheService,
+    private readonly stellarService: StellarService,
+    private readonly contractHealthService: ContractHealthService,
+  ) {}
+
+  async getSmokeReport(): Promise<DeploymentSmokeReport> {
+    const startedAt = Date.now();
+
+    const [dependencyChecks, contractChecks] = await Promise.all([
+      this.checkDependencies(),
+      this.checkContracts(),
+    ]);
+
+    const checks = [
+      ...this.checkEnvironment(),
+      ...dependencyChecks,
+      ...contractChecks,
+    ];
+    const summary = this.summarize(checks);
+    const status = this.worstStatus(checks);
+
+    if (status === 'fail') {
+      this.logger.warn(
+        `Deployment smoke check failed: ${summary.failed} of ${summary.total} checks failed`,
+      );
+    }
+
+    return {
+      status,
+      ready: status !== 'fail',
+      checkedAt: new Date().toISOString(),
+      durationMs: Date.now() - startedAt,
+      network: config.stellar.network,
+      environment: config.nodeEnv,
+      summary,
+      checks,
+    };
+  }
+
+  // ── Config ─────────────────────────────────────────────────────────────────
+
+  private checkEnvironment(): DeploymentSmokeCheck[] {
+    const checks: DeploymentSmokeCheck[] = REQUIRED_ENV_VARS.map((name) => ({
+      id: `env.${name}`,
+      category: 'config' as const,
+      status: this.isEnvPresent(name) ? ('pass' as const) : ('fail' as const),
+      message: this.isEnvPresent(name)
+        ? `${name} is set`
+        : `${name} is missing — the backend cannot operate without it`,
+    }));
+
+    // DB_DATABASE accepts DB_NAME as a fallback (see lib/config.ts).
+    const hasDatabaseName =
+      this.isEnvPresent('DB_DATABASE') || this.isEnvPresent('DB_NAME');
+    checks.push({
+      id: 'env.DB_DATABASE',
+      category: 'config',
+      status: hasDatabaseName ? 'pass' : 'fail',
+      message: hasDatabaseName
+        ? 'DB_DATABASE (or DB_NAME) is set'
+        : 'DB_DATABASE is missing — set DB_DATABASE or DB_NAME',
+    });
+
+    for (const conditional of CONDITIONAL_ENV_VARS) {
+      const present = this.isEnvPresent(conditional.name);
+      const required = conditional.isRequired();
+
+      checks.push({
+        id: `env.${conditional.name}`,
+        category: 'config',
+        status: present ? 'pass' : required ? 'fail' : 'warn',
+        message: present
+          ? `${conditional.name} is set`
+          : `${conditional.name} is not set (${conditional.requirement})`,
+      });
+    }
+
+    return checks;
+  }
+
+  private isEnvPresent(name: string): boolean {
+    const raw = process.env[name];
+    return typeof raw === 'string' && raw.trim().length > 0;
+  }
+
+  // ── Dependencies ───────────────────────────────────────────────────────────
+
+  private async checkDependencies(): Promise<DeploymentSmokeCheck[]> {
+    const [database, redis, horizon] = await Promise.all([
+      this.checkDatabase(),
+      this.checkRedis(),
+      this.checkHorizon(),
+    ]);
+
+    return [database, redis, horizon];
+  }
+
+  private async checkDatabase(): Promise<DeploymentSmokeCheck> {
+    try {
+      await this.dataSource.query('SELECT 1');
+      return {
+        id: 'dependency.database',
+        category: 'dependency',
+        status: 'pass',
+        message: 'Database accepted a connection',
+      };
+    } catch (error) {
+      // The driver error can embed host/user details — log it, never return it.
+      this.logger.error(
+        `Deployment smoke database check failed: ${this.describeError(error)}`,
+      );
+      return {
+        id: 'dependency.database',
+        category: 'dependency',
+        status: 'fail',
+        message: 'Database is unreachable',
+      };
+    }
+  }
+
+  private async checkRedis(): Promise<DeploymentSmokeCheck> {
+    const isHealthy = await this.cacheService.checkHealth();
+
+    return {
+      id: 'dependency.redis',
+      category: 'dependency',
+      // Redis degrades rather than breaks the API, so a miss is a warning.
+      status: isHealthy ? 'pass' : 'warn',
+      message: isHealthy
+        ? 'Redis cache responded'
+        : 'Redis cache is unreachable — the API runs uncached',
+    };
+  }
+
+  private async checkHorizon(): Promise<DeploymentSmokeCheck> {
+    const isHealthy = await this.stellarService.checkHealth();
+
+    return {
+      id: 'dependency.horizon',
+      category: 'dependency',
+      status: isHealthy ? 'pass' : 'fail',
+      message: isHealthy
+        ? `Stellar Horizon responded on ${config.stellar.network}`
+        : `Stellar Horizon is unreachable on ${config.stellar.network}`,
+    };
+  }
+
+  // ── Contracts ──────────────────────────────────────────────────────────────
+
+  private async checkContracts(): Promise<DeploymentSmokeCheck[]> {
+    try {
+      const report = await this.contractHealthService.getContractHealthReport();
+
+      return report.contracts.map((contract) => ({
+        id: `contract.${contract.name}`,
+        category: 'contract' as const,
+        status: this.contractStatusToSmokeStatus(contract.status),
+        message: this.describeContract(
+          contract.name,
+          contract.status,
+          contract.envVar,
+        ),
+      }));
+    } catch (error) {
+      this.logger.error(
+        `Deployment smoke contract check failed: ${this.describeError(error)}`,
+      );
+      return [
+        {
+          id: 'contract.report',
+          category: 'contract',
+          status: 'fail',
+          message: 'Contract reachability could not be determined',
+        },
+      ];
+    }
+  }
+
+  private contractStatusToSmokeStatus(
+    status: 'reachable' | 'misconfigured' | 'unreachable',
+  ): SmokeStatus {
+    return status === 'reachable' ? 'pass' : 'fail';
+  }
+
+  private describeContract(
+    name: string,
+    status: 'reachable' | 'misconfigured' | 'unreachable',
+    envVar: string,
+  ): string {
+    if (status === 'reachable') {
+      return `${name} contract is reachable`;
+    }
+
+    if (status === 'misconfigured') {
+      return `${name} contract is misconfigured — check ${envVar}`;
+    }
+
+    return `${name} contract is configured but not callable on ${config.stellar.network}`;
+  }
+
+  // ── Aggregation ────────────────────────────────────────────────────────────
+
+  private summarize(checks: DeploymentSmokeCheck[]): DeploymentSmokeSummary {
+    return {
+      total: checks.length,
+      passed: checks.filter((check) => check.status === 'pass').length,
+      warned: checks.filter((check) => check.status === 'warn').length,
+      failed: checks.filter((check) => check.status === 'fail').length,
+    };
+  }
+
+  private worstStatus(checks: DeploymentSmokeCheck[]): SmokeStatus {
+    if (checks.some((check) => check.status === 'fail')) {
+      return 'fail';
+    }
+    if (checks.some((check) => check.status === 'warn')) {
+      return 'warn';
+    }
+    return 'pass';
+  }
+
+  private describeError(error: unknown): string {
+    return error instanceof Error ? error.message : 'unknown error';
+  }
+}

--- a/apps/backend/src/health/health.controller.ts
+++ b/apps/backend/src/health/health.controller.ts
@@ -1,4 +1,9 @@
-import { Controller, Get, Res, ServiceUnavailableException } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Res,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { HealthCheck } from '@nestjs/terminus';
 import {
   ApiOkResponse,
@@ -8,6 +13,7 @@ import {
 } from '@nestjs/swagger';
 import type { Response } from 'express';
 import { ContractHealthService } from './contract-health.service';
+import { DeploymentSmokeService } from './deployment-smoke.service';
 import { HealthService } from './health.service';
 import { ShutdownService } from './shutdown.service';
 
@@ -17,6 +23,7 @@ export class HealthController {
   constructor(
     private readonly healthService: HealthService,
     private readonly contractHealthService: ContractHealthService,
+    private readonly deploymentSmokeService: DeploymentSmokeService,
     private readonly shutdownService: ShutdownService,
   ) {}
 
@@ -40,7 +47,10 @@ export class HealthController {
 
   @Get('health/live')
   @HealthCheck()
-  @ApiOperation({ summary: 'Liveness probe (returns healthy even during graceful shutdown drain)' })
+  @ApiOperation({
+    summary:
+      'Liveness probe (returns healthy even during graceful shutdown drain)',
+  })
   async getLiveness(@Res({ passthrough: true }) response: Response) {
     const healthReport = await this.healthService.getHealthReport();
     response.status(healthReport.status === 'error' ? 503 : 200);
@@ -49,7 +59,10 @@ export class HealthController {
 
   @Get('health/ready')
   @HealthCheck()
-  @ApiOperation({ summary: 'Readiness probe (returns unready immediately upon shutdown signal)' })
+  @ApiOperation({
+    summary:
+      'Readiness probe (returns unready immediately upon shutdown signal)',
+  })
   async getReadiness(@Res({ passthrough: true }) response: Response) {
     if (this.shutdownService.isShuttingDown()) {
       throw new ServiceUnavailableException('Service is shutting down');
@@ -106,5 +119,37 @@ export class HealthController {
     response.status(latencyReport.overallState === 'hard_down' ? 503 : 200);
 
     return latencyReport;
+  }
+
+  @Get('health/smoke')
+  @ApiOperation({
+    summary: 'Deployment smoke check for CI and Vercel',
+    description:
+      'Single endpoint that confirms the backend and its testnet dependencies ' +
+      'are ready to serve. Verifies required environment variables are present, ' +
+      'core dependencies (database, Redis, Horizon) respond, and every ' +
+      'configured Soroban contract ID is reachable. ' +
+      'Returns a machine-readable report: `status` is "pass", "warn" or "fail", ' +
+      '`ready` is false only when something failed, and every check carries a ' +
+      'stable `id` so CI can assert on individual results. ' +
+      'Safe to expose publicly — environment variables are reported by name and ' +
+      'presence only, contract IDs are redacted, and dependency errors are ' +
+      'replaced with fixed messages so no connection detail can leak.',
+  })
+  @ApiOkResponse({
+    description:
+      'All checks passed, or only non-blocking warnings were raised (status ' +
+      '"pass" or "warn").',
+  })
+  @ApiServiceUnavailableResponse({
+    description:
+      'At least one check failed (status "fail") — the deployment is not ready.',
+  })
+  async getDeploymentSmoke(@Res({ passthrough: true }) response: Response) {
+    const report = await this.deploymentSmokeService.getSmokeReport();
+
+    response.status(report.ready ? 200 : 503);
+
+    return report;
   }
 }

--- a/apps/backend/src/health/health.module.ts
+++ b/apps/backend/src/health/health.module.ts
@@ -5,6 +5,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { AppCacheModule } from '../cache/cache.module';
 import { StellarModule } from '../stellar/stellar.module';
 import { ContractHealthService } from './contract-health.service';
+import { DeploymentSmokeService } from './deployment-smoke.service';
 import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
 import { LatencyBudgetHealthService } from './latency-budget.health.service';
@@ -25,6 +26,7 @@ import { ShutdownService } from './shutdown.service';
   providers: [
     HealthService,
     ContractHealthService,
+    DeploymentSmokeService,
     LatencyBudgetHealthService,
     ShutdownService,
   ],

--- a/apps/backend/src/stellar/controllers/testnet-bootstrap.controller.spec.ts
+++ b/apps/backend/src/stellar/controllers/testnet-bootstrap.controller.spec.ts
@@ -74,7 +74,10 @@ describe('TestnetBootstrapController', () => {
     );
 
     expect(result).toEqual(mockResponse);
-    expect(service.fundTestnetAccount).toHaveBeenCalledWith(VALID_TESTNET_KEY);
+    expect(service.fundTestnetAccount).toHaveBeenCalledWith(
+      VALID_TESTNET_KEY,
+      adminUser.id,
+    );
   });
 
   it('rejects when the feature flag is disabled', async () => {

--- a/apps/backend/src/stellar/controllers/testnet-bootstrap.controller.ts
+++ b/apps/backend/src/stellar/controllers/testnet-bootstrap.controller.ts
@@ -101,6 +101,6 @@ export class TestnetBootstrapController {
       `Admin ${user.id} requesting testnet bootstrap for ${dto.publicKey}`,
     );
 
-    return this.bootstrapService.fundTestnetAccount(dto.publicKey);
+    return this.bootstrapService.fundTestnetAccount(dto.publicKey, user.id);
   }
 }

--- a/apps/backend/src/stellar/dto/testnet-bootstrap.dto.ts
+++ b/apps/backend/src/stellar/dto/testnet-bootstrap.dto.ts
@@ -51,4 +51,15 @@ export class TestnetBootstrapResponseDto {
     required: false,
   })
   fundingAmount?: string;
+
+  @ApiProperty({
+    description:
+      'Identifier of the recorded bootstrap run. Pass it to ' +
+      'POST /demo-bootstrap/runs/{runId}/teardown to discard the local record ' +
+      'of this account. Absent when the run could not be recorded (the account ' +
+      'was still funded).',
+    example: '3f6c1a6e-2f4b-4b2a-9c0a-5d8f0b1c2d3e',
+    required: false,
+  })
+  runId?: string;
 }

--- a/apps/backend/src/stellar/services/testnet-bootstrap.service.spec.ts
+++ b/apps/backend/src/stellar/services/testnet-bootstrap.service.spec.ts
@@ -19,6 +19,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import axios, { AxiosError } from 'axios';
 import { ConfigService } from '../../config/config.service';
 import { ErrorCode } from '../../common/enums/error-code.enum';
+import { BootstrapRunRegistryService } from '../../bootstrap-runs/bootstrap-run-registry.service';
 import { TestnetBootstrapService } from './testnet-bootstrap.service';
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -26,6 +27,7 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 describe('TestnetBootstrapService', () => {
   let service: TestnetBootstrapService;
   let configService: ConfigService;
+  let runRegistry: { recordSafely: jest.Mock };
 
   const VALID_TESTNET_KEY =
     'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
@@ -33,6 +35,10 @@ describe('TestnetBootstrapService', () => {
 
   beforeEach(async () => {
     mockConfig.featureFlags.friendbotBootstrap = true;
+
+    runRegistry = {
+      recordSafely: jest.fn().mockResolvedValue('run-1'),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -42,6 +48,10 @@ describe('TestnetBootstrapService', () => {
           useValue: {
             getStellarConfig: jest.fn(),
           },
+        },
+        {
+          provide: BootstrapRunRegistryService,
+          useValue: runRegistry,
         },
       ],
     }).compile();
@@ -139,6 +149,48 @@ describe('TestnetBootstrapService', () => {
           params: { addr: VALID_TESTNET_KEY },
         }),
       );
+    });
+
+    it('records the funded account as a teardown-trackable bootstrap run', async () => {
+      (configService.getStellarConfig as jest.Mock).mockReturnValue({
+        network: 'testnet',
+      });
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { transaction_hash: 'mock_tx_hash', amount_lumens: '10000' },
+      });
+
+      const result = await service.fundTestnetAccount(
+        VALID_TESTNET_KEY,
+        'admin-1',
+      );
+
+      expect(result.runId).toBe('run-1');
+      expect(runRegistry.recordSafely).toHaveBeenCalledWith({
+        kind: 'testnet_account',
+        createdBy: 'admin-1',
+        resources: [
+          {
+            type: 'testnet_account',
+            identifier: VALID_TESTNET_KEY,
+            label: 'Friendbot-funded testnet account (10000 XLM)',
+          },
+        ],
+      });
+    });
+
+    it('still reports success when the run registry write fails', async () => {
+      (configService.getStellarConfig as jest.Mock).mockReturnValue({
+        network: 'testnet',
+      });
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { transaction_hash: 'mock_tx_hash', amount_lumens: '10000' },
+      });
+      runRegistry.recordSafely.mockResolvedValueOnce(null);
+
+      const result = await service.fundTestnetAccount(VALID_TESTNET_KEY);
+
+      expect(result.success).toBe(true);
+      expect(result.runId).toBeUndefined();
     });
 
     it('maps Friendbot 429 to STEL_FRIENDBOT_ALREADY_FUNDED', async () => {

--- a/apps/backend/src/stellar/services/testnet-bootstrap.service.ts
+++ b/apps/backend/src/stellar/services/testnet-bootstrap.service.ts
@@ -12,6 +12,11 @@ import { StrKey } from '@stellar/stellar-sdk';
 import { ConfigService } from '../../config/config.service';
 import { ErrorCode } from '../../common/enums/error-code.enum';
 import { config } from '../../lib/config';
+import { BootstrapRunRegistryService } from '../../bootstrap-runs/bootstrap-run-registry.service';
+import {
+  BootstrapResourceType,
+  BootstrapRunKind,
+} from '../../bootstrap-runs/entities/bootstrap-run.entity';
 import { TestnetBootstrapResponseDto } from '../dto/testnet-bootstrap.dto';
 
 /**
@@ -46,18 +51,28 @@ function asOptionalString(value: unknown): string | undefined {
  * - Feature flag: FRIENDBOT_BOOTSTRAP_ENABLED must be true
  * - Hardcoded Friendbot URL (never configurable)
  * - Auth/rate-limit enforced at the controller layer
+ *
+ * Every successful funding is recorded as a bootstrap run so the environment
+ * can be traced back to a clean baseline. See BootstrapTeardownService for the
+ * teardown path and the limits of what it can undo on-chain.
  */
 @Injectable()
 export class TestnetBootstrapService {
   private readonly logger = new Logger(TestnetBootstrapService.name);
 
-  constructor(private readonly configService: ConfigService) {}
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly runRegistry: BootstrapRunRegistryService,
+  ) {}
 
   /**
    * Fund a testnet account via Friendbot.
+   *
+   * @param createdBy Admin user id to attribute the bootstrap run to.
    */
   async fundTestnetAccount(
     publicKey: string,
+    createdBy: string | null = null,
   ): Promise<TestnetBootstrapResponseDto> {
     if (!config.featureFlags.friendbotBootstrap) {
       throw new ForbiddenException({
@@ -111,8 +126,21 @@ export class TestnetBootstrapService {
         asOptionalString(data.amount) ??
         '10000';
 
+      const runId = await this.runRegistry.recordSafely({
+        kind: BootstrapRunKind.TESTNET_ACCOUNT,
+        createdBy,
+        resources: [
+          {
+            type: BootstrapResourceType.TESTNET_ACCOUNT,
+            identifier: publicKey,
+            label: `Friendbot-funded testnet account (${fundingAmount} XLM)`,
+          },
+        ],
+      });
+
       this.logger.log(
-        `Successfully funded testnet account ${publicKey}, tx: ${txHash ?? 'unknown'}`,
+        `Successfully funded testnet account ${publicKey}, tx: ${txHash ?? 'unknown'}, ` +
+          `runId: ${runId ?? 'untracked'}`,
       );
 
       return {
@@ -121,6 +149,7 @@ export class TestnetBootstrapService {
         publicKey,
         transactionHash: txHash,
         fundingAmount,
+        runId: runId ?? undefined,
       };
     } catch (error: unknown) {
       this.handleFriendBotError(error, publicKey);

--- a/apps/backend/src/stellar/stellar.module.ts
+++ b/apps/backend/src/stellar/stellar.module.ts
@@ -14,6 +14,7 @@ import { MatchingPoolAdminController } from './controllers/matching-pool-admin.c
 import { TestnetBootstrapController } from './controllers/testnet-bootstrap.controller';
 import { TestnetBootstrapService } from './services/testnet-bootstrap.service';
 import { AppCacheModule } from '../cache/cache.module';
+import { BootstrapRunsModule } from '../bootstrap-runs/bootstrap-runs.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { AppCacheModule } from '../cache/cache.module';
     AuditModule,
     AppConfigModule,
     AppCacheModule,
+    BootstrapRunsModule,
   ],
   controllers: [
     StellarController,

--- a/apps/backend/test/health.e2e-spec.ts
+++ b/apps/backend/test/health.e2e-spec.ts
@@ -2,21 +2,36 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import { Server } from 'http';
 import request from 'supertest';
+import { ContractHealthService } from '../src/health/contract-health.service';
+import { DeploymentSmokeService } from '../src/health/deployment-smoke.service';
 import { HealthController } from '../src/health/health.controller';
 import {
   HealthService,
   LumenpulseHealthReport,
 } from '../src/health/health.service';
+import { ShutdownService } from '../src/health/shutdown.service';
 
 describe('Health Check (e2e)', () => {
   let app: INestApplication;
   let healthService: { getHealthReport: jest.Mock };
+  let contractHealthService: { getContractHealthReport: jest.Mock };
+  let deploymentSmokeService: { getSmokeReport: jest.Mock };
+  let shutdownService: { isShuttingDown: jest.Mock };
 
   const getHttpServer = (): Server => app.getHttpServer() as Server;
 
   beforeAll(async () => {
     healthService = {
       getHealthReport: jest.fn(),
+    };
+    contractHealthService = {
+      getContractHealthReport: jest.fn(),
+    };
+    deploymentSmokeService = {
+      getSmokeReport: jest.fn(),
+    };
+    shutdownService = {
+      isShuttingDown: jest.fn().mockReturnValue(false),
     };
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -25,6 +40,18 @@ describe('Health Check (e2e)', () => {
         {
           provide: HealthService,
           useValue: healthService,
+        },
+        {
+          provide: ContractHealthService,
+          useValue: contractHealthService,
+        },
+        {
+          provide: DeploymentSmokeService,
+          useValue: deploymentSmokeService,
+        },
+        {
+          provide: ShutdownService,
+          useValue: shutdownService,
         },
       ],
     }).compile();
@@ -151,5 +178,67 @@ describe('Health Check (e2e)', () => {
     healthService.getHealthReport.mockResolvedValue(report);
 
     await request(getHttpServer()).get('/health').expect(503);
+  });
+
+  describe('GET /health/smoke', () => {
+    const passingReport = {
+      status: 'pass',
+      ready: true,
+      checkedAt: '2026-08-29T00:00:00.000Z',
+      durationMs: 42,
+      network: 'testnet',
+      environment: 'test',
+      summary: { total: 2, passed: 2, warned: 0, failed: 0 },
+      checks: [
+        {
+          id: 'env.JWT_SECRET',
+          category: 'config',
+          status: 'pass',
+          message: 'JWT_SECRET is set',
+        },
+        {
+          id: 'contract.lumenToken',
+          category: 'contract',
+          status: 'pass',
+          message: 'lumenToken contract is reachable',
+        },
+      ],
+    };
+
+    it('returns 200 with a machine-readable report when everything is ready', async () => {
+      deploymentSmokeService.getSmokeReport.mockResolvedValue(passingReport);
+
+      const response = await request(getHttpServer())
+        .get('/health/smoke')
+        .expect(200)
+        .expect('Content-Type', /json/);
+
+      expect(response.body).toEqual(passingReport);
+    });
+
+    it('returns 200 when only non-blocking warnings were raised', async () => {
+      deploymentSmokeService.getSmokeReport.mockResolvedValue({
+        ...passingReport,
+        status: 'warn',
+        summary: { total: 2, passed: 1, warned: 1, failed: 0 },
+      });
+
+      await request(getHttpServer()).get('/health/smoke').expect(200);
+    });
+
+    it('returns 503 when a check failed', async () => {
+      deploymentSmokeService.getSmokeReport.mockResolvedValue({
+        ...passingReport,
+        status: 'fail',
+        ready: false,
+        summary: { total: 2, passed: 1, warned: 0, failed: 1 },
+      });
+
+      const response = await request(getHttpServer())
+        .get('/health/smoke')
+        .expect(503);
+
+      expect((response.body as { ready: boolean }).ready).toBe(false);
+    });
   });
 });

--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -245,6 +245,32 @@ export default function SettingsScreen() {
 
           <View style={[styles.divider, { backgroundColor: colors.border }]} />
 
+          <TouchableOpacity
+            style={styles.navRow}
+            activeOpacity={0.75}
+            onPress={() => router.push('/settings/data-privacy')}
+            accessibilityRole="link"
+            accessibilityLabel={t('settings.data_privacy.title')}
+            accessibilityHint={t('settings.data_privacy.description')}
+          >
+            <View style={styles.navRowCopy}>
+              <View style={[styles.navIconShell, { backgroundColor: colors.card }]}>
+                <Ionicons name="shield-outline" size={18} color={colors.accent} />
+              </View>
+              <View style={styles.navTextWrap}>
+                <Text style={[styles.navTitle, { color: colors.text }]} accessible>
+                  {t('settings.data_privacy.title')}
+                </Text>
+                <Text style={[styles.navDescription, { color: colors.textSecondary }]} accessible>
+                  {t('settings.data_privacy.description')}
+                </Text>
+              </View>
+            </View>
+            <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
+          </TouchableOpacity>
+
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+
           <View style={styles.preferenceRow}>
             <View style={styles.navRowCopy}>
               <View style={[styles.navIconShell, { backgroundColor: colors.card }]}>

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { View } from 'react-native';
+import { applyPrivacyPreferences } from '../lib/privacy-preferences';
 import { AuthProvider } from '../contexts/AuthContext';
 import { DeepLinkProvider } from '../contexts/DeepLinkContext';
 import { EnvironmentProvider } from '../contexts/EnvironmentContext';
@@ -10,6 +12,12 @@ import NetworkBadge from '../components/NetworkBadge';
 import { LocalizationProvider } from '../src/context';
 
 export default function RootLayout() {
+  // Re-apply the stored analytics/crash-reporting opt-outs on every launch, so
+  // a choice made in Settings › Data & Privacy holds across sessions.
+  useEffect(() => {
+    void applyPrivacyPreferences();
+  }, []);
+
   return (
     <LocalizationProvider>
       <EnvironmentProvider>

--- a/apps/mobile/app/settings/data-privacy.tsx
+++ b/apps/mobile/app/settings/data-privacy.tsx
@@ -1,0 +1,524 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { useTheme } from '../../contexts/ThemeContext';
+import { useLocalization } from '../../src/context';
+import { formatBytes } from '../../lib/image-cache';
+import {
+  LocalDataCategoryId,
+  LocalDataInventory,
+  clearAllLocalData,
+  clearLocalDataCategory,
+  getLocalDataInventory,
+} from '../../lib/local-data';
+import {
+  DEFAULT_PRIVACY_PREFERENCES,
+  PrivacyPreferences,
+  getPrivacyPreferences,
+  setAnalyticsEnabled,
+  setCrashReportingEnabled,
+} from '../../lib/privacy-preferences';
+
+const CATEGORY_ICONS: Record<LocalDataCategoryId, string> = {
+  cached_content: 'cloud-download-outline',
+  saved_news: 'bookmark-outline',
+  watchlists: 'eye-outline',
+  image_cache: 'images-outline',
+  drafts: 'create-outline',
+  diagnostics: 'pulse-outline',
+};
+
+/**
+ * Settings › Data & Privacy.
+ *
+ * Lists every category of locally stored data with its current size, clears
+ * each one behind a confirmation, and hosts the analytics and crash-reporting
+ * opt-out toggles.
+ *
+ * Clearing never signs the user out and never discards queued offline writes —
+ * see lib/local-data.ts for the protected-key rules that guarantee it. When
+ * mutations are queued the screen says so explicitly before the user confirms.
+ */
+export default function DataPrivacyScreen() {
+  const { colors } = useTheme();
+  const { t } = useLocalization();
+  const router = useRouter();
+
+  const [inventory, setInventory] = useState<LocalDataInventory | null>(null);
+  const [preferences, setPreferences] = useState<PrivacyPreferences>(DEFAULT_PRIVACY_PREFERENCES);
+  const [loading, setLoading] = useState(true);
+  const [busyCategory, setBusyCategory] = useState<LocalDataCategoryId | 'all' | null>(null);
+  const [savingPreference, setSavingPreference] = useState<'analytics' | 'crash' | null>(null);
+
+  const loadInventory = useCallback(async () => {
+    const next = await getLocalDataInventory();
+    setInventory(next);
+  }, []);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [, storedPreferences] = await Promise.all([loadInventory(), getPrivacyPreferences()]);
+        setPreferences(storedPreferences);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void load();
+  }, [loadInventory]);
+
+  const confirmAndClear = (id: LocalDataCategoryId, categoryLabel: string) => {
+    Alert.alert(
+      t('settings.data_privacy.clear_category_title', { category: categoryLabel }),
+      t('settings.data_privacy.clear_category_message', { category: categoryLabel }),
+      [
+        { text: t('common.cancel'), style: 'cancel' },
+        {
+          text: t('common.confirm'),
+          style: 'destructive',
+          onPress: async () => {
+            setBusyCategory(id);
+            try {
+              await clearLocalDataCategory(id);
+              await loadInventory();
+              Alert.alert(
+                t('success'),
+                t('settings.data_privacy.category_cleared', {
+                  category: categoryLabel,
+                }),
+              );
+            } catch {
+              Alert.alert(t('errors.error'), t('settings.data_privacy.clear_failed'));
+            } finally {
+              setBusyCategory(null);
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  const confirmAndClearAll = () => {
+    const queued = inventory?.queuedMutationCount ?? 0;
+    const message =
+      queued > 0
+        ? `${t('settings.data_privacy.clear_all_message')}\n\n${t(
+            'settings.data_privacy.queued_preserved_warning',
+            { count: queued },
+          )}`
+        : t('settings.data_privacy.clear_all_message');
+
+    Alert.alert(t('settings.data_privacy.clear_all_title'), message, [
+      { text: t('common.cancel'), style: 'cancel' },
+      {
+        text: t('common.confirm'),
+        style: 'destructive',
+        onPress: async () => {
+          setBusyCategory('all');
+          try {
+            const result = await clearAllLocalData();
+            await loadInventory();
+
+            if (result.failed.length > 0) {
+              Alert.alert(
+                t('errors.error'),
+                t('settings.data_privacy.clear_all_partial', {
+                  count: result.failed.length,
+                }),
+              );
+              return;
+            }
+
+            Alert.alert(t('success'), t('settings.data_privacy.clear_all_success'));
+          } catch {
+            Alert.alert(t('errors.error'), t('settings.data_privacy.clear_failed'));
+          } finally {
+            setBusyCategory(null);
+          }
+        },
+      },
+    ]);
+  };
+
+  const handleAnalyticsToggle = async (nextValue: boolean) => {
+    if (savingPreference) return;
+    setSavingPreference('analytics');
+    try {
+      setPreferences(await setAnalyticsEnabled(nextValue));
+    } catch {
+      Alert.alert(t('errors.error'), t('settings.data_privacy.preference_save_failed'));
+    } finally {
+      setSavingPreference(null);
+    }
+  };
+
+  const handleCrashReportingToggle = async (nextValue: boolean) => {
+    if (savingPreference) return;
+    setSavingPreference('crash');
+    try {
+      setPreferences(await setCrashReportingEnabled(nextValue));
+    } catch {
+      Alert.alert(t('errors.error'), t('settings.data_privacy.preference_save_failed'));
+    } finally {
+      setSavingPreference(null);
+    }
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.header, { borderBottomColor: colors.border }]}>
+        <TouchableOpacity
+          onPress={() => router.back()}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.back')}
+        >
+          <Ionicons name="arrow-back" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text
+          style={[styles.headerTitle, { color: colors.text }]}
+          accessible
+          accessibilityRole="header"
+        >
+          {t('settings.data_privacy.title')}
+        </Text>
+        <View style={{ width: 24 }} />
+      </View>
+
+      <ScrollView style={styles.content} contentContainerStyle={styles.contentInner}>
+        <Text style={[styles.intro, { color: colors.textSecondary }]} accessible>
+          {t('settings.data_privacy.description')}
+        </Text>
+
+        {/* ── Stored data ──────────────────────────────────────────────── */}
+        <Text
+          style={[styles.sectionTitle, { color: colors.text }]}
+          accessible
+          accessibilityRole="header"
+        >
+          {t('settings.data_privacy.stored_data')}
+        </Text>
+
+        {loading ? (
+          <ActivityIndicator
+            style={styles.loader}
+            color={colors.accent}
+            accessibilityLabel={t('common.loading')}
+          />
+        ) : (
+          <>
+            {inventory?.categories.map((category) => {
+              const label = t(`settings.data_privacy.categories.${category.id}.title`);
+              const isEmpty = category.bytes === 0;
+              const isBusy = busyCategory === category.id;
+
+              return (
+                <View
+                  key={category.id}
+                  style={[
+                    styles.categoryRow,
+                    { backgroundColor: colors.surface, borderColor: colors.cardBorder },
+                  ]}
+                  accessible
+                  accessibilityLabel={`${label}: ${formatBytes(category.bytes)}`}
+                >
+                  <View style={[styles.categoryIcon, { backgroundColor: colors.card }]}>
+                    <Ionicons
+                      name={CATEGORY_ICONS[category.id] as any}
+                      size={20}
+                      color={colors.accent}
+                    />
+                  </View>
+
+                  <View style={styles.categoryCopy}>
+                    <Text style={[styles.categoryTitle, { color: colors.text }]} accessible>
+                      {label}
+                    </Text>
+                    <Text style={[styles.categoryMeta, { color: colors.textSecondary }]} accessible>
+                      {t(`settings.data_privacy.categories.${category.id}.description`)}
+                    </Text>
+                    <Text style={[styles.categorySize, { color: colors.accent }]} accessible>
+                      {formatBytes(category.bytes)}
+                      {category.entryCount > 0
+                        ? ` · ${t('settings.data_privacy.item_count', {
+                            count: category.entryCount,
+                          })}`
+                        : ''}
+                    </Text>
+                  </View>
+
+                  {isBusy ? (
+                    <ActivityIndicator color={colors.accent} />
+                  ) : (
+                    <TouchableOpacity
+                      style={[
+                        styles.clearButton,
+                        {
+                          borderColor: isEmpty ? colors.cardBorder : colors.danger,
+                          opacity: isEmpty ? 0.4 : 1,
+                        },
+                      ]}
+                      onPress={() => confirmAndClear(category.id, label)}
+                      disabled={isEmpty || busyCategory !== null}
+                      activeOpacity={0.7}
+                      accessibilityRole="button"
+                      accessibilityState={{ disabled: isEmpty || busyCategory !== null }}
+                      accessibilityLabel={t('settings.data_privacy.clear_category_title', {
+                        category: label,
+                      })}
+                    >
+                      <Text
+                        style={[
+                          styles.clearButtonText,
+                          { color: isEmpty ? colors.textSecondary : colors.danger },
+                        ]}
+                      >
+                        {t('settings.data_privacy.clear')}
+                      </Text>
+                    </TouchableOpacity>
+                  )}
+                </View>
+              );
+            })}
+
+            <View style={[styles.totalRow, { borderColor: colors.border }]}>
+              <Text style={[styles.totalLabel, { color: colors.textSecondary }]} accessible>
+                {t('settings.data_privacy.total_stored')}
+              </Text>
+              <Text style={[styles.totalValue, { color: colors.text }]} accessible>
+                {formatBytes(inventory?.totalBytes ?? 0)}
+              </Text>
+            </View>
+
+            {(inventory?.queuedMutationCount ?? 0) > 0 && (
+              <View
+                style={[
+                  styles.noticeBox,
+                  { backgroundColor: colors.surface, borderColor: colors.warning },
+                ]}
+                accessible
+                accessibilityLabel={t('settings.data_privacy.queued_preserved_warning', {
+                  count: inventory?.queuedMutationCount ?? 0,
+                })}
+              >
+                <Ionicons name="sync-outline" size={18} color={colors.warning} />
+                <Text style={[styles.noticeText, { color: colors.textSecondary }]}>
+                  {t('settings.data_privacy.queued_preserved_warning', {
+                    count: inventory?.queuedMutationCount ?? 0,
+                  })}
+                </Text>
+              </View>
+            )}
+
+            <TouchableOpacity
+              style={[
+                styles.clearAllButton,
+                {
+                  backgroundColor: colors.danger,
+                  opacity: busyCategory !== null ? 0.6 : 1,
+                },
+              ]}
+              onPress={confirmAndClearAll}
+              disabled={busyCategory !== null}
+              activeOpacity={0.8}
+              accessibilityRole="button"
+              accessibilityLabel={t('settings.data_privacy.clear_all_title')}
+              accessibilityHint={t('settings.data_privacy.clear_all_hint')}
+            >
+              {busyCategory === 'all' ? (
+                <ActivityIndicator color="#ffffff" />
+              ) : (
+                <>
+                  <Ionicons
+                    name="trash-outline"
+                    size={18}
+                    color="#ffffff"
+                    style={{ marginRight: 8 }}
+                  />
+                  <Text style={styles.clearAllButtonText} accessible>
+                    {t('settings.data_privacy.clear_all_title')}
+                  </Text>
+                </>
+              )}
+            </TouchableOpacity>
+
+            <Text style={[styles.footnote, { color: colors.textSecondary }]} accessible>
+              {t('settings.data_privacy.clear_all_hint')}
+            </Text>
+          </>
+        )}
+
+        {/* ── Privacy controls ─────────────────────────────────────────── */}
+        <Text
+          style={[styles.sectionTitle, { color: colors.text }]}
+          accessible
+          accessibilityRole="header"
+        >
+          {t('settings.data_privacy.privacy_controls')}
+        </Text>
+
+        <View
+          style={[
+            styles.preferenceCard,
+            { backgroundColor: colors.surface, borderColor: colors.cardBorder },
+          ]}
+        >
+          <View style={styles.preferenceRow}>
+            <View style={styles.preferenceCopy}>
+              <Text style={[styles.categoryTitle, { color: colors.text }]} accessible>
+                {t('settings.data_privacy.analytics.title')}
+              </Text>
+              <Text style={[styles.categoryMeta, { color: colors.textSecondary }]} accessible>
+                {t('settings.data_privacy.analytics.description')}
+              </Text>
+            </View>
+
+            {savingPreference === 'analytics' ? (
+              <ActivityIndicator color={colors.accent} />
+            ) : (
+              <Switch
+                value={preferences.analyticsEnabled}
+                onValueChange={handleAnalyticsToggle}
+                trackColor={{ false: colors.cardBorder, true: colors.accent }}
+                thumbColor="#ffffff"
+                accessibilityRole="switch"
+                accessibilityLabel={t('settings.data_privacy.analytics.title')}
+              />
+            )}
+          </View>
+
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+
+          <View style={styles.preferenceRow}>
+            <View style={styles.preferenceCopy}>
+              <Text style={[styles.categoryTitle, { color: colors.text }]} accessible>
+                {t('settings.data_privacy.crash_reporting.title')}
+              </Text>
+              <Text style={[styles.categoryMeta, { color: colors.textSecondary }]} accessible>
+                {t('settings.data_privacy.crash_reporting.description')}
+              </Text>
+            </View>
+
+            {savingPreference === 'crash' ? (
+              <ActivityIndicator color={colors.accent} />
+            ) : (
+              <Switch
+                value={preferences.crashReportingEnabled}
+                onValueChange={handleCrashReportingToggle}
+                trackColor={{ false: colors.cardBorder, true: colors.accent }}
+                thumbColor="#ffffff"
+                accessibilityRole="switch"
+                accessibilityLabel={t('settings.data_privacy.crash_reporting.title')}
+              />
+            )}
+          </View>
+        </View>
+
+        <Text style={[styles.footnote, { color: colors.textSecondary }]} accessible>
+          {t('settings.data_privacy.preferences_survive_clear')}
+        </Text>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  headerTitle: { fontSize: 18, fontWeight: '600' },
+  content: { flex: 1 },
+  contentInner: { padding: 16, paddingBottom: 48 },
+  intro: { fontSize: 14, lineHeight: 20, marginBottom: 20 },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    marginTop: 12,
+    marginBottom: 12,
+  },
+  loader: { marginVertical: 24 },
+  categoryRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    padding: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 8,
+  },
+  categoryIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  categoryCopy: { flex: 1 },
+  categoryTitle: { fontSize: 15, fontWeight: '600', marginBottom: 2 },
+  categoryMeta: { fontSize: 12, lineHeight: 17, marginBottom: 4 },
+  categorySize: { fontSize: 13, fontWeight: '600' },
+  clearButton: {
+    minHeight: 36,
+    paddingHorizontal: 12,
+    justifyContent: 'center',
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  clearButtonText: { fontSize: 13, fontWeight: '600' },
+  totalRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 12,
+    marginTop: 4,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  totalLabel: { fontSize: 14 },
+  totalValue: { fontSize: 15, fontWeight: '700' },
+  noticeBox: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+    padding: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    marginBottom: 12,
+  },
+  noticeText: { flex: 1, fontSize: 13, lineHeight: 18 },
+  clearAllButton: {
+    flexDirection: 'row',
+    height: 52,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 8,
+  },
+  clearAllButtonText: { color: '#ffffff', fontSize: 16, fontWeight: '600' },
+  footnote: { fontSize: 12, lineHeight: 17, marginTop: 10 },
+  preferenceCard: { borderRadius: 12, borderWidth: 1, padding: 14 },
+  preferenceRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  preferenceCopy: { flex: 1 },
+  divider: { height: StyleSheet.hairlineWidth, marginVertical: 14 },
+});

--- a/apps/mobile/lib/__tests__/local-data.test.ts
+++ b/apps/mobile/lib/__tests__/local-data.test.ts
@@ -1,0 +1,329 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { imageCache } from '../image-cache';
+import {
+  categorizeKey,
+  clearAllLocalData,
+  clearLocalDataCategory,
+  getLocalDataInventory,
+  isProtectedKey,
+  utf8ByteLength,
+} from '../local-data';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+  getAllKeys: jest.fn(),
+  multiGet: jest.fn(),
+  multiRemove: jest.fn(),
+}));
+
+jest.mock('@react-native-community/netinfo', () => ({
+  addEventListener: jest.fn(),
+}));
+
+jest.mock('react-native', () => ({
+  DeviceEventEmitter: { emit: jest.fn() },
+}));
+
+jest.mock('../image-cache', () => ({
+  imageCache: {
+    getStats: jest.fn(),
+    clearAll: jest.fn(),
+  },
+}));
+
+const mockedStorage = AsyncStorage as unknown as {
+  getAllKeys: jest.Mock;
+  multiGet: jest.Mock;
+  multiRemove: jest.Mock;
+};
+const mockedImageCache = imageCache as unknown as {
+  getStats: jest.Mock;
+  clearAll: jest.Mock;
+};
+
+/** Builds a store and wires getAllKeys/multiGet to serve it. */
+function primeStorage(store: Record<string, string>) {
+  const keys = Object.keys(store);
+  mockedStorage.getAllKeys.mockResolvedValue(keys);
+  mockedStorage.multiGet.mockImplementation((requested: string[]) =>
+    Promise.resolve(requested.map((key) => [key, store[key] ?? null])),
+  );
+}
+
+describe('utf8ByteLength', () => {
+  it('counts ASCII as one byte per character', () => {
+    expect(utf8ByteLength('hello')).toBe(5);
+  });
+
+  it('counts multi-byte characters correctly', () => {
+    expect(utf8ByteLength('é')).toBe(2);
+    expect(utf8ByteLength('中')).toBe(3);
+  });
+
+  it('counts a surrogate pair as a single 4-byte code point', () => {
+    expect(utf8ByteLength('😀')).toBe(4);
+  });
+
+  it('returns zero for an empty string', () => {
+    expect(utf8ByteLength('')).toBe(0);
+  });
+});
+
+describe('categorizeKey', () => {
+  it.each([
+    ['cache_news_feed', 'cached_content'],
+    ['saved_articles', 'saved_news'],
+    ['watchlist_local_cache_user-1', 'watchlists'],
+    ['watchlist_last_synced_user-1', 'watchlists'],
+    ['img_cache_meta', 'image_cache'],
+    ['contribution_draft', 'drafts'],
+    ['lumenpulse.analytics.session', 'diagnostics'],
+  ])('classifies %s as %s', (key, expected) => {
+    expect(categorizeKey(key)).toBe(expected);
+  });
+
+  it('returns null for unknown keys so clearing never touches them', () => {
+    expect(categorizeKey('some_third_party_key')).toBeNull();
+  });
+
+  it('never classifies a protected key into a clearable category', () => {
+    expect(categorizeKey('watchlist_pending_sync_user-1')).toBeNull();
+    expect(categorizeKey('pending_mutation_queue')).toBeNull();
+    expect(categorizeKey('lumenpulse.privacy.analytics_enabled')).toBeNull();
+    expect(categorizeKey('auth_token')).toBeNull();
+    expect(categorizeKey('wallet_metadata')).toBeNull();
+  });
+});
+
+describe('isProtectedKey', () => {
+  it('protects queued mutations, session state and privacy choices', () => {
+    expect(isProtectedKey('pending_mutation_queue')).toBe(true);
+    expect(isProtectedKey('watchlist_pending_sync_user-1')).toBe(true);
+    expect(isProtectedKey('lumenpulse.privacy.crash_reporting_enabled')).toBe(true);
+    expect(isProtectedKey('refresh_token')).toBe(true);
+    expect(isProtectedKey('biometric_lock_enabled')).toBe(true);
+  });
+
+  it('does not protect ordinary cached content', () => {
+    expect(isProtectedKey('cache_portfolio')).toBe(false);
+    expect(isProtectedKey('saved_articles')).toBe(false);
+  });
+});
+
+describe('getLocalDataInventory', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedImageCache.getStats.mockResolvedValue({
+      entryCount: 12,
+      totalBytes: 2_400_000,
+      maxBytes: 52_428_800,
+    });
+  });
+
+  it('reports a size per category and an overall total', async () => {
+    primeStorage({
+      cache_news: JSON.stringify({ data: 'a'.repeat(100) }),
+      saved_articles: JSON.stringify([{ id: '1' }]),
+      'watchlist_local_cache_user-1': JSON.stringify([{ symbol: 'XLM' }]),
+      contribution_draft: JSON.stringify({ projectId: 'p1' }),
+    });
+
+    const inventory = await getLocalDataInventory();
+    const byId = Object.fromEntries(
+      inventory.categories.map((category) => [category.id, category]),
+    );
+
+    expect(byId.cached_content.entryCount).toBe(1);
+    expect(byId.cached_content.bytes).toBeGreaterThan(100);
+    expect(byId.saved_news.entryCount).toBe(1);
+    expect(byId.watchlists.entryCount).toBe(1);
+    expect(byId.drafts.entryCount).toBe(1);
+    expect(inventory.totalBytes).toBe(
+      inventory.categories.reduce((sum, category) => sum + category.bytes, 0),
+    );
+  });
+
+  it('lists every category even when nothing is stored', async () => {
+    primeStorage({});
+    mockedImageCache.getStats.mockResolvedValue({
+      entryCount: 0,
+      totalBytes: 0,
+      maxBytes: 52_428_800,
+    });
+
+    const inventory = await getLocalDataInventory();
+
+    expect(inventory.categories).toHaveLength(6);
+    expect(inventory.totalBytes).toBe(0);
+  });
+
+  it('takes the image cache size from the on-disk stats, not the ledger key', async () => {
+    primeStorage({ img_cache_meta: JSON.stringify([{ uri: 'x' }]) });
+
+    const inventory = await getLocalDataInventory();
+    const imageCategory = inventory.categories.find((category) => category.id === 'image_cache');
+
+    expect(imageCategory).toEqual({
+      id: 'image_cache',
+      bytes: 2_400_000,
+      entryCount: 12,
+    });
+  });
+
+  it('counts queued mutations without attributing them to a category', async () => {
+    primeStorage({
+      pending_mutation_queue: JSON.stringify([{ id: '1' }, { id: '2' }]),
+      'watchlist_pending_sync_user-1': JSON.stringify([{ id: '3' }]),
+    });
+
+    const inventory = await getLocalDataInventory();
+
+    expect(inventory.queuedMutationCount).toBe(3);
+    expect(inventory.totalBytes).toBe(2_400_000); // image cache stats only
+  });
+
+  it('tolerates a corrupt queue value instead of throwing', async () => {
+    primeStorage({ pending_mutation_queue: 'not-json' });
+
+    const inventory = await getLocalDataInventory();
+
+    expect(inventory.queuedMutationCount).toBe(0);
+  });
+
+  it('degrades to zeros when storage reads fail', async () => {
+    mockedStorage.getAllKeys.mockRejectedValue(new Error('storage offline'));
+    mockedImageCache.getStats.mockRejectedValue(new Error('no stats'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const inventory = await getLocalDataInventory();
+
+    expect(inventory.categories).toHaveLength(6);
+    expect(inventory.totalBytes).toBe(0);
+  });
+});
+
+describe('clearLocalDataCategory', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedImageCache.getStats.mockResolvedValue({
+      entryCount: 0,
+      totalBytes: 0,
+      maxBytes: 52_428_800,
+    });
+    mockedStorage.multiRemove.mockResolvedValue(undefined);
+  });
+
+  it('removes only the keys the category owns', async () => {
+    primeStorage({
+      saved_articles: '[]',
+      cache_news: '{}',
+      pending_mutation_queue: '[]',
+    });
+
+    await clearLocalDataCategory('saved_news');
+
+    expect(mockedStorage.multiRemove).toHaveBeenCalledWith(['saved_articles']);
+  });
+
+  it('preserves pending watchlist syncs when clearing watchlists', async () => {
+    primeStorage({
+      'watchlist_local_cache_user-1': '[]',
+      'watchlist_last_synced_user-1': '2026-08-29T00:00:00.000Z',
+      'watchlist_pending_sync_user-1': JSON.stringify([{ id: '1' }]),
+    });
+
+    await clearLocalDataCategory('watchlists');
+
+    const removed = mockedStorage.multiRemove.mock.calls[0][0] as string[];
+    expect(removed).toEqual(
+      expect.arrayContaining(['watchlist_local_cache_user-1', 'watchlist_last_synced_user-1']),
+    );
+    expect(removed).not.toContain('watchlist_pending_sync_user-1');
+  });
+
+  it('delegates the image cache to the native purge', async () => {
+    mockedImageCache.clearAll.mockResolvedValue(undefined);
+
+    await clearLocalDataCategory('image_cache');
+
+    expect(mockedImageCache.clearAll).toHaveBeenCalledTimes(1);
+    expect(mockedStorage.multiRemove).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the category has nothing stored', async () => {
+    primeStorage({ cache_news: '{}' });
+
+    await clearLocalDataCategory('drafts');
+
+    expect(mockedStorage.multiRemove).not.toHaveBeenCalled();
+  });
+});
+
+describe('clearAllLocalData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedStorage.multiRemove.mockResolvedValue(undefined);
+    mockedImageCache.clearAll.mockResolvedValue(undefined);
+    mockedImageCache.getStats.mockResolvedValue({
+      entryCount: 0,
+      totalBytes: 0,
+      maxBytes: 52_428_800,
+    });
+  });
+
+  it('clears every category and reports them', async () => {
+    primeStorage({ saved_articles: '[]', contribution_draft: '{}' });
+
+    const result = await clearAllLocalData();
+
+    expect(result.cleared).toHaveLength(6);
+    expect(result.failed).toHaveLength(0);
+  });
+
+  it('never removes session or queued-mutation keys', async () => {
+    primeStorage({
+      cache_news: '{}',
+      saved_articles: '[]',
+      auth_token: 'jwt-token',
+      refresh_token: 'refresh-token',
+      wallet_metadata: '{}',
+      pending_mutation_queue: JSON.stringify([{ id: '1' }]),
+      'watchlist_pending_sync_user-1': JSON.stringify([{ id: '2' }]),
+      'lumenpulse.privacy.analytics_enabled': 'false',
+    });
+
+    const result = await clearAllLocalData();
+
+    const removed = mockedStorage.multiRemove.mock.calls.flatMap((call) => call[0] as string[]);
+    expect(removed).not.toContain('auth_token');
+    expect(removed).not.toContain('refresh_token');
+    expect(removed).not.toContain('wallet_metadata');
+    expect(removed).not.toContain('pending_mutation_queue');
+    expect(removed).not.toContain('watchlist_pending_sync_user-1');
+    expect(removed).not.toContain('lumenpulse.privacy.analytics_enabled');
+    expect(result.preservedQueuedMutations).toBe(2);
+  });
+
+  it('leaves unrecognised third-party keys untouched', async () => {
+    primeStorage({ saved_articles: '[]', some_other_library_key: 'value' });
+
+    await clearAllLocalData();
+
+    const removed = mockedStorage.multiRemove.mock.calls.flatMap((call) => call[0] as string[]);
+    expect(removed).not.toContain('some_other_library_key');
+  });
+
+  it('continues past a failing category and reports it', async () => {
+    primeStorage({ saved_articles: '[]', contribution_draft: '{}' });
+    mockedImageCache.clearAll.mockRejectedValue(new Error('disk busy'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await clearAllLocalData();
+
+    expect(result.failed).toEqual(['image_cache']);
+    expect(result.cleared).toHaveLength(5);
+  });
+});

--- a/apps/mobile/lib/__tests__/privacy-preferences.test.ts
+++ b/apps/mobile/lib/__tests__/privacy-preferences.test.ts
@@ -1,0 +1,128 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { errorReporter } from '../error-reporting';
+import {
+  DEFAULT_PRIVACY_PREFERENCES,
+  applyPrivacyPreferences,
+  getPrivacyPreferences,
+  setAnalyticsEnabled,
+  setCrashReportingEnabled,
+} from '../privacy-preferences';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  multiGet: jest.fn(),
+}));
+
+const mockedStorage = AsyncStorage as unknown as {
+  setItem: jest.Mock;
+  multiGet: jest.Mock;
+};
+
+const ANALYTICS_KEY = 'lumenpulse.privacy.analytics_enabled';
+const CRASH_KEY = 'lumenpulse.privacy.crash_reporting_enabled';
+
+function primePreferences(analytics: string | null, crash: string | null) {
+  mockedStorage.multiGet.mockResolvedValue([
+    [ANALYTICS_KEY, analytics],
+    [CRASH_KEY, crash],
+  ]);
+}
+
+describe('privacy preferences', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedStorage.setItem.mockResolvedValue(undefined);
+    errorReporter.setEnabled(true);
+  });
+
+  it('defaults both toggles to enabled when nothing is stored', async () => {
+    primePreferences(null, null);
+
+    await expect(getPrivacyPreferences()).resolves.toEqual(DEFAULT_PRIVACY_PREFERENCES);
+  });
+
+  it('honours a stored opt-out', async () => {
+    primePreferences('false', 'false');
+
+    await expect(getPrivacyPreferences()).resolves.toEqual({
+      analyticsEnabled: false,
+      crashReportingEnabled: false,
+    });
+  });
+
+  it('falls back to the default for a corrupted value rather than guessing', async () => {
+    primePreferences('maybe', '');
+
+    await expect(getPrivacyPreferences()).resolves.toEqual(DEFAULT_PRIVACY_PREFERENCES);
+  });
+
+  it('falls back to defaults when storage throws', async () => {
+    mockedStorage.multiGet.mockRejectedValue(new Error('storage offline'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(getPrivacyPreferences()).resolves.toEqual(DEFAULT_PRIVACY_PREFERENCES);
+  });
+
+  it('persists an analytics opt-out', async () => {
+    primePreferences('false', 'true');
+
+    const preferences = await setAnalyticsEnabled(false);
+
+    expect(mockedStorage.setItem).toHaveBeenCalledWith(ANALYTICS_KEY, 'false');
+    expect(preferences.analyticsEnabled).toBe(false);
+  });
+
+  it('applies a crash-reporting opt-out to the reporter immediately', async () => {
+    primePreferences('true', 'false');
+
+    await setCrashReportingEnabled(false);
+
+    expect(mockedStorage.setItem).toHaveBeenCalledWith(CRASH_KEY, 'false');
+    expect(errorReporter.enabled).toBe(false);
+  });
+
+  it('re-enables the reporter when the user opts back in', async () => {
+    primePreferences('true', 'true');
+    errorReporter.setEnabled(false);
+
+    await setCrashReportingEnabled(true);
+
+    expect(errorReporter.enabled).toBe(true);
+  });
+
+  it('applies stored preferences to the reporter at start-up', async () => {
+    primePreferences('true', 'false');
+
+    const preferences = await applyPrivacyPreferences();
+
+    expect(preferences.crashReportingEnabled).toBe(false);
+    expect(errorReporter.enabled).toBe(false);
+  });
+});
+
+describe('errorReporter opt-out behaviour', () => {
+  beforeEach(() => {
+    errorReporter.setEnabled(true);
+  });
+
+  it('drops captured errors while disabled', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+    errorReporter.setEnabled(false);
+
+    errorReporter.captureError(new Error('boom'));
+
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it('reports captured errors while enabled', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    errorReporter.captureError(new Error('boom'));
+
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/apps/mobile/lib/error-reporting.ts
+++ b/apps/mobile/lib/error-reporting.ts
@@ -1,4 +1,4 @@
-import { fallbackReleaseMetadata } from "./release-metadata";
+import { fallbackReleaseMetadata } from './release-metadata';
 
 export interface ErrorReportOptions {
   optOut?: boolean;
@@ -9,9 +9,23 @@ class ErrorReporter {
   private isEnabled = true;
 
   init(options?: ErrorReportOptions) {
-    if (options?.optOut || process.env.NODE_ENV === "development") {
+    if (options?.optOut || process.env.NODE_ENV === 'development') {
       this.isEnabled = false;
     }
+  }
+
+  /**
+   * Explicit on/off switch driven by the user's crash-reporting preference in
+   * Settings › Data & Privacy. Unlike {@link init} this honours `true` even in
+   * development, because it reflects a deliberate choice rather than a default.
+   */
+  setEnabled(enabled: boolean) {
+    this.isEnabled = enabled;
+  }
+
+  /** Whether reports are currently being sent. */
+  get enabled(): boolean {
+    return this.isEnabled;
   }
 
   captureError(error: Error, extra?: Record<string, unknown>) {
@@ -22,10 +36,9 @@ class ErrorReporter {
 
   private scrubPayload(data: Record<string, unknown>): Record<string, unknown> {
     const raw = JSON.stringify(data);
-    const scrubbed = raw.replace(/G[A-Z2-7]{55}/g, "[REDACTED_ADDRESS]");
+    const scrubbed = raw.replace(/G[A-Z2-7]{55}/g, '[REDACTED_ADDRESS]');
     return JSON.parse(scrubbed);
   }
 }
 
 export const errorReporter = new ErrorReporter();
-

--- a/apps/mobile/lib/local-data.ts
+++ b/apps/mobile/lib/local-data.ts
@@ -1,0 +1,293 @@
+/**
+ * Inventory and teardown for everything the app keeps on the device.
+ *
+ * Backs Settings › Data & Privacy: it groups AsyncStorage keys into the
+ * categories a user actually recognises, measures each one, and clears them
+ * individually or all at once.
+ *
+ * Two invariants hold throughout:
+ *
+ *  1. **Nothing that would sign the user out is ever cleared.** Session tokens
+ *     and wallet metadata live in SecureStore and are never touched here; the
+ *     legacy plaintext copies that may still sit in AsyncStorage are treated as
+ *     protected so a clear-all cannot strand a logged-in session.
+ *  2. **Queued mutations survive.** Offline writes waiting to sync are the one
+ *     thing a user cannot recreate, so they are protected from every clear
+ *     path — including clear-all — and surfaced in the inventory instead.
+ *
+ * Keys that match no category are left alone. Clearing only ever removes what
+ * this module can name.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { cache } from './cache';
+import { CONTRIBUTION_DRAFT_STORAGE_KEY } from './contribution-drafts';
+import { imageCache } from './image-cache';
+import { PRIVACY_KEY_PREFIX } from './privacy-preferences';
+
+// ── Categories ─────────────────────────────────────────────────────────────
+
+export type LocalDataCategoryId =
+  'cached_content' | 'saved_news' | 'watchlists' | 'image_cache' | 'drafts' | 'diagnostics';
+
+/** Ordered as the settings screen renders them. */
+export const LOCAL_DATA_CATEGORY_IDS: LocalDataCategoryId[] = [
+  'cached_content',
+  'saved_news',
+  'watchlists',
+  'image_cache',
+  'drafts',
+  'diagnostics',
+];
+
+/**
+ * Keys no clear path may remove.
+ *
+ * `watchlist_pending_sync` and `pending_mutation_queue` hold offline writes
+ * that have not reached the server yet — dropping them would silently discard
+ * the user's work. The rest keep the current session and the user's own
+ * privacy choices intact.
+ */
+const PROTECTED_KEY_PREFIXES = [
+  // Queued offline mutations — unrecoverable if dropped.
+  'watchlist_pending_sync',
+  'pending_mutation_queue',
+  // Privacy choices must outlive a data wipe, or clearing would silently
+  // opt the user back in to reporting they had turned off.
+  PRIVACY_KEY_PREFIX,
+  // Session state. Current tokens live in SecureStore; these are the legacy
+  // plaintext keys that may still linger in AsyncStorage.
+  'auth_token',
+  'refresh_token',
+  'token',
+  'user',
+  'wallet_metadata',
+  'biometric_lock_enabled',
+  // Stable device identity for push delivery — not user content.
+  'lumenpulse.push.device-id',
+];
+
+const CACHE_KEY_PREFIX = 'cache_';
+const SAVED_ARTICLES_KEY = 'saved_articles';
+const IMAGE_CACHE_META_KEY = 'img_cache_meta';
+const WATCHLIST_LOCAL_PREFIX = 'watchlist_local_cache';
+const WATCHLIST_LAST_SYNCED_PREFIX = 'watchlist_last_synced';
+const WATCHLIST_PENDING_PREFIX = 'watchlist_pending_sync';
+const MUTATION_QUEUE_KEY = 'pending_mutation_queue';
+const DIAGNOSTICS_KEY_PREFIXES = ['lumenpulse.analytics.', 'lumenpulse.diagnostics.'];
+
+export function isProtectedKey(key: string): boolean {
+  return PROTECTED_KEY_PREFIXES.some((prefix) => key.startsWith(prefix));
+}
+
+/**
+ * Maps a storage key to its category, or `null` when the key is protected or
+ * belongs to no category. Protection is checked first so a key can never be
+ * classified into something clearable by accident.
+ */
+export function categorizeKey(key: string): LocalDataCategoryId | null {
+  if (isProtectedKey(key)) return null;
+
+  if (key.startsWith(CACHE_KEY_PREFIX)) return 'cached_content';
+  if (key === SAVED_ARTICLES_KEY) return 'saved_news';
+  if (key === IMAGE_CACHE_META_KEY) return 'image_cache';
+  if (key === CONTRIBUTION_DRAFT_STORAGE_KEY) return 'drafts';
+  if (key.startsWith(WATCHLIST_LOCAL_PREFIX) || key.startsWith(WATCHLIST_LAST_SYNCED_PREFIX)) {
+    return 'watchlists';
+  }
+  if (DIAGNOSTICS_KEY_PREFIXES.some((prefix) => key.startsWith(prefix))) {
+    return 'diagnostics';
+  }
+
+  return null;
+}
+
+// ── Sizing ─────────────────────────────────────────────────────────────────
+
+/**
+ * UTF-8 byte length of a string without depending on `Buffer` or `TextEncoder`,
+ * neither of which is guaranteed on every React Native runtime.
+ */
+export function utf8ByteLength(value: string): number {
+  let bytes = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+
+    if (code < 0x80) {
+      bytes += 1;
+    } else if (code < 0x800) {
+      bytes += 2;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      // Surrogate pair — one 4-byte code point spanning two UTF-16 units.
+      bytes += 4;
+      index += 1;
+    } else {
+      bytes += 3;
+    }
+  }
+
+  return bytes;
+}
+
+export interface LocalDataCategorySize {
+  id: LocalDataCategoryId;
+  /** Estimated bytes on device. */
+  bytes: number;
+  /** Number of stored entries (images, for the image cache). */
+  entryCount: number;
+}
+
+export interface LocalDataInventory {
+  categories: LocalDataCategorySize[];
+  totalBytes: number;
+  /**
+   * Offline writes still waiting to sync. Never cleared — shown so the user
+   * knows a clear will not discard them.
+   */
+  queuedMutationCount: number;
+}
+
+const emptyCategories = (): Record<LocalDataCategoryId, LocalDataCategorySize> =>
+  LOCAL_DATA_CATEGORY_IDS.reduce(
+    (acc, id) => {
+      acc[id] = { id, bytes: 0, entryCount: 0 };
+      return acc;
+    },
+    {} as Record<LocalDataCategoryId, LocalDataCategorySize>,
+  );
+
+/**
+ * Measures every category. Failures degrade to zeros rather than throwing —
+ * the screen must still render (and still offer clearing) if sizing fails.
+ */
+export async function getLocalDataInventory(): Promise<LocalDataInventory> {
+  const categories = emptyCategories();
+  let queuedMutationCount = 0;
+
+  try {
+    const keys = await AsyncStorage.getAllKeys();
+    const entries = await AsyncStorage.multiGet([...keys]);
+
+    for (const [key, value] of entries) {
+      const size = utf8ByteLength(key) + utf8ByteLength(value ?? '');
+      const category = categorizeKey(key);
+
+      if (category) {
+        categories[category].bytes += size;
+        categories[category].entryCount += 1;
+      }
+
+      queuedMutationCount += countQueuedMutations(key, value);
+    }
+  } catch (error) {
+    console.error('Error reading local data inventory:', error);
+  }
+
+  // The image cache's real weight is on disk, not in its AsyncStorage ledger.
+  try {
+    const stats = await imageCache.getStats();
+    categories.image_cache = {
+      id: 'image_cache',
+      bytes: stats.totalBytes,
+      entryCount: stats.entryCount,
+    };
+  } catch {
+    // Non-fatal — the ledger-derived figure above stands in.
+  }
+
+  const list = LOCAL_DATA_CATEGORY_IDS.map((id) => categories[id]);
+
+  return {
+    categories: list,
+    totalBytes: list.reduce((total, category) => total + category.bytes, 0),
+    queuedMutationCount,
+  };
+}
+
+/** Counts pending operations held in a queue key, tolerating corrupt values. */
+function countQueuedMutations(key: string, value: string | null): number {
+  const isQueueKey = key === MUTATION_QUEUE_KEY || key.startsWith(WATCHLIST_PENDING_PREFIX);
+
+  if (!isQueueKey || !value) return 0;
+
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+// ── Clearing ───────────────────────────────────────────────────────────────
+
+/** Removes the keys a category owns, skipping anything protected. */
+async function removeKeysForCategory(id: LocalDataCategoryId): Promise<void> {
+  const keys = await AsyncStorage.getAllKeys();
+  const targets = keys.filter((key) => categorizeKey(key) === id);
+
+  if (targets.length > 0) {
+    await AsyncStorage.multiRemove(targets);
+  }
+}
+
+/**
+ * Clears one category. Safe to call when the category is already empty.
+ *
+ * Never touches queued mutations, session state, or the user's privacy
+ * choices — see {@link isProtectedKey}.
+ */
+export async function clearLocalDataCategory(id: LocalDataCategoryId): Promise<void> {
+  switch (id) {
+    case 'cached_content':
+      // Delegated so the cache manager can drop in-memory bookkeeping too.
+      await cache.clear();
+      return;
+    case 'image_cache':
+      // Also purges expo-image's native disk and memory caches.
+      await imageCache.clearAll();
+      return;
+    case 'saved_news':
+    case 'watchlists':
+    case 'drafts':
+    case 'diagnostics':
+      await removeKeysForCategory(id);
+      return;
+  }
+}
+
+export interface ClearAllResult {
+  cleared: LocalDataCategoryId[];
+  failed: LocalDataCategoryId[];
+  /** Queued mutations deliberately left in place. */
+  preservedQueuedMutations: number;
+}
+
+/**
+ * Clears every category.
+ *
+ * Categories are cleared independently so one failure cannot abort the rest,
+ * and the result reports exactly which ones did not clear. The user stays
+ * signed in and queued mutations remain intact.
+ */
+export async function clearAllLocalData(): Promise<ClearAllResult> {
+  const { queuedMutationCount } = await getLocalDataInventory();
+  const cleared: LocalDataCategoryId[] = [];
+  const failed: LocalDataCategoryId[] = [];
+
+  for (const id of LOCAL_DATA_CATEGORY_IDS) {
+    try {
+      await clearLocalDataCategory(id);
+      cleared.push(id);
+    } catch (error) {
+      console.error(`Error clearing local data category '${id}':`, error);
+      failed.push(id);
+    }
+  }
+
+  return {
+    cleared,
+    failed,
+    preservedQueuedMutations: queuedMutationCount,
+  };
+}

--- a/apps/mobile/lib/privacy-preferences.ts
+++ b/apps/mobile/lib/privacy-preferences.ts
@@ -1,0 +1,84 @@
+/**
+ * Analytics and crash-reporting opt-out preferences.
+ *
+ * These live under the `lumenpulse.privacy.` namespace, which
+ * {@link ./local-data} treats as protected: clearing local data must never
+ * silently opt a user back in to reporting they had turned off.
+ *
+ * Both default to enabled, matching the app's behaviour before this screen
+ * existed. `false` means the user explicitly opted out.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { errorReporter } from './error-reporting';
+
+export const PRIVACY_KEY_PREFIX = 'lumenpulse.privacy.';
+
+const ANALYTICS_ENABLED_KEY = `${PRIVACY_KEY_PREFIX}analytics_enabled`;
+const CRASH_REPORTING_ENABLED_KEY = `${PRIVACY_KEY_PREFIX}crash_reporting_enabled`;
+
+export interface PrivacyPreferences {
+  /** Usage analytics collection. */
+  analyticsEnabled: boolean;
+  /** Automatic crash and error reporting. */
+  crashReportingEnabled: boolean;
+}
+
+export const DEFAULT_PRIVACY_PREFERENCES: PrivacyPreferences = {
+  analyticsEnabled: true,
+  crashReportingEnabled: true,
+};
+
+/**
+ * A stored value is only honoured when it is exactly `'false'`. Anything else —
+ * missing, corrupted, a half-written string — falls back to the default rather
+ * than guessing, so a storage glitch can never flip a preference silently.
+ */
+const parseStoredFlag = (raw: string | null, fallback: boolean): boolean => {
+  if (raw === 'false') return false;
+  if (raw === 'true') return true;
+  return fallback;
+};
+
+export async function getPrivacyPreferences(): Promise<PrivacyPreferences> {
+  try {
+    const [[, analytics], [, crashReporting]] = await AsyncStorage.multiGet([
+      ANALYTICS_ENABLED_KEY,
+      CRASH_REPORTING_ENABLED_KEY,
+    ]);
+
+    return {
+      analyticsEnabled: parseStoredFlag(analytics, DEFAULT_PRIVACY_PREFERENCES.analyticsEnabled),
+      crashReportingEnabled: parseStoredFlag(
+        crashReporting,
+        DEFAULT_PRIVACY_PREFERENCES.crashReportingEnabled,
+      ),
+    };
+  } catch (error) {
+    console.error('Error reading privacy preferences:', error);
+    return { ...DEFAULT_PRIVACY_PREFERENCES };
+  }
+}
+
+export async function setAnalyticsEnabled(enabled: boolean): Promise<PrivacyPreferences> {
+  await AsyncStorage.setItem(ANALYTICS_ENABLED_KEY, String(enabled));
+  return getPrivacyPreferences();
+}
+
+export async function setCrashReportingEnabled(enabled: boolean): Promise<PrivacyPreferences> {
+  await AsyncStorage.setItem(CRASH_REPORTING_ENABLED_KEY, String(enabled));
+  // Apply immediately so an opt-out takes effect for the current session
+  // rather than only after the next launch.
+  errorReporter.setEnabled(enabled);
+  return getPrivacyPreferences();
+}
+
+/**
+ * Reads the stored preferences and applies them to the reporting clients.
+ * Call once during app start-up, after storage is available.
+ */
+export async function applyPrivacyPreferences(): Promise<PrivacyPreferences> {
+  const preferences = await getPrivacyPreferences();
+  errorReporter.setEnabled(preferences.crashReportingEnabled);
+  return preferences;
+}

--- a/apps/mobile/locales/en/common.json
+++ b/apps/mobile/locales/en/common.json
@@ -390,6 +390,64 @@
       "cache_status": "Network Status",
       "online": "Online",
       "offline": "Offline"
+    },
+    "data_privacy": {
+      "title": "Data & Privacy",
+      "description": "Review everything LumenPulse stores on this device, clear it by category or all at once, and choose what diagnostics you share.",
+      "stored_data": "Stored on this device",
+      "privacy_controls": "Privacy controls",
+      "total_stored": "Total stored",
+      "clear": "Clear",
+      "item_count_one": "{{count}} item",
+      "item_count_other": "{{count}} items",
+      "clear_category_title": "Clear {{category}}?",
+      "clear_category_message": "This removes all {{category}} stored on this device. It can be downloaded again when you are online.",
+      "category_cleared": "{{category}} cleared.",
+      "clear_failed": "Couldn't clear that data. Please try again.",
+      "clear_all_title": "Clear all local data",
+      "clear_all_message": "This removes cached content, saved news, watchlists, cached images, drafts, and diagnostics data from this device. You will stay signed in.",
+      "clear_all_hint": "You stay signed in, and any changes waiting to sync are kept.",
+      "clear_all_success": "All local data cleared. You are still signed in.",
+      "clear_all_partial_one": "Cleared most data, but {{count}} category couldn't be cleared. Please try again.",
+      "clear_all_partial_other": "Cleared most data, but {{count}} categories couldn't be cleared. Please try again.",
+      "queued_preserved_warning_one": "{{count}} change is still waiting to sync and will be kept.",
+      "queued_preserved_warning_other": "{{count}} changes are still waiting to sync and will be kept.",
+      "preference_save_failed": "Couldn't save that preference. Please try again.",
+      "preferences_survive_clear": "Your analytics and crash-reporting choices are kept when you clear data — clearing never opts you back in.",
+      "analytics": {
+        "title": "Usage analytics",
+        "description": "Share anonymous usage data to help improve the app. Turn this off to stop collection on this device."
+      },
+      "crash_reporting": {
+        "title": "Crash reporting",
+        "description": "Automatically report crashes and errors. Wallet addresses are always removed before a report is sent."
+      },
+      "categories": {
+        "cached_content": {
+          "title": "Cached content",
+          "description": "News, portfolio snapshots, projects, and asset prices kept for offline use."
+        },
+        "saved_news": {
+          "title": "Saved news",
+          "description": "Articles you bookmarked to read later."
+        },
+        "watchlists": {
+          "title": "Watchlists",
+          "description": "Your locally cached watchlist and its last sync time."
+        },
+        "image_cache": {
+          "title": "Cached images",
+          "description": "Remote images stored on disk so they don't re-download."
+        },
+        "drafts": {
+          "title": "Drafts",
+          "description": "An unfinished contribution saved so you can resume it."
+        },
+        "diagnostics": {
+          "title": "Diagnostics data",
+          "description": "Local analytics and diagnostics state collected on this device."
+        }
+      }
     }
   },
   "transaction_receipt": {

--- a/apps/mobile/locales/zh/common.json
+++ b/apps/mobile/locales/zh/common.json
@@ -349,6 +349,61 @@
       "version_prefix": "版本 {{version}}",
       "published": "发布日期: {{date}}",
       "testing": "测试中..."
+    },
+    "data_privacy": {
+      "title": "数据与隐私",
+      "description": "查看 LumenPulse 存储在本设备上的所有数据，按类别或一次性清除，并选择要分享的诊断信息。",
+      "stored_data": "存储在本设备",
+      "privacy_controls": "隐私设置",
+      "total_stored": "存储总量",
+      "clear": "清除",
+      "item_count_other": "{{count}} 项",
+      "clear_category_title": "清除{{category}}？",
+      "clear_category_message": "这将删除本设备上存储的所有{{category}}。联网后可重新下载。",
+      "category_cleared": "已清除{{category}}。",
+      "clear_failed": "无法清除该数据，请重试。",
+      "clear_all_title": "清除所有本地数据",
+      "clear_all_message": "这将从本设备删除缓存内容、已保存的新闻、自选列表、缓存图片、草稿和诊断数据。您仍将保持登录状态。",
+      "clear_all_hint": "您将保持登录状态，等待同步的更改也会保留。",
+      "clear_all_success": "已清除所有本地数据，您仍处于登录状态。",
+      "clear_all_partial_other": "已清除大部分数据，但有 {{count}} 个类别未能清除，请重试。",
+      "queued_preserved_warning_other": "仍有 {{count}} 项更改等待同步，将予以保留。",
+      "preference_save_failed": "无法保存该偏好设置，请重试。",
+      "preferences_survive_clear": "清除数据时会保留您的分析和崩溃报告选择 — 清除操作绝不会重新开启它们。",
+      "analytics": {
+        "title": "使用分析",
+        "description": "分享匿名使用数据以帮助改进应用。关闭后将停止在本设备上收集。"
+      },
+      "crash_reporting": {
+        "title": "崩溃报告",
+        "description": "自动报告崩溃和错误。发送报告前始终会移除钱包地址。"
+      },
+      "categories": {
+        "cached_content": {
+          "title": "缓存内容",
+          "description": "为离线使用而保存的新闻、投资组合快照、项目和资产价格。"
+        },
+        "saved_news": {
+          "title": "已保存的新闻",
+          "description": "您收藏以便稍后阅读的文章。"
+        },
+        "watchlists": {
+          "title": "自选列表",
+          "description": "本地缓存的自选列表及其上次同步时间。"
+        },
+        "image_cache": {
+          "title": "缓存图片",
+          "description": "存储在磁盘上的远程图片，避免重复下载。"
+        },
+        "drafts": {
+          "title": "草稿",
+          "description": "已保存的未完成贡献，可稍后继续。"
+        },
+        "diagnostics": {
+          "title": "诊断数据",
+          "description": "本设备上收集的本地分析和诊断状态。"
+        }
+      }
     }
   },
   "errors": {


### PR DESCRIPTION
## Summary

Resolves three issues: backend bootstrap teardown, a deployment smoke endpoint for CI/Vercel, and mobile data & privacy controls.

- Closes #1212 
- Closes #1194 
- Closes #720 

---

## 1. Backend: teardown and reset path for testnet bootstrap

Repeated bootstraps accumulated state with no supported way to undo them. Every bootstrap — demo seed **and** Friendbot funding — is now recorded as a *bootstrap run* that can be torn down by identifier.

**New**
- `bootstrap_runs` table (migration `1848000000000-CreateBootstrapRuns`) storing the run id, kind, network, environment, the resources it created, and — once torn down — the per-resource outcome.
- `BootstrapRunsModule` / `BootstrapRunRegistryService` — shared registry imported by both `StellarModule` and `DemoBootstrapModule` so all bootstrap paths agree on one record.
- `BootstrapTeardownService` — environment gate, dry-run planning, execution, idempotency.

**Endpoints** (admin JWT required)
| Method | Path | Purpose |
|---|---|---|
| `GET` | `/demo-bootstrap/runs` | List runs newest-first; filter by `kind`, `status`, `limit` |
| `POST` | `/demo-bootstrap/runs/:runId/teardown` | Remove what one run created; `{"dryRun": true}` previews |

`POST /demo-bootstrap/seed` and `POST /dev/testnet-bootstrap/fund` now return a `runId` in their response.

**Environment gate.** Teardown is refused with `403` unless **both** hold:
1. `NODE_ENV` is not `production` — never permitted in production, whatever the network says; and
2. the environment is explicitly marked testnet (`STELLAR_NETWORK=testnet`) **or** development (`NODE_ENV=development|test`).

The refusal response names which condition failed. The gate is re-evaluated per request, so a misconfigured deploy cannot leave a stale "allowed" verdict.

**Design note — what teardown cannot undo.** Friendbot-funded testnet accounts stay on-chain; Stellar has no way to delete an account the backend doesn't hold the secret for. Rather than report a false success, those resources come back as `skipped` with an explicit reason, and only the local record is discarded. Demo seed data is in-memory and is genuinely removed.

Teardown is idempotent: a second call returns `status: "already_torn_down"` and removes nothing; resources a prior `reset` already wiped report as `not_found`.

Registry writes on the *creating* paths are best-effort — a seed or a funding call is never failed by a registry write failure (it logs and returns no `runId`). Teardown reads, by contrast, surface their errors: refusing to tear down is safer than silently reporting nothing to remove.

Documented end-to-end in `apps/backend/README.md` (find the id → dry run → tear down → gate rules → limits).

**AC mapping**
- [x] Admin-only endpoint removes data created by a specific run, identified by a run id
- [x] Runs recorded with identifier + resources created
- [x] Refuses any environment not explicitly testnet or development
- [x] Dry-run mode lists what would be removed
- [x] Flow documented in the backend README

---

## 2. Backend: deployment smoke endpoint for frontend/CI

`GET /health/smoke` — one call for CI and Vercel checks.

Verifies:
- required env vars are present (`DB_*`, `PORT`, `JWT_SECRET`, `STELLAR_SERVER_SECRET`, plus `CORS_ORIGIN` / `PYTHON_API_URL` where the environment requires them);
- core dependencies respond — database, Redis, Horizon;
- every configured Soroban contract ID is reachable.

**Machine-readable**, with a stable `id` per check so CI can assert on individual results:

```jsonc
{
  "status": "pass",        // "pass" | "warn" | "fail" — worst across all checks
  "ready": true,           // false only when something failed
  "checkedAt": "2026-08-29T10:15:00.000Z",
  "durationMs": 412,
  "network": "testnet",
  "environment": "production",
  "summary": { "total": 14, "passed": 13, "warned": 1, "failed": 0 },
  "checks": [
    { "id": "env.JWT_SECRET", "category": "config", "status": "pass", "message": "JWT_SECRET is set" },
    { "id": "dependency.redis", "category": "dependency", "status": "warn", "message": "Redis cache is unreachable — the API runs uncached" },
    { "id": "contract.lumenToken", "category": "contract", "status": "pass", "message": "lumenToken contract is reachable" }
  ]
}
```

HTTP status mirrors readiness: **200** for `pass`/`warn`, **503** for `fail` — so a bare `curl -sf` gates a deploy; `jq -e '.status == "pass"'` also fails on warnings.

Redis is a *warning* not a failure: the API degrades to uncached rather than breaking. Missing required env vars, an unreachable database or Horizon, and any misconfigured or uncallable contract ID all fail.

**Safe to expose publicly — enforced structurally, not incidentally:**
- env vars reported by name and presence only — never a value, prefix, or length;
- contract IDs redacted (`ABC123...XYZ789`) via the existing `ContractHealthService`;
- dependency failures return **fixed** messages (`"Database is unreachable"`), never the driver's error text, so a connection string or internal host cannot leak — the real error goes to the server log.

Two regression tests lock this down: one asserts the serialized response contains none of the secret values, another that a failing DB response contains no part of the connection string.

**AC mapping**
- [x] Verifies env vars present and contract IDs reachable
- [x] Returns machine-readable status
- [x] Safe to expose publicly without leaking secrets

---

## 3. Mobile: data and privacy controls in settings

New **Settings › Data & Privacy** screen (`app/settings/data-privacy.tsx`), linked from the settings tab.

- Lists six categories of locally stored data — cached content, saved news, watchlists, cached images, drafts, diagnostics — each with its current size and entry count, plus a running total.
- Each category clears individually behind a confirmation; the button is disabled when the category is empty.
- A single clear-all action resets local data. The user stays signed in.
- Analytics and crash-reporting opt-out toggles live on the same screen, wired into `errorReporter` and re-applied on every launch from `app/_layout.tsx`.

**"Clearing does not corrupt an in-flight session or queued mutations" is enforced structurally.** `lib/local-data.ts` checks an explicit protected-key list *before* categorising, so a key can never be classified into something clearable by accident. Protected: queued offline writes (`pending_mutation_queue`, `watchlist_pending_sync*`), session state, and the privacy preferences themselves. Unrecognised third-party keys are left alone — clearing only ever removes what the module can name. When writes are pending, the confirmation dialog says how many will be kept.

Protecting the privacy keys matters: a wipe must never silently opt someone back in to reporting they had turned off.

Clear-all clears each category independently so one failure can't abort the rest, and reports which ones didn't clear.

New `lib/privacy-preferences.ts` stores both toggles under `lumenpulse.privacy.*`; a corrupted stored value falls back to the default rather than guessing. `lib/error-reporting.ts` gains `setEnabled()` / `enabled` so an opt-out takes effect for the current session, not just after the next launch.

en + zh translations added for the whole screen.

**AC mapping**
- [x] Screen lists each category of locally stored data with its current size
- [x] Each category clears individually, with a confirmation step
- [x] Clear-all resets local data without logging the user out
- [x] Analytics and crash-reporting opt-out toggles on the same screen
- [x] Clearing does not corrupt an in-flight session or queued mutations

---

## Drive-by fix

`test/health.e2e-spec.ts` under-provided `HealthController`'s dependencies (`ContractHealthService`, `ShutdownService`) and could not construct the controller. Fixed and extended with coverage for the new smoke endpoint.

---

## Verification

| Check | Result |
|---|---|
| Backend unit | 692 passed, 19 skipped, 0 failed (82 suites) |
| Backend e2e (health) | 6 passed |
| Mobile unit | 111 passed (17 suites) |
| Mobile `tsc --noEmit` | 0 errors |
| Migration safety check | PASSED (migration detected) |
| ESLint | clean on all changed files |

New modules land at 100% statement coverage (`local-data.ts`, `privacy-preferences.ts`); mobile coverage thresholds still met.

## Notes for reviewers

- **No new dependencies.** `pnpm-lock.yaml` and the committed `apps/mobile/coverage/` artifacts were touched while getting tests runnable locally and have been reverted — the diff is source only.
- **Pre-existing, not addressed here:** the mobile locale files are never loaded into i18next (`src/i18n/index.ts` calls `init()` with no `resources`, and nothing imports `locales/*/common.json`), so every `t()` call in the app currently renders its key. This affects all screens equally; the new screen follows the same pattern and ships full en/zh strings for when resource loading is wired. Fixing it would change visible text app-wide, so I left it out of this PR — happy to do it as a follow-up.
